### PR TITLE
173062429 full width question

### DIFF
--- a/src/components/activity-page/activity-page-content.scss
+++ b/src/components/activity-page/activity-page-content.scss
@@ -32,6 +32,13 @@
     }
 
     .group {
+      &.responsive {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: space-between;
+      }
+
       &.left {
         margin-right: 20px;
       }

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -39,47 +39,36 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
   render() {
     const { isFirstActivityPage, isLastActivityPage, page, totalPreviousQuestions } = this.props;
     const { scrollOffset } = this.state;
-    // Layout types are named in a somewhat confusing manner - particularly in relation to container widths.
-    // Responsive layout actually uses the entire page width, whereas the other layouts use only 960 horizontal pixels.
-    // FullWidth layout, despite its name, does not use the full screen width (it would be better named "stacked").
-    // However, in an effort to sync names with the authoring and activity JSON we will continue to use the previously defined naming conventions.
-    const useFullPageWidth = page.layout === PageLayouts.Responsive;
-    const vertical = page.layout === PageLayouts.FullWidth;
     const primaryFirst = page.layout === PageLayouts.FullWidth || page.layout === PageLayouts.FortySixty;
-
+    const pageSectionQuestionCount = getPageSectionQuestionCount(page);
     const introEmbeddables = page.embeddables.filter((e: any) => e.section === EmbeddableSections.Introduction);
     const primaryEmbeddables = page.embeddables.filter((e: any) => e.section === EmbeddableSections.Interactive);
     const secondaryEmbeddables = page.embeddables.filter((e: any) => (e.section !== EmbeddableSections.Interactive && e.section !== EmbeddableSections.Introduction));
 
-    const pinOffSet = page.layout !== PageLayouts.FullWidth && secondaryEmbeddables.length ? scrollOffset : 0;
-    const pageSectionQuestionCount = getPageSectionQuestionCount(page);
     const questionsBeforePrimary = totalPreviousQuestions + pageSectionQuestionCount.Header
                                    + (primaryFirst ? 0 : pageSectionQuestionCount.InfoAssessment);
-    const renderPrimary = this.renderPrimaryEmbeddables(primaryEmbeddables, questionsBeforePrimary, vertical, primaryFirst && !vertical, pinOffSet);
+    const primaryIsOnLeft = page.layout === PageLayouts.FortySixty;
+    const pinOffSet = page.layout !== PageLayouts.FullWidth && secondaryEmbeddables.length ? scrollOffset : 0;
+    const renderPrimary = this.renderPrimaryEmbeddables(primaryEmbeddables, questionsBeforePrimary, page.layout, primaryIsOnLeft, pinOffSet);
 
-    const collapsible = page.toggle_info_assessment && page.layout !== PageLayouts.FullWidth;
     const questionsBeforeSecondary = totalPreviousQuestions + pageSectionQuestionCount.Header
                                      + (primaryFirst ? pageSectionQuestionCount.InteractiveBlock : 0);
-    const renderSecondary = this.renderSecondaryEmbeddables(secondaryEmbeddables, questionsBeforeSecondary, vertical, !primaryFirst && !vertical, collapsible);
+    const secondaryIsOnLeft = page.layout === PageLayouts.Responsive || page.layout === PageLayouts.SixtyForty;
+    const collapsible = page.toggle_info_assessment && page.layout !== PageLayouts.FullWidth;
+    const renderSecondary = this.renderSecondaryEmbeddables(secondaryEmbeddables, questionsBeforeSecondary, page.layout, secondaryIsOnLeft, collapsible);
 
     const [first, second] = primaryFirst
                             ? [renderPrimary, renderSecondary]
                             : [renderSecondary, renderPrimary];
 
     return (
-      <div className={`page-content ${useFullPageWidth ? "full" : ""}`} data-cy="page-content">
+      <div className={`page-content ${page.layout === PageLayouts.Responsive ? "full" : ""}`} data-cy="page-content">
         <div className="name">{page.name}</div>
         <div className="introduction">
           { page.text && renderHTML(page.text) }
-          { introEmbeddables &&
-            <div className="embeddables">
-              <div className="group responsive">
-                {this.renderEmbeddables(introEmbeddables, EmbeddableSections.Introduction, totalPreviousQuestions)}
-              </div>
-            </div>
-          }
+          { introEmbeddables && this.renderIntroEmbeddables(introEmbeddables, totalPreviousQuestions) }
         </div>
-        <div className={`embeddables ${vertical ? "vertical" : ""}`}>
+        <div className={`embeddables ${page.layout === PageLayouts.FullWidth ? "vertical" : ""}`}>
           { first }
           { second }
         </div>
@@ -158,25 +147,36 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
     );
   }
 
-  private renderPrimaryEmbeddables = (primaryEmbeddables: any[], totalPreviousQuestions: number, vertical: boolean, leftContent: boolean, pinOffset: number) => {
-    const position = { top: pinOffset };
-    const containerClass = `group fill-remaining ${vertical ? "responsive" : ""} ${vertical ? "top" : ""} ${leftContent ? "left" : ""}`;
+  private renderIntroEmbeddables = (embeddables: any[], totalPreviousQuestions: number) => {
     return (
-      <div className={containerClass} style={position} ref={elt => this.primaryDivRef = elt}>
-        { this.renderEmbeddables(primaryEmbeddables, EmbeddableSections.Interactive, totalPreviousQuestions) }
+      <div className="embeddables">
+        <div className="group responsive">
+          {this.renderEmbeddables(embeddables, EmbeddableSections.Introduction, totalPreviousQuestions)}
+        </div>
       </div>
     );
   }
 
-  private renderSecondaryEmbeddables = (secondaryEmbeddables: any[], totalPreviousQuestions: number, vertical: boolean, leftContent: boolean, collapsible: boolean) => {
+  private renderPrimaryEmbeddables = (embeddables: any[], totalPreviousQuestions: number, layout: string, isLeft: boolean, pinOffset: number) => {
+    const position = { top: pinOffset };
+    const isFullWidth = layout === PageLayouts.FullWidth;
+    const containerClass = `group fill-remaining ${isFullWidth ? "responsive top" : ""} ${isLeft ? "left" : ""}`;
+    return (
+      <div className={containerClass} style={position} ref={elt => this.primaryDivRef = elt}>
+        { this.renderEmbeddables(embeddables, EmbeddableSections.Interactive, totalPreviousQuestions) }
+      </div>
+    );
+  }
+
+  private renderSecondaryEmbeddables = (embeddables: any[], totalPreviousQuestions: number, layout: string, isLeft: boolean, collapsible: boolean) => {
     const { isSecondaryCollapsed } = this.state;
-    const pageLayout = this.props.page.layout;
-    const staticWidth = pageLayout === PageLayouts.FortySixty || pageLayout === PageLayouts.SixtyForty || pageLayout === PageLayouts.Responsive;
-    const containerClass = `group ${vertical ? "responsive" : ""} ${leftContent ? "left" : ""} ${staticWidth ? "static-width" : ""} ${isSecondaryCollapsed ? "collapsed" : ""}`;
+    const isFullWidth = layout === PageLayouts.FullWidth;
+    const staticWidth = layout === PageLayouts.FortySixty || layout === PageLayouts.SixtyForty || layout === PageLayouts.Responsive;
+    const containerClass = `group ${isFullWidth ? "responsive" : ""} ${isLeft ? "left" : ""} ${staticWidth ? "static-width" : ""} ${isSecondaryCollapsed ? "collapsed" : ""}`;
     return (
       <div className={containerClass} ref={elt => this.secondaryDivRef = elt}>
         { collapsible && this.renderCollapsibleHeader() }
-        { !isSecondaryCollapsed && this.renderEmbeddables(secondaryEmbeddables, EmbeddableSections.InfoAssessment, totalPreviousQuestions)}
+        { !isSecondaryCollapsed && this.renderEmbeddables(embeddables, EmbeddableSections.InfoAssessment, totalPreviousQuestions)}
       </div>
     );
   }

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -60,7 +60,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
     const collapsible = page.toggle_info_assessment && page.layout !== PageLayouts.FullWidth;
     const questionsBeforeSecondary = totalPreviousQuestions + pageSectionQuestionCount.Header
                                      + (primaryFirst ? pageSectionQuestionCount.InteractiveBlock : 0);
-    const renderSecondary = this.renderSecondaryEmbeddables(secondaryEmbeddables, questionsBeforeSecondary, !primaryFirst && !vertical, collapsible);
+    const renderSecondary = this.renderSecondaryEmbeddables(secondaryEmbeddables, questionsBeforeSecondary, vertical, !primaryFirst && !vertical, collapsible);
 
     const [first, second] = primaryFirst
                             ? [renderPrimary, renderSecondary]
@@ -71,7 +71,13 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
         <div className="name">{page.name}</div>
         <div className="introduction">
           { page.text && renderHTML(page.text) }
-          { introEmbeddables && this.renderEmbeddables(introEmbeddables, EmbeddableSections.Introduction, totalPreviousQuestions) }
+          { introEmbeddables &&
+            <div className="embeddables">
+              <div className="group responsive">
+                {this.renderEmbeddables(introEmbeddables, EmbeddableSections.Introduction, totalPreviousQuestions)}
+              </div>
+            </div>
+          }
         </div>
         <div className={`embeddables ${vertical ? "vertical" : ""}`}>
           { first }
@@ -154,7 +160,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
 
   private renderPrimaryEmbeddables = (primaryEmbeddables: any[], totalPreviousQuestions: number, vertical: boolean, leftContent: boolean, pinOffset: number) => {
     const position = { top: pinOffset };
-    const containerClass = `group fill-remaining ${vertical ? "top" : ""} ${leftContent ? "left" : ""}`;
+    const containerClass = `group fill-remaining ${vertical ? "responsive" : ""} ${vertical ? "top" : ""} ${leftContent ? "left" : ""}`;
     return (
       <div className={containerClass} style={position} ref={elt => this.primaryDivRef = elt}>
         { this.renderEmbeddables(primaryEmbeddables, EmbeddableSections.Interactive, totalPreviousQuestions) }
@@ -162,11 +168,11 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
     );
   }
 
-  private renderSecondaryEmbeddables = (secondaryEmbeddables: any[], totalPreviousQuestions: number, leftContent: boolean, collapsible: boolean) => {
+  private renderSecondaryEmbeddables = (secondaryEmbeddables: any[], totalPreviousQuestions: number, vertical: boolean, leftContent: boolean, collapsible: boolean) => {
     const { isSecondaryCollapsed } = this.state;
     const pageLayout = this.props.page.layout;
     const staticWidth = pageLayout === PageLayouts.FortySixty || pageLayout === PageLayouts.SixtyForty || pageLayout === PageLayouts.Responsive;
-    const containerClass = `group ${leftContent ? "left" : ""} ${staticWidth ? "static-width" : ""} ${isSecondaryCollapsed ? "collapsed" : ""}`;
+    const containerClass = `group ${vertical ? "responsive" : ""} ${leftContent ? "left" : ""} ${staticWidth ? "static-width" : ""} ${isSecondaryCollapsed ? "collapsed" : ""}`;
     return (
       <div className={containerClass} ref={elt => this.secondaryDivRef = elt}>
         { collapsible && this.renderCollapsibleHeader() }

--- a/src/components/activity-page/embeddable.scss
+++ b/src/components/activity-page/embeddable.scss
@@ -7,7 +7,7 @@
     width: 100%;
   }
   &.reduced-width {
-    width: 45%;
+    width: 440px;
   }
 
   .header {


### PR DESCRIPTION
This PR formats questions to be full or half width in the layout (with half width questions potentially displayed side-by-side) of a full width activity page.  It also refactors some of the layout organization in `activity-page-content.tsx` to be more concise and easier to read.

![image](https://user-images.githubusercontent.com/5126913/88203841-47355d00-cbff-11ea-98b4-1571e5e6db05.png)
