### PR TITLE
Update activity url param to accept urls directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ Inside of your `package.json` file:
 ## Url Parameters
 ### Note: these are subject to change
 
-* activity={id}:     load sample-activity {id} or, if baseUrl is defined, load authored activity from `{baseUrl}/api/v1/activities/{activity}.json`
+* activity={id|url}: load sample-activity {id} or load json from specified url
 * page={n}:          load page n, where 0 is the activity introduction and 1 is the first page
-* baseUrl={url}:     full url to authoring site, such as `https%3A%2F%2Fauthoring.concord.org` or `http%3A%2F%2Fapp.lara.docker%2F`
 
 ## License
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -2,32 +2,27 @@ import sampleActivities from "./data";
 
 export type ActivityDefinition = any;
 
-export const getActivityDefinition = (activity: string, baseUrl?: string | null): Promise<ActivityDefinition> => {
+export const getActivityDefinition = (activity: string): Promise<ActivityDefinition> => {
   return new Promise((resolve, reject) => {
-    if (!baseUrl) {
+    const urlRegex = /^(https:|http:)\/\/\S+/;
+    if (activity.match(urlRegex)) {
+      getActivityDefinitionFromLara(activity).then(resolve);
+    } else {
       if (sampleActivities[activity]) {
         setTimeout(() => resolve(sampleActivities[activity]), 250);
       } else {
-        reject(`No sample activity matches ${activity}. For an authored activity, use "baseUrl=..."`);
-      }
-    } else {
-      const urlRegex = /^(https:|http:)\/\/\S+/;
-      if (baseUrl.match(urlRegex)) {
-        getActivityDefinitionFromLara(activity, baseUrl).then(resolve);
-      } else {
-        reject(`${baseUrl} must be a valid url, e.g. baseUrl=https%3A%2F%2Fauthoring.concord.org`);
+        reject(`No sample activity matches ${activity}`);
       }
     }
   });
 };
 
-const getActivityDefinitionFromLara = (activity: string, baseUrl: string): Promise<ActivityDefinition> => {
+const getActivityDefinitionFromLara = (activityUrl: string): Promise<ActivityDefinition> => {
   return new Promise((resolve, reject) => {
-    const exportUrl = `${baseUrl.replace(/\/$/, "")}/api/v1/activities/${activity}.json`;
-    fetch(exportUrl)
+    fetch(activityUrl)
     .then(response => {
       if (response.status !== 200) {
-        reject(`Errored fetching ${exportUrl}. Status Code: ${response.status}`);
+        reject(`Errored fetching ${activityUrl}. Status Code: ${response.status}`);
         return;
       }
 
@@ -36,7 +31,7 @@ const getActivityDefinitionFromLara = (activity: string, baseUrl: string): Promi
       });
     })
     .catch(function(err) {
-      reject(`Errored fetching ${exportUrl}. ${err}`);
+      reject(`Errored fetching ${activityUrl}. ${err}`);
     });
   });
 };

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -34,8 +34,7 @@ export class App extends React.PureComponent<IProps, IState> {
   async componentDidMount() {
     try {
       const activityPath = queryValue("activity") || kDefaultActivity;
-      const baseUrl = queryValue("baseUrl");
-      const activity = await getActivityDefinition(activityPath, baseUrl);
+      const activity = await getActivityDefinition(activityPath);
 
       // page 0 is introduction, inner pages start from 1 and match page.position in exported activity
       const currentPage = Number(queryValue("page")) || 0;


### PR DESCRIPTION
This avoids assuming that the source is LARA, and allows us to load any JSON from a readable source.

See discussion at https://github.com/concord-consortium/lara/pull/590#discussion_r457398699