### PR TITLE
Refactor to eliminate embeddable.embeddable and use embeddableWrapper

### DIFF
--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -137,17 +137,17 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
     let questionNumber = totalPreviousQuestions;
     return (
       <React.Fragment>
-        { embeddables.map((embeddable, i: number) => {
-            if (isQuestion(embeddable)) {
+        { embeddables.map((embeddableWrapper, i: number) => {
+            if (isQuestion(embeddableWrapper)) {
               questionNumber++;
             }
             return (
               <Embeddable
                 key={`embeddable ${i}`}
-                embeddable={embeddable}
+                embeddableWrapper={embeddableWrapper}
                 isPageIntroduction={i === 0 && section === EmbeddableSections.Introduction}
                 pageLayout={this.props.page.layout}
-                questionNumber={isQuestion(embeddable) ? questionNumber : undefined}
+                questionNumber={isQuestion(embeddableWrapper) ? questionNumber : undefined}
               />
             );
           })

--- a/src/components/activity-page/embeddable.test.tsx
+++ b/src/components/activity-page/embeddable.test.tsx
@@ -7,7 +7,7 @@ import { EmbeddableWrapper } from "../../types";
 
 describe("Embeddable component", () => {
   it("renders component", () => {
-    const embeddable: EmbeddableWrapper = {
+    const embeddableWrapper: EmbeddableWrapper = {
       "embeddable": {
         "content": "<p><strong>This is a page with full width layout</strong>.&nbsp;&nbsp;Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>",
         "is_full_width": true,
@@ -18,7 +18,7 @@ describe("Embeddable component", () => {
       },
       "section": "header_block"
     };
-    const wrapper = shallow(<Embeddable embeddable={embeddable} isPageIntroduction={false} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
+    const wrapper = shallow(<Embeddable embeddableWrapper={embeddableWrapper} isPageIntroduction={false} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
     expect(wrapper.find(TextBox).length).toBe(1);
   });
 });

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -8,27 +8,27 @@ import { EmbeddableWrapper } from "../../types";
 
 interface IProps {
   activityLayout?: number;
-  embeddable: EmbeddableWrapper;
+  embeddableWrapper: EmbeddableWrapper;
   isPageIntroduction: boolean;
   pageLayout: string;
   questionNumber?: number;
 }
 
 export const Embeddable: React.FC<IProps> = (props) => {
-  const { activityLayout, embeddable, isPageIntroduction, pageLayout, questionNumber } = props;
+  const { activityLayout, embeddableWrapper, isPageIntroduction, pageLayout, questionNumber } = props;
   const EmbeddableComponent = {
     "MwInteractive": ManagedInteractive,
     "ManagedInteractive": ManagedInteractive,
     "Embeddable::Xhtml": TextBox,
   };
-  const type = embeddable.embeddable.type;
-  const QComponent = embeddable ? EmbeddableComponent[type] : undefined;
+  const type = embeddableWrapper.embeddable.type;
+  const QComponent = embeddableWrapper ? EmbeddableComponent[type] : undefined;
   const staticWidth = pageLayout === PageLayouts.FortySixty || pageLayout === PageLayouts.SixtyForty || pageLayout === PageLayouts.Responsive;
   const singlePageLayout = activityLayout === ActivityLayouts.SinglePage;
   return (
-    <div className={`embeddable ${embeddable.embeddable.is_full_width || staticWidth || singlePageLayout ? "full-width" : "reduced-width"}`} data-cy="embeddable">
+    <div className={`embeddable ${embeddableWrapper.embeddable.is_full_width || staticWidth || singlePageLayout ? "full-width" : "reduced-width"}`} data-cy="embeddable">
       { QComponent
-        ? <QComponent embeddable={embeddable.embeddable} questionNumber={questionNumber} isPageIntroduction={isPageIntroduction} />
+        ? <QComponent embeddable={embeddableWrapper.embeddable} questionNumber={questionNumber} isPageIntroduction={isPageIntroduction} />
         : <div>Content type not supported</div>
       }
     </div>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -187,10 +187,10 @@ export class App extends React.PureComponent<IProps, IState> {
 
     const newActivityState = JSON.parse(JSON.stringify(this.state.activity)) as Activity;   // clone
     newActivityState.pages.forEach((page) => {
-      page.embeddables.forEach((embeddable) => {
-        const refId = embeddable.embeddable.ref_id;
+      page.embeddables.forEach((embeddableWrapper) => {
+        const refId = embeddableWrapper.embeddable.ref_id;
         if (questionAnswers[refId]) {
-          embeddable.embeddable.interactiveState = questionAnswers[refId];
+          embeddableWrapper.embeddable.interactiveState = questionAnswers[refId];
         }
       });
     });

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -22,8 +22,8 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
     const embeddables = [...visibleEmbeddables.headerBlock, ...visibleEmbeddables.interactiveBox, ...visibleEmbeddables.infoAssessment];
     return (
       <React.Fragment key={index}>
-        { embeddables.map((embeddable, i: number) => {
-            if (isQuestion(embeddable)) {
+        { embeddables.map((embeddableWrapper, i: number) => {
+            if (isQuestion(embeddableWrapper)) {
               questionNumber++;
             }
             embeddableNumber++;
@@ -31,10 +31,10 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
               <Embeddable
                 activityLayout={ActivityLayouts.SinglePage}
                 key={`embeddable ${embeddableNumber}`}
-                embeddable={embeddable}
+                embeddableWrapper={embeddableWrapper}
                 isPageIntroduction={questionNumber === 0}
                 pageLayout={PageLayouts.FullWidth}
-                questionNumber={isQuestion(embeddable) ? questionNumber : undefined}
+                questionNumber={isQuestion(embeddableWrapper) ? questionNumber : undefined}
               />
             );
           })

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -24,9 +24,9 @@ export interface VisibleEmbeddables {
   infoAssessment: EmbeddableWrapper[],
 }
 
-export const isQuestion = (embeddable: EmbeddableWrapper) => {
-  return ((embeddable.embeddable.type === "ManagedInteractive" && embeddable.embeddable.library_interactive?.data?.enable_learner_state)
-          || (embeddable.embeddable.type === "MwInteractive" && embeddable.embeddable.enable_learner_state));
+export const isQuestion = (embeddableWrapper: EmbeddableWrapper) => {
+  return ((embeddableWrapper.embeddable.type === "ManagedInteractive" && embeddableWrapper.embeddable.library_interactive?.data?.enable_learner_state)
+          || (embeddableWrapper.embeddable.type === "MwInteractive" && embeddableWrapper.embeddable.enable_learner_state));
 };
 
 export interface PageSectionQuestionCount {
@@ -59,13 +59,13 @@ export const getVisibleEmbeddablesOnPage = (page: Page) => {
 export const getPageSectionQuestionCount = (page: Page) => {
   const pageSectionQuestionCount: PageSectionQuestionCount = { Header: 0, InfoAssessment: 0, InteractiveBlock: 0 };
   for (let embeddableNum = 0; embeddableNum < page.embeddables.length; embeddableNum++) {
-    const embeddable = page.embeddables[embeddableNum];
-    if (isQuestion(embeddable) && !embeddable.embeddable.is_hidden) {
-      if (embeddable.section === EmbeddableSections.Introduction && !isEmbeddableSectionHidden(page, embeddable.section)) {
+    const embeddableWrapper = page.embeddables[embeddableNum];
+    if (isQuestion(embeddableWrapper) && !embeddableWrapper.embeddable.is_hidden) {
+      if (embeddableWrapper.section === EmbeddableSections.Introduction && !isEmbeddableSectionHidden(page, embeddableWrapper.section)) {
         pageSectionQuestionCount.Header++;
-      } else if (!embeddable.section && !isEmbeddableSectionHidden(page, embeddable.section)) {
+      } else if (!embeddableWrapper.section && !isEmbeddableSectionHidden(page, embeddableWrapper.section)) {
         pageSectionQuestionCount.InfoAssessment++;
-      } else if (embeddable.section === EmbeddableSections.Interactive && !isEmbeddableSectionHidden(page, embeddable.section)) {
+      } else if (embeddableWrapper.section === EmbeddableSections.Interactive && !isEmbeddableSectionHidden(page, embeddableWrapper.section)) {
         pageSectionQuestionCount.InteractiveBlock++;
       }
     }
@@ -78,8 +78,8 @@ export const numQuestionsOnPreviousPages = (currentPage: number, activity: Activ
   for (let page = 0; page < currentPage - 1; page++) {
     if (!activity.pages[page].is_hidden) {
       for (let embeddableNum = 0; embeddableNum < activity.pages[page].embeddables.length; embeddableNum++) {
-        const embeddable = activity.pages[page].embeddables[embeddableNum];
-        if (isQuestion(embeddable) && !embeddable.embeddable.is_hidden && !isEmbeddableSectionHidden(activity.pages[page], embeddable.section)) {
+        const embeddableWrapper = activity.pages[page].embeddables[embeddableNum];
+        if (isQuestion(embeddableWrapper) && !embeddableWrapper.embeddable.is_hidden && !isEmbeddableSectionHidden(activity.pages[page], embeddableWrapper.section)) {
           numQuestions++;
         }
       }


### PR DESCRIPTION
In several cases we had redundant and confusing naming patterns where `embeddable.embeddable` was used.  With the introduction of new activity types, it's clearer to use 'embeddableWrapper.embeddable` in these cases to distinguish the two unique objects inside the activity object.