### PR TITLE
Load page from url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Inside of your `package.json` file:
 ### Note: these are subject to change
 
 * activity={id}:     load sample-activity {id} or, if baseUrl is defined, load authored activity from `{baseUrl}/api/v1/activities/{activity}.json`
+* page={n}:          load page n, where 0 is the activity introduction and 1 is the first page
 * baseUrl={url}:     full url to authoring site, such as `https%3A%2F%2Fauthoring.concord.org` or `http%3A%2F%2Fapp.lara.docker%2F`
 
 ## License

--- a/cypress/integration/load-activities.test.ts
+++ b/cypress/integration/load-activities.test.ts
@@ -1,10 +1,35 @@
-context("Loading sample activities", () => {
-  it("can open one sample activity",() => {
-    cy.visit("?activity=sample-activity-1");
-    cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+import ActivityPage from "../support/elements/activity-page";
+const activityPage = new ActivityPage;
+
+context("Loading activities", () => {
+
+  describe("Loading sample activities", () => {
+    it("can open one sample activity", () => {
+      cy.visit("?activity=sample-activity-1");
+      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+    });
+
+    it("can open a different sample activity", () => {
+      cy.visit("?activity=sample-activity-multiple-layout-types");
+      cy.get("[data-cy=activity-summary]").should("contain", "Sample Layout Types");
+    });
   });
-  it("can open a different sample activity",() => {
-    cy.visit("?activity=sample-activity-multiple-layout-types");
-    cy.get("[data-cy=activity-summary]").should("contain", "Sample Layout Types");
+
+  describe("Loading pages", () => {
+    it("can open the introduction page by default", () => {
+      cy.visit("?activity=sample-activity-1");
+      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+    });
+
+    it("can load page 0", () => {
+      cy.visit("?activity=sample-activity-multiple-layout-types&page=0");
+      cy.get("[data-cy=activity-summary]").should("contain", "Sample Layout Types");
+    });
+
+    it("can load page 3", () => {
+      cy.visit("?activity=sample-activity-multiple-layout-types&page=3");
+      activityPage.getSecondaryEmbeddable("text-box").scrollIntoView()
+        .should("be.visible").and("contain","Duis vitae ultrices augue, eu fermentum elit.");
+    });
   });
 });

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import queryString from "query-string";
 import { Header } from "./activity-header/header";
 import { ActivityNavHeader } from "./activity-header/activity-nav-header";
 import { ProfileNavHeader } from "./activity-header/profile-nav-header";
@@ -10,6 +9,7 @@ import { PageLayouts } from "../utilities/activity-utils";
 import { ActivityDefinition, getActivityDefinition } from "../api";
 
 import "./app.scss";
+import { queryValue } from "../utilities/url-query";
 
 const kDefaultActivity = "sample-activity-multiple-layout-types";   // may eventually want to get rid of this
 
@@ -30,16 +30,8 @@ export class App extends React.PureComponent<IProps, IState> {
 
   async componentDidMount() {
     try {
-      // ?activity=url&baseUrl=https%3A%2F%2Fauthoring.concord.org or ?activity=sample-activity
-      const query = queryString.parse(window.location.search);
-      const activityPath = query.activity || kDefaultActivity;
-      const baseUrl = query.baseUrl;
-      if (Array.isArray(activityPath)) {
-        throw "May only have one activity query parameter";
-      }
-      if (Array.isArray(baseUrl)) {
-        throw "May only have one baseUrl query parameter";
-      }
+      const activityPath = queryValue("activity") || kDefaultActivity;
+      const baseUrl = queryValue("baseUrl");
       const activity = await getActivityDefinition(activityPath, baseUrl);
       this.setState({activity});
     } catch (e) {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -33,7 +33,11 @@ export class App extends React.PureComponent<IProps, IState> {
       const activityPath = queryValue("activity") || kDefaultActivity;
       const baseUrl = queryValue("baseUrl");
       const activity = await getActivityDefinition(activityPath, baseUrl);
-      this.setState({activity});
+
+      // page 0 is introduction, inner pages start from 1 and match page.position in exported activity
+      const currentPage = Number(queryValue("page")) || 0;
+
+      this.setState({activity, currentPage});
     } catch (e) {
       console.warn(e);
     }

--- a/src/utilities/url-query.ts
+++ b/src/utilities/url-query.ts
@@ -1,0 +1,16 @@
+import queryString from "query-string";
+
+/**
+ * Simplifies query-string library by only returning `string | undefined`, instead
+ * of `string | string[] | null | undefined`.
+ * @param prop
+ */
+export const queryValue = (prop: string): string | undefined => {
+  const query = queryString.parse(window.location.search);
+  const val = query[prop];
+  if (!val) return;
+  if (Array.isArray(val)) {
+    throw `May only have one query parameter for ${prop}. Found: ${val}`;
+  }
+  return val;
+};


### PR DESCRIPTION
This adds the `?page={n}` url parameter, where page 0 is the introduction and page 1 is the first page of the activity. This matches the url parameters created by the LARA activity page previews in https://github.com/concord-consortium/lara/pull/590.

This can be tested even without updating local LARA with the sample activities.