### PR TITLE
Add URL param to show theme buttons

### DIFF
--- a/src/components/activity-introduction/footer.scss
+++ b/src/components/activity-introduction/footer.scss
@@ -3,11 +3,11 @@
 .footer {
   width: $content-width;
   font-size: 13px;
-  color: white;
+  color: var(--theme-primary-text-color);
   margin: 10px 0 10px 0;
 
   a:link, a:visited, a:hover, a:active {
-    color: white;
+    color: var(--theme-primary-text-color);
   }
 
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -7,6 +7,7 @@ import { IntroductionPageContent } from "./activity-introduction/introduction-pa
 import Footer from "./activity-introduction/footer";
 import { PageLayouts } from "../utilities/activity-utils";
 import { ActivityDefinition, getActivityDefinition } from "../api";
+import { ThemeButtons } from "./theme-buttons";
 
 import "./app.scss";
 import { queryValue } from "../utilities/url-query";
@@ -16,6 +17,7 @@ const kDefaultActivity = "sample-activity-multiple-layout-types";   // may event
 interface IState {
   activity?: ActivityDefinition;
   currentPage: number;
+  showThemeButtons?: boolean;
 }
 interface IProps {}
 
@@ -37,7 +39,10 @@ export class App extends React.PureComponent<IProps, IState> {
       // page 0 is introduction, inner pages start from 1 and match page.position in exported activity
       const currentPage = Number(queryValue("page")) || 0;
 
-      this.setState({activity, currentPage});
+      const showThemeButtons = queryValue("themeButtons")?.toLowerCase() === "true";
+
+      this.setState({activity, currentPage, showThemeButtons});
+
     } catch (e) {
       console.warn(e);
     }
@@ -47,6 +52,7 @@ export class App extends React.PureComponent<IProps, IState> {
     return (
       <div className="app">
         { this.renderActivity() }
+        { this.state.showThemeButtons && <ThemeButtons/>}
       </div>
     );
   }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -26,7 +26,8 @@ export class App extends React.PureComponent<IProps, IState> {
   public constructor(props: IProps) {
     super(props);
     this.state = {
-      currentPage: 0
+      currentPage: 0,
+      showThemeButtons: false
     };
   }
 


### PR DESCRIPTION
Adds a URL parameter, themeButtons=true, to enable the color theme buttons which are used to change the primary and secondary theme colors.  These buttons were requested for testing/demoing until we have the colors in the actual activity JSON.

![image](https://user-images.githubusercontent.com/5126913/87960226-dbb98700-ca68-11ea-97d3-f4af16b2d7e8.png)
