### PR TITLE
Move interactiveState out of global activity props

### DIFF
--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import { TextBox } from "./text-box/text-box";
 import { ManagedInteractive } from "./managed-interactive/managed-interactive";
 import { ActivityLayouts, PageLayouts } from "../../utilities/activity-utils";
 
 import "./embeddable.scss";
 import { EmbeddableWrapper } from "../../types";
+import { interactiveStatePath, getCurrentDBValue } from "../../firebase-db";
 
 interface IProps {
   activityLayout?: number;
@@ -18,9 +19,18 @@ export const Embeddable: React.FC<IProps> = (props) => {
   const { activityLayout, embeddableWrapper, isPageIntroduction, pageLayout, questionNumber } = props;
   const embeddable = embeddableWrapper.embeddable;
 
+  const [initialInteractiveState, setInitialInteractiveState] = useState({});
+
+  // A one-time grab of the initial user state. We don't currently support live-updating the embeddable
+  // with new user state from the database.
+  // Although the request to start watching the data happens in app.ts, we have to assume that the
+  // initialInteractiveState may be delayed for network reasons, and so this listener may return after
+  // if the embeddable has already loaded. In that case, the embeddble will rerender.
+  getCurrentDBValue(interactiveStatePath(embeddable.ref_id), setInitialInteractiveState);
+
   let qComponent;
   if (embeddable.type === "MwInteractive" || embeddable.type === "ManagedInteractive") {
-    qComponent = <ManagedInteractive embeddable={embeddable} questionNumber={questionNumber} />;
+    qComponent = <ManagedInteractive embeddable={embeddable} initialInteractiveState={initialInteractiveState} questionNumber={questionNumber} />;
   } else {
     qComponent = <TextBox embeddable={embeddable} isPageIntroduction={isPageIntroduction} />;
   }

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -7,7 +7,13 @@ describe("IframeRuntime component", () => {
     const stubFunction = () => {
       // do nothing.
     };
-    const wrapper = shallow(<IframeRuntime url={"https://www.google.com/"} authoredState={null} interactiveState={null} setInteractiveState={stubFunction} />);
+    const wrapper = shallow(
+      <IframeRuntime
+        url={"https://www.google.com/"}
+        authoredState={null}
+        initialInteractiveState={null}
+        setInteractiveState={stubFunction}
+      />);
     expect(wrapper.find('[data-cy="iframe-runtime"]').length).toBe(1);
   });
 });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -17,7 +17,7 @@ interface ILogRequest {
 interface IProps {
   url: string;
   authoredState: any;
-  interactiveState: any;
+  initialInteractiveState: any;
   setInteractiveState: (state: any) => void;
   report?: boolean;
   proposedHeight?: number;
@@ -25,7 +25,7 @@ interface IProps {
 }
 
 export const IframeRuntime: React.FC<IProps> =
-  ({ url, authoredState, interactiveState, setInteractiveState, report, proposedHeight, containerWidth }) => {
+  ({ url, authoredState, initialInteractiveState, setInteractiveState, report, proposedHeight, containerWidth }) => {
   const [ heightFromInteractive, setHeightFromInteractive ] = useState(0);
   const [ ARFromSupportedFeatures, setARFromSupportedFeatures ] = useState(0);
   const [ hint, setHint ] = useState("");
@@ -36,9 +36,9 @@ export const IframeRuntime: React.FC<IProps> =
   // it reloads the iframe each time it's called, it's not a great experience for user when that happens while he is
   // interacting with the iframe (e.g. typing in textarea). And interactiveState is being updated very often,
   // as well as setInteractiveState that is generated during each render of the parent component.
-  const interactiveStateRef = useRef<any>(interactiveState);
+  const interactiveStateRef = useRef<any>(initialInteractiveState);
   const setInteractiveStateRef = useRef<((state: any) => void)>(setInteractiveState);
-  interactiveStateRef.current = interactiveState;
+  interactiveStateRef.current = initialInteractiveState;
   setInteractiveStateRef.current = setInteractiveState;
 
   useEffect(() => {
@@ -81,7 +81,7 @@ export const IframeRuntime: React.FC<IProps> =
         phoneRef.current.disconnect();
       }
     };
-  }, [url, authoredState, report]);
+  }, [url, authoredState, report, initialInteractiveState]);
 
   const heightFromSupportedFeatures = ARFromSupportedFeatures && containerWidth ? containerWidth / ARFromSupportedFeatures : 0;
   // There are several options for specifying the iframe height. Check if we have height specified by interactive (from IframePhone

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -6,6 +6,7 @@ import { IManagedInteractive, IMwInteractive, LibraryInteractiveData } from "../
 interface IProps {
   embeddable: IManagedInteractive | IMwInteractive;
   questionNumber?: number;
+  initialInteractiveState: any;     // user state that existed in DB when embeddable was first loaded
 }
 
 const kDefaultAspectRatio = 4 / 3;
