### PR TITLE
Improve handling of empty managed interactive

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -25,7 +25,7 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
     const questionName = embeddable.name ? `: ${embeddable.name}` : "";
     const url = embeddable.url
                 ? embeddable.url
-                : (embeddable.library_interactive.data.base_url ? embeddable.library_interactive.data.base_url : "");
+                : (embeddable.library_interactive?.data?.base_url ? embeddable.library_interactive.data.base_url : "");
     return (
       <div ref={divRef}>
         { questionNumber && <div className="header">Question #{questionNumber}{questionName}</div> }

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -17,7 +17,7 @@ export enum EmbeddableSections {
 }
 
 export const isQuestion = (embeddable: any) => {
-  return ((embeddable.embeddable.type === "ManagedInteractive" && embeddable.embeddable.library_interactive.data.enable_learner_state)
+  return ((embeddable.embeddable.type === "ManagedInteractive" && embeddable.embeddable.library_interactive?.data?.enable_learner_state)
           || (embeddable.embeddable.type === "MwInteractive" && embeddable.embeddable.enable_learner_state));
 };
 


### PR DESCRIPTION
When authoring, a user can add a library interactive, but cancel the selection of a library type from the list.  This results in an embeddable section being added that is marked as a library interactive, but has no library interactive section (which causes the app to crash)  These changes prevent us from crashing when we hit this case when reading activity JSON.