### PR TITLE
Load activities using url parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Inside of your `package.json` file:
 2. `cypress run --headed --no-exit` will open cypress test runner when tests begin to run, and it will remain open when tests are finished running.
 3. `cypress run --spec 'cypress/integration/examples/smoke-test.js'` will point to a smoke-test file rather than running all of the test files for a project.
 
+## Url Parameters
+### Note: these are subject to change
+
+* activity={id}:     load sample-activity {id} or, if baseUrl is defined, load authored activity from `{baseUrl}/api/v1/activities/{activity}.json`
+* baseUrl={url}:     full url to authoring site, such as `https%3A%2F%2Fauthoring.concord.org` or `http%3A%2F%2Fapp.lara.docker%2F`
+
 ## License
 
 Activity Player is Copyright 2020 (c) by the Concord Consortium and is distributed under the [MIT license](http://www.opensource.org/licenses/MIT).

--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -4,7 +4,7 @@ const activityPage = new ActivityPage;
 
 context("Test the overall app", () => {
   before(() => {
-    cy.visit("");
+    cy.visit("?activity=sample-activity-multiple-layout-types");
     activityPage.getPage(2).click();
   });
   describe("Sidebar",() => {

--- a/cypress/integration/load-activities.test.ts
+++ b/cypress/integration/load-activities.test.ts
@@ -1,0 +1,10 @@
+context("Loading sample activities", () => {
+  it("can open one sample activity",() => {
+    cy.visit("?activity=sample-activity-1");
+    cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+  });
+  it("can open a different sample activity",() => {
+    cy.visit("?activity=sample-activity-multiple-layout-types");
+    cy.get("[data-cy=activity-summary]").should("contain", "Sample Layout Types");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8840,8 +8840,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "1.1.1",
@@ -14460,6 +14459,24 @@
         "prepend-http": "^1.0.0",
         "query-string": "^4.1.0",
         "sort-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+          "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+          "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+          "dev": true
+        }
       }
     },
     "npm-run-all": {
@@ -15629,13 +15646,13 @@
       "dev": true
     },
     "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dev": true,
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
+      "integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
       "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       }
     },
     "querystring": {
@@ -17370,6 +17387,11 @@
         }
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -17505,10 +17527,9 @@
       "dev": true
     },
     "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
   "dependencies": {
     "dompurify": "^2.0.12",
     "html-react-parser": "^0.13.0",
+    "query-string": "^6.13.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-share": "^4.2.0"

--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,6 @@ export const getActivityDefinition = (activity: string, baseUrl?: string | null)
   });
 };
 
-// http://app.lara.docker/activities/5/pages/10/export
 const getActivityDefinitionFromLara = (activity: string, baseUrl: string): Promise<ActivityDefinition> => {
   return new Promise((resolve, reject) => {
     const exportUrl = `${baseUrl.replace(/\/$/, "")}/api/v1/activities/${activity}.json`;

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,16 @@
+import sampleActivities from "./data";
+
+export type ActivityDefinition = any;
+
+export const getActivityDefinition = (urlOrName: string): Promise<ActivityDefinition> => {
+  return new Promise((resolve, reject) => {
+    const urlRegex = /^(https:|http:)\/\/\S+/;
+    if (urlOrName.match(urlRegex)) {
+      reject("Not supporting urls yet");
+    } else if (sampleActivities[urlOrName]) {
+      setTimeout(() => resolve(sampleActivities[urlOrName]), 250);
+    } else {
+      reject("Activity name is neither a url nor matches a sample activity: " + urlOrName);
+    }
+  });
+};

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,15 +2,42 @@ import sampleActivities from "./data";
 
 export type ActivityDefinition = any;
 
-export const getActivityDefinition = (urlOrName: string): Promise<ActivityDefinition> => {
+export const getActivityDefinition = (activity: string, baseUrl?: string | null): Promise<ActivityDefinition> => {
   return new Promise((resolve, reject) => {
-    const urlRegex = /^(https:|http:)\/\/\S+/;
-    if (urlOrName.match(urlRegex)) {
-      reject("Not supporting urls yet");
-    } else if (sampleActivities[urlOrName]) {
-      setTimeout(() => resolve(sampleActivities[urlOrName]), 250);
+    if (!baseUrl) {
+      if (sampleActivities[activity]) {
+        setTimeout(() => resolve(sampleActivities[activity]), 250);
+      } else {
+        reject(`No sample activity matches ${activity}. For an authored activity, use "baseUrl=..."`);
+      }
     } else {
-      reject("Activity name is neither a url nor matches a sample activity: " + urlOrName);
+      const urlRegex = /^(https:|http:)\/\/\S+/;
+      if (baseUrl.match(urlRegex)) {
+        getActivityDefinitionFromLara(activity, baseUrl).then(resolve);
+      } else {
+        reject(`${baseUrl} must be a valid url, e.g. baseUrl=https%3A%2F%2Fauthoring.concord.org`);
+      }
     }
+  });
+};
+
+// http://app.lara.docker/activities/5/pages/10/export
+const getActivityDefinitionFromLara = (activity: string, baseUrl: string): Promise<ActivityDefinition> => {
+  return new Promise((resolve, reject) => {
+    const exportUrl = `${baseUrl.replace(/\/$/, "")}/api/v1/activities/${activity}.json`;
+    fetch(exportUrl)
+    .then(response => {
+      if (response.status !== 200) {
+        reject(`Errored fetching ${exportUrl}. Status Code: ${response.status}`);
+        return;
+      }
+
+      response.json().then(function(data) {
+        resolve(data);
+      });
+    })
+    .catch(function(err) {
+      reject(`Errored fetching ${exportUrl}. ${err}`);
+    });
   });
 };

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -6,11 +6,12 @@ import { ActivityPageContent } from "./activity-page/activity-page-content";
 import { IntroductionPageContent } from "./activity-introduction/introduction-page-content";
 import Footer from "./activity-introduction/footer";
 import { PageLayouts } from "../utilities/activity-utils";
-import sampleActivity from "../data/sample-activity-multiple-layout-types.json";
+import { ActivityDefinition, getActivityDefinition } from "../api";
 
 import "./app.scss";
 
 interface IState {
+  activity?: ActivityDefinition;
   currentPage: number;
 }
 interface IProps {}
@@ -23,6 +24,16 @@ export class App extends React.PureComponent<IProps, IState> {
       currentPage: 0
     };
   }
+
+  async componentDidMount() {
+    try {
+      const activity = await getActivityDefinition("sample-activity-multiple-layout-types");
+      this.setState({activity});
+    } catch (e) {
+      console.warn(e);
+    }
+  }
+
   render() {
     return (
       <div className="app">
@@ -32,28 +43,30 @@ export class App extends React.PureComponent<IProps, IState> {
   }
 
   private renderActivity = () => {
-    const { currentPage } = this.state;
+    const { activity, currentPage } = this.state;
+    if (!activity) return (<div>Loading</div>);
+
     let totalPreviousQuestions = 0;
 
     for (let page = 0; page < currentPage - 1; page++) {
-      for (let embeddable = 0; embeddable < sampleActivity.pages[page].embeddables.length; embeddable++) {
-        if (!sampleActivity.pages[page].embeddables[embeddable].section) {
+      for (let embeddable = 0; embeddable < activity.pages[page].embeddables.length; embeddable++) {
+        if (!activity.pages[page].embeddables[embeddable].section) {
           totalPreviousQuestions++;
         }
       }
     }
 
-    const fullWidth = (currentPage !== 0) && (sampleActivity.pages[currentPage - 1].layout === PageLayouts.Responsive);
+    const fullWidth = (currentPage !== 0) && (activity.pages[currentPage - 1].layout === PageLayouts.Responsive);
 
     return (
       <React.Fragment>
         <Header
           fullWidth={fullWidth}
-          projectId={sampleActivity.project_id}
+          projectId={activity.project_id}
         />
         <ActivityNavHeader
-          activityName={sampleActivity.name}
-          activityPages={sampleActivity.pages}
+          activityName={activity.name}
+          activityPages={activity.pages}
           currentPage={currentPage}
           fullWidth={fullWidth}
           onPageChange={this.handleChangePage}
@@ -66,10 +79,10 @@ export class App extends React.PureComponent<IProps, IState> {
           ? this.renderIntroductionContent()
           : <ActivityPageContent
               isFirstActivityPage={currentPage === 1}
-              isLastActivityPage={currentPage === sampleActivity.pages.length}
+              isLastActivityPage={currentPage === activity.pages.length}
               pageNumber={currentPage}
               onPageChange={this.handleChangePage}
-              page={sampleActivity.pages[currentPage - 1]}
+              page={activity.pages[currentPage - 1]}
               totalPreviousQuestions={totalPreviousQuestions}
             />
         }
@@ -81,7 +94,7 @@ export class App extends React.PureComponent<IProps, IState> {
     return (
       <React.Fragment>
         <IntroductionPageContent
-          activity={sampleActivity}
+          activity={this.state.activity}
           onPageChange={this.handleChangePage}
         />
         <Footer/ >

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import queryString from "query-string";
 import { Header } from "./activity-header/header";
 import { ActivityNavHeader } from "./activity-header/activity-nav-header";
 import { ProfileNavHeader } from "./activity-header/profile-nav-header";
@@ -9,6 +10,8 @@ import { PageLayouts } from "../utilities/activity-utils";
 import { ActivityDefinition, getActivityDefinition } from "../api";
 
 import "./app.scss";
+
+const kDefaultActivity = "sample-activity-multiple-layout-types";   // may eventually want to get rid of this
 
 interface IState {
   activity?: ActivityDefinition;
@@ -27,7 +30,12 @@ export class App extends React.PureComponent<IProps, IState> {
 
   async componentDidMount() {
     try {
-      const activity = await getActivityDefinition("sample-activity-multiple-layout-types");
+      // ?activity=url or ?activity=sample-activity
+      const activityPath = queryString.parse(window.location.search).activity || kDefaultActivity;
+      if (typeof activityPath !== "string") {
+        throw "activity url parameter must be a string";
+      }
+      const activity = await getActivityDefinition(activityPath);
       this.setState({activity});
     } catch (e) {
       console.warn(e);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -30,12 +30,17 @@ export class App extends React.PureComponent<IProps, IState> {
 
   async componentDidMount() {
     try {
-      // ?activity=url or ?activity=sample-activity
-      const activityPath = queryString.parse(window.location.search).activity || kDefaultActivity;
-      if (typeof activityPath !== "string") {
-        throw "activity url parameter must be a string";
+      // ?activity=url&baseUrl=https%3A%2F%2Fauthoring.concord.org or ?activity=sample-activity
+      const query = queryString.parse(window.location.search);
+      const activityPath = query.activity || kDefaultActivity;
+      const baseUrl = query.baseUrl;
+      if (Array.isArray(activityPath)) {
+        throw "May only have one activity query parameter";
       }
-      const activity = await getActivityDefinition(activityPath);
+      if (Array.isArray(baseUrl)) {
+        throw "May only have one baseUrl query parameter";
+      }
+      const activity = await getActivityDefinition(activityPath, baseUrl);
       this.setState({activity});
     } catch (e) {
       console.warn(e);

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,19 @@
+
+import { ActivityDefinition } from "../api";
+import sampleActivity1 from "../data/sample-activity-1.json";
+import sampleActivity2 from "../data/sample-activity-2.json";
+import sampleActivityCbio from "../data/sample-activity-CBIO.json";
+import sampleActivityHas from "../data/sample-activity-HAS.json";
+import sampleActivityMultipleLayoutTypes from "../data/sample-activity-multiple-layout-types.json";
+import sampleActivityResponsive from "../data/sample-activity-responsive-layout.json";
+
+const sampleActivities: {[name: string]: ActivityDefinition} = {
+  "sample-activity-1": sampleActivity1,
+  "sample-activity-2": sampleActivity2,
+  "sample-activity-cbio": sampleActivityCbio,
+  "sample-activity-has": sampleActivityHas,
+  "sample-activity-multiple-layout-types": sampleActivityMultipleLayoutTypes,
+  "sample-activity-responsive-layout": sampleActivityResponsive,
+};
+
+export default sampleActivities;


### PR DESCRIPTION
This adds url parameters to allow loading either a sampler activity, or an exported activity from LARA.

* `[activity_player_url]/`: Load the default sample activity, "sample-activity-multiple-layout-types". (We may want to eventually remove this default, but this way going to the url with no parameters continues to work as before.)
* `[activity_player_url]/?activity=sample-activity-cbio`: Load "sample-activity-cbio"
* `[activity_player_url]/?activity=1&baseUrl=http%3A%2F%2Fapp.lara.docker`: Loads activity "1" from http://app.lara.docker

The last option depends on PR https://github.com/concord-consortium/lara/pull/590.

To test the LARA connection:

1. Check out the LARA PR above
2. Modify `ACTIVITY_PLAYER_URL` in `docker-compose.yml` to `http://localhost:8080`, or the appropriate url (note: for devs this should probably be part of a separate docker-compose file brought in using .env, will update when I see comments on other PR)
3. Run `docker compose up` to load the changes
4. Click on the Preview in Activity Player link

Note that LARA will show preview links for individual pages as well, but those don't work yet.