### PR TITLE
Fix handling of unsupported embeddable types

### DIFF
--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -21,7 +21,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
   let qComponent;
   if (embeddable.type === "MwInteractive" || embeddable.type === "ManagedInteractive") {
     qComponent = <ManagedInteractive embeddable={embeddable} questionNumber={questionNumber} />;
-  } else {
+  } else if (embeddable.type === "Embeddable::Xhtml") {
     qComponent = <TextBox embeddable={embeddable} isPageIntroduction={isPageIntroduction} />;
   }
 


### PR DESCRIPTION
Previously we were rendering all embeddable types other than `MwInteractive` and `ManagedInteractive` using the `TextBox` component.  This PR adds a small change so that we only use the `TextBox` component if the type is `Embeddable::Xhtml`  and all other types are, at present, reported as unsupported.