### PR TITLE
Add font theme colors and getContrastYIQColor function 

### DIFF
--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -18,6 +18,8 @@ $cc-orange-light3: #ffcea1;
 $cc-orange-light4: #ffe6d0;
 $cc-orange-light5: #fff2e7;
 $cc-orange-light6: #fff9f3;
+$light-font-color: #eeeeee;
+$dark-font-color: #222222;
 
 $content-width: 960px;
 
@@ -30,4 +32,9 @@ $content-width: 960px;
   --theme-secondary-hover-color: #ff8415;
   --theme-secondary-active-color: #ff8415;
   --theme-secondary-text-color: #222222;
+}
+
+:export {
+  lightFontColor: $light-font-color;
+  darkFontColor: $dark-font-color;
 }

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -25,7 +25,9 @@ $content-width: 960px;
   --theme-primary-color: #0592af;
   --theme-primary-hover-color: #007e9b;
   --theme-primary-active-color: #006a87;
+  --theme-primary-text-color: #eeeeee;
   --theme-secondary-color: #ff8415;
   --theme-secondary-hover-color: #ff8415;
   --theme-secondary-active-color: #ff8415;
+  --theme-secondary-text-color: #222222;
 }

--- a/src/components/vars.scss.d.ts
+++ b/src/components/vars.scss.d.ts
@@ -1,0 +1,10 @@
+// cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
+
+export interface IThemeColorExports {
+  lightFontColor: string;
+  darkFontColor: string;
+}
+
+export const colors: IThemeColorExports;
+
+export default colors;

--- a/src/utilities/theme-utils.ts
+++ b/src/utilities/theme-utils.ts
@@ -1,10 +1,10 @@
 // example from:
 // https://stackoverflow.com/a/62640342
-export const colorShade = (col: string, amt: number) => {
-  col = col.replace(/^#/, "");
-  if (col.length === 3) col = col[0] + col[0] + col[1] + col[1] + col[2] + col[2];
+export const colorShade = (color: string, amt: number) => {
+  color = color.replace(/^#/, "");
+  if (color.length === 3) color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
 
-  let [r, g, b]: any = col.match(/.{2}/g);
+  let [r, g, b]: any = color.match(/.{2}/g);
   ([r, g, b] = [parseInt(r, 16) + amt, parseInt(g, 16) + amt, parseInt(b, 16) + amt]);
 
   r = Math.max(Math.min(255, r), 0).toString(16);
@@ -22,7 +22,21 @@ export const setThemeColors = (primary: string, secondary: string) => {
   document.documentElement.style.setProperty("--theme-primary-color", primary);
   document.documentElement.style.setProperty("--theme-primary-hover-color", colorShade(primary, -20));
   document.documentElement.style.setProperty("--theme-primary-active-color", colorShade(primary, -40));
+  document.documentElement.style.setProperty("--theme-primary-text-color", getContrastYIQColor(primary));
   document.documentElement.style.setProperty("--theme-secondary-color", secondary);
   document.documentElement.style.setProperty("--theme-secondary-hover-color", colorShade(secondary, -20));
   document.documentElement.style.setProperty("--theme-secondary-active-color", colorShade(secondary, -40));
+  document.documentElement.style.setProperty("--theme-secondary-text-color", getContrastYIQColor(secondary));
+};
+
+// example from:
+// https://24ways.org/2010/calculating-color-contrast
+const getContrastYIQColor = (color: string) => {
+  color = color.replace(/^#/, "");
+  if (color.length === 3) color = color[0] + color[0] + color[1] + color[1] + color[2] + color[2];
+  const r = parseInt(color.substr(0,2),16);
+  const g = parseInt(color.substr(2,2),16);
+  const b = parseInt(color.substr(4,2),16);
+  const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+  return (yiq >= 128) ? "#222222" : "#eeeeee";
 };

--- a/src/utilities/theme-utils.ts
+++ b/src/utilities/theme-utils.ts
@@ -1,3 +1,6 @@
+// cf. https://mattferderer.com/use-sass-variables-in-typescript-and-javascript
+import colors from "../components/vars.scss";
+
 // example from:
 // https://stackoverflow.com/a/62640342
 export const colorShade = (color: string, amt: number) => {
@@ -38,5 +41,5 @@ const getContrastYIQColor = (color: string) => {
   const g = parseInt(color.substr(2,2),16);
   const b = parseInt(color.substr(4,2),16);
   const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
-  return (yiq >= 128) ? "#222222" : "#eeeeee";
+  return (yiq >= 128) ? colors.darkFontColor : colors.lightFontColor;
 };


### PR DESCRIPTION
This PR adds primary and secondary font theme colors and a function, getContrastYIQColor, which will compute a light or dark font color based on a background color (or can be used generally for computing a light/dark contrast color from a base color).  Note, failed Travis test is fixed in a separate PR (https://github.com/concord-consortium/activity-player/pull/11).


Contrast color example from this article:
https://24ways.org/2010/calculating-color-contrast

![image](https://user-images.githubusercontent.com/5126913/87110829-cba9d800-c21c-11ea-9a66-7d87da106d0c.png)

![image](https://user-images.githubusercontent.com/5126913/87110857-da908a80-c21c-11ea-8680-db3c301f721c.png)