@@ -16,7 +17,7 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
       // TODO: handle interactive state
     };
 
-    const { embeddable, questionNumber } = props;
+    const { embeddable, questionNumber, initialInteractiveState } = props;
     const questionName = embeddable.name ? `: ${embeddable.name}` : "";
     // in older iframe interactive embeddables, we get url, native_width, native_height, etc. directly off
     // of the embeddable object. On newer managed/library interactives, this data is in library_interactive.data.
@@ -55,7 +56,7 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
         <IframeRuntime
           url={url}
           authoredState={embeddable.authored_state}
-          interactiveState={embeddable.interactiveState}
+          initialInteractiveState={initialInteractiveState}
           setInteractiveState={handleNewInteractiveState}
           proposedHeight={proposedHeight}
           containerWidth={containerWidth}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -46,7 +46,7 @@ export class App extends React.PureComponent<IProps, IState> {
         const portalData = await fetchPortalData();
         await initializeDB(portalData.database.appName);
         await signInWithToken(portalData.database.rawFirebaseJWT);
-        watchAnswers(portalData, this.handleAnswersUpdated);
+        watchAnswers(portalData);
       }
 
       // page 0 is introduction, inner pages start from 1 and match page.position in exported activity
@@ -159,43 +159,4 @@ export class App extends React.PureComponent<IProps, IState> {
   private handleChangePage = (page: number) => {
     this.setState({currentPage: page});
   }
-
-  // updates `state.activity` to add `interactiveState` to embeddables
-  private handleAnswersUpdated = (answers: firebase.firestore.DocumentData[]) => {
-    // this is annoying and possibly a bug? Embeddables are coming through with `refId`'s such
-    // as "404-ManagedInteractive", while answers are coming through with `question_id`'s such
-    // as "managed_interactive_404"
-    const questionIdToRefId = (questionId: string) => {
-      const snakeCaseRegEx = /(\D*)_(\d*)/gm;
-      const parsed = snakeCaseRegEx.exec(questionId);
-      if (parsed && parsed.length) {
-        const [ , embeddableType, embeddableId] = parsed;
-        const camelCased = embeddableType.split("_").map(str => str.charAt(0).toUpperCase() + str.slice(1)).join("");
-        return `${embeddableId}-${camelCased}`;
-      }
-      return questionId;
-    };
-
-    const getInteractiveState = (answer: firebase.firestore.DocumentData) => {
-      const reportState = JSON.parse(answer.report_state);
-      return JSON.parse(reportState.interactiveState);
-    };
-
-    // restructure answers to key off question_id
-    const questionAnswers: {[id: string]: firebase.firestore.DocumentData} = {};
-    answers.forEach(answer => questionAnswers[questionIdToRefId(answer.question_id)] = getInteractiveState(answer));
-
-    const newActivityState = JSON.parse(JSON.stringify(this.state.activity)) as Activity;   // clone
-    newActivityState.pages.forEach((page) => {
-      page.embeddables.forEach((embeddableWrapper) => {
-        const refId = embeddableWrapper.embeddable.ref_id;
-        if (questionAnswers[refId]) {
-          embeddableWrapper.embeddable.interactiveState = questionAnswers[refId];
-        }
-      });
-    });
-
-    this.setState({activity: newActivityState});
-  }
-
 }


### PR DESCRIPTION
Previously we added the interactive state directly to the individual embeddables in the global Activity state. Among other issues, this would make the entire app re-render if the interactive state changed.

This changes things such that

1. app.ts initializes the listener on `answers` as before
2. Individual embeddables request the interactive state data

Since we are watching for changes on `answers`, any embeddable will always get the freshest state when the embeddable loads. However, once an embeddable has loaded it will no longer be listening for changes to the interactive state, as this is not currently supported by the interactive API.

To make this clearer, we now pass down `initialInteractiveState` to the nested embeddable components. If this changes (e.g. if we only hear back from Firestore after the embeddable has already rendered) we will re-render the embeddable.