### PR TITLE
Add basic template for theme colors

### DIFF
--- a/src/components/activity-header/nav-pages.scss
+++ b/src/components/activity-header/nav-pages.scss
@@ -25,13 +25,13 @@
     }
 
     &.current {
-      background-color: $cc-teal-light2;
+      background-color: var(--theme-primary-color);
     }
     &.current:hover {
-      background-color: $cc-teal-light1;
+      background-color: var(--theme-primary-hover-color);
     }
     &.current:active {
-      background-color: $cc-teal;
+      background-color: var(--theme-primary-active-color);
     }
 
     .label {

--- a/src/components/activity-introduction/activity-page-links.scss
+++ b/src/components/activity-introduction/activity-page-links.scss
@@ -17,15 +17,15 @@
   }
 
   .page-link {
-    color: $cc-teal-light2;
+    color: var(--theme-primary-color);
     cursor: pointer;
 
     &:hover {
-      color: $cc-teal-light1;
+      color: var(--theme-primary-hover-color);
       text-decoration: underline;
     }
     &:active {
-      color: $cc-teal;
+      color: var(--theme-primary-active-color);
       text-decoration: underline;
     }
   }
@@ -35,7 +35,7 @@
     width: 275px;
     margin: 5px 0 5px 0;
     color: white;
-    background-color: $cc-teal-light2;
+    background-color: var(--theme-primary-color);
     font-size: 22px;
     border-radius: 4px;
     border: solid 2px $cc-charcoal-light2;
@@ -43,10 +43,10 @@
     cursor: pointer;
 
     &:hover {
-      background-color: $cc-teal-light1;
+      background-color: var(--theme-primary-hover-color);
     }
     &:active {
-      background-color: $cc-teal;
+      background-color: var(--theme-primary-active-color);
     }
   }
 

--- a/src/components/activity-introduction/activity-summary.scss
+++ b/src/components/activity-introduction/activity-summary.scss
@@ -6,5 +6,6 @@
   h2 {
     font-size: 45px;
     margin: 15px 0 15px 0;
+    color: var(--theme-secondary-color);
   }
 }

--- a/src/components/activity-page/activity-page-content.scss
+++ b/src/components/activity-page/activity-page-content.scss
@@ -15,7 +15,7 @@
     font-size: 24px;
     font-weight: bold;;
     max-width: 900px;
-    color: $cc-teal-light1;
+    color: var(--theme-secondary-color);
   }
 
   .introduction {

--- a/src/components/activity-page/bottom-buttons.scss
+++ b/src/components/activity-page/bottom-buttons.scss
@@ -10,7 +10,7 @@
     width: 120px;
     margin: 5px 0 5px 0;
     color: white;
-    background-color: $cc-teal-light2;
+    background-color: var(--theme-primary-color);
     font-size: 22px;
     border-radius: 4px;
     border: solid 2px $cc-charcoal-light2;
@@ -18,10 +18,10 @@
     cursor: pointer;
 
     &:hover {
-      background-color: $cc-teal-light1;
+      background-color: var(--theme-primary-hover-color);
     }
     &:active {
-      background-color: $cc-teal;
+      background-color: var(--theme-primary-active-color);
     }
   }
 }

--- a/src/components/activity-page/secondary-embeddable.scss
+++ b/src/components/activity-page/secondary-embeddable.scss
@@ -14,12 +14,12 @@
     align-items: center;
     padding: 0 0 0 10px;
     color: white;
-    background-color: $cc-teal-light1;
+    background-color: var(--theme-primary-color);
   }
 
   .content {
     height: 250px;
     border-radius: 0 0 13px 13px;
-    border: 1px solid #ededed;
+    border: 1px solid $cc-charcoal-light1;
   }
 }

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -9,7 +9,7 @@
   display: flex;
   justify-content: center;
   color: #242424;
-  background-color: $cc-teal-light3;
+  background-color: var(--theme-primary-color);
   overflow-y: auto;
 }
 

--- a/src/components/theme-buttons.scss
+++ b/src/components/theme-buttons.scss
@@ -1,0 +1,8 @@
+.theme-buttons {
+  display: flex;
+  flex-direction: row;
+
+  .button {
+    margin: 5px;
+  }
+}

