### PR TITLE
Split Embeddable type into different sub-types

### DIFF
--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -16,21 +16,20 @@ interface IProps {
 
 export const Embeddable: React.FC<IProps> = (props) => {
   const { activityLayout, embeddableWrapper, isPageIntroduction, pageLayout, questionNumber } = props;
-  const EmbeddableComponent = {
-    "MwInteractive": ManagedInteractive,
-    "ManagedInteractive": ManagedInteractive,
-    "Embeddable::Xhtml": TextBox,
-  };
-  const type = embeddableWrapper.embeddable.type;
-  const QComponent = embeddableWrapper ? EmbeddableComponent[type] : undefined;
+  const embeddable = embeddableWrapper.embeddable;
+
+  let qComponent;
+  if (embeddable.type === "MwInteractive" || embeddable.type === "ManagedInteractive") {
+    qComponent = <ManagedInteractive embeddable={embeddable} questionNumber={questionNumber} />;
+  } else {
+    qComponent = <TextBox embeddable={embeddable} isPageIntroduction={isPageIntroduction} />;
+  }
+
   const staticWidth = pageLayout === PageLayouts.FortySixty || pageLayout === PageLayouts.SixtyForty || pageLayout === PageLayouts.Responsive;
   const singlePageLayout = activityLayout === ActivityLayouts.SinglePage;
   return (
     <div className={`embeddable ${embeddableWrapper.embeddable.is_full_width || staticWidth || singlePageLayout ? "full-width" : "reduced-width"}`} data-cy="embeddable">
-      { QComponent
-        ? <QComponent embeddable={embeddableWrapper.embeddable} questionNumber={questionNumber} isPageIntroduction={isPageIntroduction} />
-        : <div>Content type not supported</div>
-      }
+      { qComponent || <div>Content type not supported</div> }
     </div>
   );
 };

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { IframeRuntime } from "./iframe-runtime";
 import useResizeObserver from "@react-hook/resize-observer";
-import { Embeddable } from "../../../types";
+import { IManagedInteractive, IMwInteractive, LibraryInteractiveData } from "../../../types";
 
 interface IProps {
-  embeddable: Embeddable;
+  embeddable: IManagedInteractive | IMwInteractive;
   questionNumber?: number;
 }
 
@@ -20,7 +20,12 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
     const questionName = embeddable.name ? `: ${embeddable.name}` : "";
     // in older iframe interactive embeddables, we get url, native_width, native_height, etc. directly off
     // of the embeddable object. On newer managed/library interactives, this data is in library_interactive.data.
-    const embeddableData = embeddable.library_interactive?.data || embeddable;
+    let embeddableData: IMwInteractive | LibraryInteractiveData;
+    if (embeddable.type === "ManagedInteractive") {
+      embeddableData = embeddable.library_interactive.data;
+    } else {
+      embeddableData = embeddable;
+    }
     const url = embeddableData.base_url || embeddableData.url || "";
     // TODO: handle different aspect ration methods
     // const aspectRatioMethod = data.aspect_ratio_method ? data.aspect_ratio_method : "";

--- a/src/components/activity-page/text-box/text-box.tsx
+++ b/src/components/activity-page/text-box/text-box.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { renderHTML } from "../../../utilities/render-html";
 
 import "./text-box.scss";
-import { Embeddable } from "../../../types";
+import { IEmbeddableXhtml } from "../../../types";
 
 interface IProps {
-  embeddable: Embeddable
+  embeddable: IEmbeddableXhtml
   isPageIntroduction: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,35 +7,35 @@ export interface IframePhone {
   disconnect: () => void;
 }
 
-export interface LibraryInteractive {
-  hash: string;
-  data: {
-    aspect_ratio_method?: "DEFAULT" | null;
-    authoring_guidance?: string;
-    base_url: string;
-    url?: string;
-    click_to_play: boolean;
-    click_to_play_prompt?: string | null;
-    description?: string;
-    enable_learner_state: boolean;
-    full_window: boolean;
-    has_report_url: boolean;
-    image_url?: string | null;
-    name?: string;
-    native_height: number;
-    native_width: number;
-    no_snapshots: boolean;
-    show_delete_data_button: boolean;
-    thumbnail_url?: string;
-    customizable: boolean;
-    authorable: boolean;
-  }
+export interface LibraryInteractiveData {
+  aspect_ratio_method?: "DEFAULT" | null;
+  authoring_guidance?: string;
+  base_url: string;
+  url?: string;
+  click_to_play: boolean;
+  click_to_play_prompt?: string | null;
+  description?: string;
+  enable_learner_state: boolean;
+  full_window: boolean;
+  has_report_url: boolean;
+  image_url?: string | null;
+  name?: string;
+  native_height: number;
+  native_width: number;
+  no_snapshots: boolean;
+  show_delete_data_button: boolean;
+  thumbnail_url?: string;
+  customizable: boolean;
+  authorable: boolean;
 }
 
-// This could in theory be split into three types, with a Base and a union Embeddable type.
-// This makes some of the component code a lot more messy. It may still be worth it, though.
-export interface Embeddable {
-  type: "ManagedInteractive" | "MwInteractive" | "Embeddable::Xhtml";
+export interface LibraryInteractive {
+  hash: string;
+  data: LibraryInteractiveData;
+}
+
+export interface EmbeddableBase {
+  type: string;
   name: string;
   authored_state?: string | null;
   interactiveState?: any | null;
@@ -43,9 +43,13 @@ export interface Embeddable {
   is_hidden: boolean;
   is_full_width: boolean;
   ref_id: string;
-  library_interactive?: LibraryInteractive;         // ManagedInteractive
-  show_in_featured_question_report?: boolean;       //    "
-  inherit_aspect_ratio_method?: boolean;            //    v
+}
+
+export interface IManagedInteractive extends EmbeddableBase {
+  type: "ManagedInteractive";
+  library_interactive: LibraryInteractive;
+  show_in_featured_question_report?: boolean;
+  inherit_aspect_ratio_method?: boolean;
   custom_aspect_ratio_method?: "DEFAULT" | null;
   inherit_native_width?: boolean;
   custom_native_width?: number;
@@ -59,13 +63,23 @@ export interface Embeddable {
   custom_click_to_play_prompt?: string | null
   inherit_image_url?: boolean;
   custom_image_url?: string | null;
-  base_url?: string;                                // non-ManagedInteractive
-  url?: string;                                     //  "
-  native_height?: number;                           //  "
-  native_width?: number;                            //  "
-  content?: string;                                 // Embeddable::Xhtml
-  enable_learner_state?: boolean;                   // MwInteractive
 }
+
+export interface IMwInteractive extends EmbeddableBase {
+  type: "MwInteractive";
+  base_url?: string;
+  url?: string;
+  native_height?: number;
+  native_width?: number;
+  enable_learner_state?: boolean;
+}
+
+export interface IEmbeddableXhtml extends EmbeddableBase {
+  type: "Embeddable::Xhtml";
+  content?: string;
+}
+
+export type Embeddable = IManagedInteractive | IMwInteractive | IEmbeddableXhtml;
 
 export interface EmbeddableWrapper {
   section: "header_block" | "interactive_box" | null;


### PR DESCRIPTION
Small commit to split Embeddable type into different sub-types, as I had mentioned maybe doing in an earlier comment. Done now in case you'll be touching similar code.

This makes some of the code more verbose, as Typescript forces us to type-guard more explicitly, but it makes everything more explicit, especially as some of the embeddable types really don't share a lot of props.

I'm unsure whether all the possible-undefined `prop?:`s are still needed, as it may be that LARA will always export those props (or `null`) for those explicit types, but it seems a little flaky what LARA exports so it seems like it can't hurt to always require checking to see if a prop exists.