--- a/src/components/theme-buttons.tsx
+++ b/src/components/theme-buttons.tsx
@@ -13,7 +13,7 @@ export const ThemeButtons: React.FC = () => {
   const handleOrangeTheme = () => {
     setThemeColors("#ff8415", "#0592af");
   };
-  const handleCbioTheme = () => {
+  const handleCBioTheme = () => {
     setThemeColors("#008fd7", "#f15a24");
   };
   const handleWatersTheme = () => {
@@ -26,7 +26,7 @@ export const ThemeButtons: React.FC = () => {
     <div className="theme-buttons">
       <button className="button" onClick={handleTealTheme}>teal</button>
       <button className="button" onClick={handleOrangeTheme}>orange</button>
-      <button className="button" onClick={handleCbioTheme}>cbio</button>
+      <button className="button" onClick={handleCBioTheme}>cbio</button>
       <button className="button" onClick={handleWatersTheme}>waters</button>
       <button className="button" onClick={handleInteractionsTheme}>interactions</button>
     </div>

--- a/src/components/theme-buttons.tsx
+++ b/src/components/theme-buttons.tsx
@@ -1,0 +1,34 @@
+// This component is designed for demoing theme color changes
+// and is not intended to be displayed in a production release.
+// Add this component to enable buttons to toggle color theme.
+import React from "react";
+import { setThemeColors } from "../utilities/theme-utils";
+
+import "./theme-buttons.scss";
+
+export const ThemeButtons: React.FC = () => {
+  const handleTealTheme = () => {
+    setThemeColors("#0592af", "#ff8415");
+  };
+  const handleOrangeTheme = () => {
+    setThemeColors("#ff8415", "#0592af");
+  };
+  const handleCbioTheme = () => {
+    setThemeColors("#008fd7", "#f15a24");
+  };
+  const handleWatersTheme = () => {
+    setThemeColors("#007c8B", "#e86e2f");
+  };
+  const handleInteractionsTheme = () => {
+    setThemeColors("#414546", "#2f70b0");
+  };
+  return (
+    <div className="theme-buttons">
+      <button className="button" onClick={handleTealTheme}>teal</button>
+      <button className="button" onClick={handleOrangeTheme}>orange</button>
+      <button className="button" onClick={handleCbioTheme}>cbio</button>
+      <button className="button" onClick={handleWatersTheme}>waters</button>
+      <button className="button" onClick={handleInteractionsTheme}>interactions</button>
+    </div>
+  );
+};

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -20,3 +20,12 @@ $cc-orange-light5: #fff2e7;
 $cc-orange-light6: #fff9f3;
 
 $content-width: 960px;
+
+:root {
+  --theme-primary-color: #0592af;
+  --theme-primary-hover-color: #007e9b;
+  --theme-primary-active-color: #006a87;
+  --theme-secondary-color: #ff8415;
+  --theme-secondary-hover-color: #ff8415;
+  --theme-secondary-active-color: #ff8415;
+}

--- a/src/utilities/theme-utils.ts
+++ b/src/utilities/theme-utils.ts
@@ -1,0 +1,28 @@
+// example from:
+// https://stackoverflow.com/questions/5560248/programmatically-lighten-or-darken-a-hex-color-or-rgb-and-blend-colors
+export const colorShade = (col: string, amt: number) => {
+  col = col.replace(/^#/, "");
+  if (col.length === 3) col = col[0] + col[0] + col[1] + col[1] + col[2] + col[2];
+
+  let [r, g, b]: any = col.match(/.{2}/g);
+  ([r, g, b] = [parseInt(r, 16) + amt, parseInt(g, 16) + amt, parseInt(b, 16) + amt]);
+
+  r = Math.max(Math.min(255, r), 0).toString(16);
+  g = Math.max(Math.min(255, g), 0).toString(16);
+  b = Math.max(Math.min(255, b), 0).toString(16);
+
+  const rr = (r.length < 2 ? "0" : "") + r;
+  const gg = (g.length < 2 ? "0" : "") + g;
+  const bb = (b.length < 2 ? "0" : "") + b;
+
+  return `#${rr}${gg}${bb}`;
+};
+
+export const setThemeColors = (primary: string, secondary: string) => {
+  document.documentElement.style.setProperty("--theme-primary-color", primary);
+  document.documentElement.style.setProperty("--theme-primary-hover-color", colorShade(primary, -20));
+  document.documentElement.style.setProperty("--theme-primary-active-color", colorShade(primary, -40));
+  document.documentElement.style.setProperty("--theme-secondary-color", secondary);
+  document.documentElement.style.setProperty("--theme-secondary-hover-color", colorShade(secondary, -20));
+  document.documentElement.style.setProperty("--theme-secondary-active-color", colorShade(secondary, -40));
+};

--- a/src/utilities/theme-utils.ts
+++ b/src/utilities/theme-utils.ts
@@ -1,5 +1,5 @@
 // example from:
-// https://stackoverflow.com/questions/5560248/programmatically-lighten-or-darken-a-hex-color-or-rgb-and-blend-colors
+// https://stackoverflow.com/a/62640342
 export const colorShade = (col: string, amt: number) => {
   col = col.replace(/^#/, "");
   if (col.length === 3) col = col[0] + col[0] + col[1] + col[1] + col[2] + col[2];


### PR DESCRIPTION
This PR adds CSS vars which can be used to store and access theme colors and utility functions for setting the theme colors (presumably from an actual activity JSON file).  It also includes a ThemeButtons component that can be added for demoing (but should not be used in production and can be removed once we integrate the color themes into the actual activities).

There were a handful of potential approaches for the color themes.  CSS vars seemed straightforward and easy to integrate into our existing CSS files.  I explored some other mechanisms, and I'm open to alternative ideas if we don't think this approach is adequate of if it is too clunky.