### PR TITLE
Save interactive state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6009,6 +6009,36 @@
         }
       }
     },
+    "@testing-library/dom": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.22.0.tgz",
+      "integrity": "sha512-soXVCM/F2WxMidqGlZsSvTkmLsmi72q5N2IrB7o1aTFpMCfEL+Kl0kzv+2Lk/dLxny/c7CWUDa+yjve5VEsjMg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "dom-accessibility-api": "^0.4.6",
+        "pretty-format": "^25.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+          "dev": true
+        }
+      }
+    },
     "@testing-library/react-hooks": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-3.3.0.tgz",
@@ -6023,6 +6053,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
       "dev": true
     },
     "@types/babel__core": {
@@ -6945,6 +6981,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arr-diff": {
@@ -10408,6 +10454,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.4.7.tgz",
+      "integrity": "sha512-5+GzhTpCQYHz4NjL8loYTDVBnXIjNLBadWQBKxXk+osFEplLt3EsSYBu2YZcdZ8QqrvCHgW6TSMGMbmgfhrn2g==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6362,6 +6362,11 @@
         "source-map": "^0.6.1"
       }
     },
+    "@types/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw=="
+    },
     "@types/webpack": {
       "version": "4.41.12",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.12.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4484,6 +4484,14 @@
         "minimist": "^1.2.0"
       }
     },
+    "@concord-consortium/lara-interactive-api": {
+      "version": "0.5.0-pre.3",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.5.0-pre.3.tgz",
+      "integrity": "sha512-Vl2SdrJXz9I4SeqfQCbvpx1jMnI56c8S+15YHes1EmpSJC57CY6UuBpkU8+OTEK6SwbtjvjhiTwR7jRJjLvlJg==",
+      "requires": {
+        "iframe-phone": "^1.3.1"
+      }
+    },
     "@cypress/browserify-preprocessor": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "@concord-consortium/lara-interactive-api": "^0.5.0-pre.3",
     "@react-hook/resize-observer": "^1.1.0",
     "@types/jquery": "^3.5.1",
     "@types/jsonwebtoken": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@cypress/code-coverage": "^3.8.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@svgr/webpack": "^5.4.0",
+    "@testing-library/dom": "^7.22.0",
     "@testing-library/react-hooks": "^3.3.0",
     "@types/dompurify": "^2.0.2",
     "@types/enzyme": "^3.10.5",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "@types/jquery": "^3.5.1",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/superagent": "^4.1.8",
+    "@types/uuid": "^8.0.0",
     "dompurify": "^2.0.12",
     "firebase": "^7.17.1",
     "html-react-parser": "^0.13.0",

--- a/src/components/activity-page/embeddable.test.tsx
+++ b/src/components/activity-page/embeddable.test.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import { waitFor } from "@testing-library/dom";
+import iframePhone from "iframe-phone";
 import { Embeddable } from "./embeddable";
 import { PageLayouts } from "../../utilities/activity-utils";
 import { mount, ReactWrapper } from "enzyme";
 import { EmbeddableWrapper } from "../../types";
 import { act } from "react-dom/test-utils";
+import { DefaultManagedInteractive } from "../../test-utils/model-for-tests";
 
 describe("Embeddable component", () => {
-  it("renders component", async () => {
+  it("renders a text component", async () => {
     const embeddableWrapper: EmbeddableWrapper = {
       "embeddable": {
         "content": "<p><strong>This is a page with full width layout</strong>.&nbsp;&nbsp;Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>",
@@ -28,6 +30,35 @@ describe("Embeddable component", () => {
 
     await waitFor(() => {
       expect(wrapper.text()).toContain("This is a page");
+    });
+  });
+
+  it("renders a managed interactive", async () => {
+    iframePhone.ParentEndpoint = jest.fn().mockImplementation(() => ({
+      disconnect: jest.fn()
+    }));
+
+    const embeddableWrapper: EmbeddableWrapper = {
+      "embeddable": {
+        ...DefaultManagedInteractive,
+        authored_state: `{"version":1,"questionType":"open_response","prompt":"<p>Write something:</p>"}`,
+        ref_id: "123-ManagedInteractive"
+      },
+      "section": "interactive_box"
+    };
+
+    let wrapper: ReactWrapper;
+    await act(async () => {
+      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} isPageIntroduction={false} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
+    });
+
+    await waitFor(() => {
+      // for some reason, can't get any version of
+      //   expect(wrapper.find("ManagedInteractive").length).toBe(1);
+      //   expect(wrapper.find("iframe").length).toBe(1);
+      //   expect(wrapper.find('[data-cy="iframe-runtime"]').length).toBe(1);
+      // to work
+      expect(wrapper.html()).toContain("iframe-runtime");
     });
   });
 });

--- a/src/components/activity-page/embeddable.test.tsx
+++ b/src/components/activity-page/embeddable.test.tsx
@@ -1,12 +1,13 @@
 import React from "react";
+import { waitFor } from "@testing-library/dom";
 import { Embeddable } from "./embeddable";
-import { TextBox } from "./text-box/text-box";
 import { PageLayouts } from "../../utilities/activity-utils";
-import { shallow } from "enzyme";
+import { mount, ReactWrapper } from "enzyme";
 import { EmbeddableWrapper } from "../../types";
+import { act } from "react-dom/test-utils";
 
 describe("Embeddable component", () => {
-  it("renders component", () => {
+  it("renders component", async () => {
     const embeddableWrapper: EmbeddableWrapper = {
       "embeddable": {
         "content": "<p><strong>This is a page with full width layout</strong>.&nbsp;&nbsp;Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>",
@@ -18,7 +19,15 @@ describe("Embeddable component", () => {
       },
       "section": "header_block"
     };
-    const wrapper = shallow(<Embeddable embeddableWrapper={embeddableWrapper} isPageIntroduction={false} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
-    expect(wrapper.find(TextBox).length).toBe(1);
+
+    let wrapper: ReactWrapper;
+    await act(async () => {
+      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} isPageIntroduction={false} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
+      expect(wrapper.containsMatchingElement(<div>Loading...</div>)).toEqual(true);
+    });
+
+    await waitFor(() => {
+      expect(wrapper.text()).toContain("This is a page");
+    });
   });
 });

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -1,10 +1,11 @@
-import React, { useRef, useEffect }  from "react";
+import React, { useRef, useEffect, useState }  from "react";
 import { TextBox } from "./text-box/text-box";
 import { ManagedInteractive } from "./managed-interactive/managed-interactive";
 import { ActivityLayouts, PageLayouts } from "../../utilities/activity-utils";
 import { EmbeddablePlugin } from "./plugins/embeddable-plugin";
 import { initializePlugin } from "../../utilities/plugin-utils";
 import { EmbeddableWrapper, IEmbeddablePlugin } from "../../types";
+import { interactiveStatePath, getCurrentDBValue } from "../../firebase-db";
 
 import "./embeddable.scss";
 
@@ -22,9 +23,18 @@ export const Embeddable: React.FC<IProps> = (props) => {
   const { activityLayout, embeddableWrapper, isPageIntroduction, linkedPluginEmbeddable, pageLayout, questionNumber, teacherEditionMode } = props;
   const embeddable = embeddableWrapper.embeddable;
 
+  const [initialInteractiveState, setInitialInteractiveState] = useState({});
+
+  // A one-time grab of the initial user state. We don't currently support live-updating the embeddable
+  // with new user state from the database.
+  // Although the request to start watching the data happens in app.ts, we have to assume that the
+  // initialInteractiveState may be delayed for network reasons, and so this listener may return after
+  // if the embeddable has already loaded. In that case, the embeddble will rerender.
+  getCurrentDBValue(interactiveStatePath(embeddable.ref_id), setInitialInteractiveState);
+
   let qComponent;
   if (embeddable.type === "MwInteractive" || embeddable.type === "ManagedInteractive") {
-    qComponent = <ManagedInteractive embeddable={embeddable} questionNumber={questionNumber} />;
+    qComponent = <ManagedInteractive embeddable={embeddable} initialInteractiveState={initialInteractiveState} questionNumber={questionNumber} />;
   } else if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.component_label === "windowShade") {
     qComponent = teacherEditionMode ? <EmbeddablePlugin embeddable={embeddable} /> : undefined;
   } else if (embeddable.type === "Embeddable::Xhtml") {

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -41,7 +41,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
     if (embeddableWrapperDivTarget.current && embeddableDivTarget.current && linkedPluginEmbeddable && teacherEditionMode) {
       initializePlugin(linkedPluginEmbeddable, embeddable, embeddableWrapperDivTarget.current, embeddableDivTarget.current);
     }
-  }, [linkedPluginEmbeddable, embeddable]);
+  }, [linkedPluginEmbeddable, embeddable, initialInteractiveState, teacherEditionMode]);
 
   // `initialInteractiveState.loaded` will be set to true the moment our initial request for `answers` data
   // comes through, whether or not there is any particular initial state for this interactive.
@@ -63,7 +63,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
       setInitialInteractiveState(newInitialInteractiveState);
     });
     return (
-      <div>Loading...</div>
+      <div key={embeddableWrapper.embeddable.ref_id}>Loading...</div>
     );
   }
 

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -4,7 +4,7 @@ import { ManagedInteractive } from "./managed-interactive/managed-interactive";
 import { ActivityLayouts, PageLayouts } from "../../utilities/activity-utils";
 import { EmbeddablePlugin } from "./plugins/embeddable-plugin";
 import { initializePlugin } from "../../utilities/plugin-utils";
-import { EmbeddableWrapper, IEmbeddablePlugin } from "../../types";
+import { EmbeddableWrapper, IEmbeddablePlugin, IExportableAnswerMetadata } from "../../types";
 import { localAnswerPath, getCurrentDBValue } from "../../firebase-db";
 
 import "./embeddable.scss";
@@ -23,27 +23,45 @@ export const Embeddable: React.FC<IProps> = (props) => {
   const { activityLayout, embeddableWrapper, isPageIntroduction, linkedPluginEmbeddable, pageLayout, questionNumber, teacherEditionMode } = props;
   const embeddable = embeddableWrapper.embeddable;
 
-  const [loadedInitialInteractiveState, setLoadedInitialInteractiveState] = useState(false);
-  const [initialInteractiveState, setInitialInteractiveState] = useState();
-  const [answerMeta, setAnswerMeta] = useState();
+  interface InitialInteractiveState {
+    state?: any;
+    answerMeta?: IExportableAnswerMetadata;
+    loaded: boolean;
+  }
 
-  // `loadedInitialInteractiveState` will be set to true the moment our initial request for `answers` data
+  const [initialInteractiveState, setInitialInteractiveState] = useState({
+    loaded: false
+  } as InitialInteractiveState);
+
+
+  const embeddableWrapperDivTarget = useRef<HTMLInputElement>(null);
+  const embeddableDivTarget = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (embeddableWrapperDivTarget.current && embeddableDivTarget.current && linkedPluginEmbeddable && teacherEditionMode) {
+      initializePlugin(linkedPluginEmbeddable, embeddable, embeddableWrapperDivTarget.current, embeddableDivTarget.current);
+    }
+  }, [linkedPluginEmbeddable, embeddable]);
+
+  // `initialInteractiveState.loaded` will be set to true the moment our initial request for `answers` data
   // comes through, whether or not there is any particular initial state for this interactive.
   // Once this has happened, we won't be setting `initialInteractiveState` again, so we won't rerender.
-  if (!loadedInitialInteractiveState) {
+  if (!initialInteractiveState.loaded) {
 
     // A one-time grab of the initial user state. We don't currently support live-updating the embeddable
     // with new user state from the database.
     // If the request is still pending, we will delay rendering the component. If we're not requesting data
     // from firestore, we will return instantly with no data.
     getCurrentDBValue(localAnswerPath(embeddable.ref_id)).then(wrappedAnswer => {
+      const newInitialInteractiveState: InitialInteractiveState = {
+        loaded: true
+      };
       if (wrappedAnswer) {
-        setInitialInteractiveState(wrappedAnswer.interactiveState);
-        setAnswerMeta(wrappedAnswer.meta);
+        newInitialInteractiveState.state = wrappedAnswer.interactiveState;
+        newInitialInteractiveState.answerMeta = wrappedAnswer.meta;
       }
-      setLoadedInitialInteractiveState(true);
+      setInitialInteractiveState(newInitialInteractiveState);
     });
-
     return (
       <div>Loading...</div>
     );
@@ -51,7 +69,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
 
   let qComponent;
   if (embeddable.type === "MwInteractive" || embeddable.type === "ManagedInteractive") {
-    qComponent = <ManagedInteractive embeddable={embeddable} initialInteractiveState={initialInteractiveState} questionNumber={questionNumber} initialAnswerMeta={answerMeta} />;
+    qComponent = <ManagedInteractive embeddable={embeddable} initialInteractiveState={initialInteractiveState.state} questionNumber={questionNumber} initialAnswerMeta={initialInteractiveState.answerMeta} />;
   } else if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.component_label === "windowShade") {
     qComponent = teacherEditionMode ? <EmbeddablePlugin embeddable={embeddable} /> : undefined;
   } else if (embeddable.type === "Embeddable::Xhtml") {
@@ -62,14 +80,6 @@ export const Embeddable: React.FC<IProps> = (props) => {
 
   const staticWidth = pageLayout === PageLayouts.FortySixty || pageLayout === PageLayouts.SixtyForty || pageLayout === PageLayouts.Responsive;
   const singlePageLayout = activityLayout === ActivityLayouts.SinglePage;
-
-  const embeddableWrapperDivTarget = useRef<HTMLInputElement>(null);
-  const embeddableDivTarget = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    if (embeddableWrapperDivTarget.current && embeddableDivTarget.current && linkedPluginEmbeddable && teacherEditionMode) {
-      initializePlugin(linkedPluginEmbeddable, embeddable, embeddableWrapperDivTarget.current, embeddableDivTarget.current);
-    }
-  }, [linkedPluginEmbeddable, embeddable]);
 
   return (
     <div

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -5,7 +5,7 @@ import { ActivityLayouts, PageLayouts } from "../../utilities/activity-utils";
 import { EmbeddablePlugin } from "./plugins/embeddable-plugin";
 import { initializePlugin } from "../../utilities/plugin-utils";
 import { EmbeddableWrapper, IEmbeddablePlugin } from "../../types";
-import { interactiveStatePath, getCurrentDBValue } from "../../firebase-db";
+import { localAnswerPath, getCurrentDBValue } from "../../firebase-db";
 
 import "./embeddable.scss";
 
@@ -23,18 +23,22 @@ export const Embeddable: React.FC<IProps> = (props) => {
   const { activityLayout, embeddableWrapper, isPageIntroduction, linkedPluginEmbeddable, pageLayout, questionNumber, teacherEditionMode } = props;
   const embeddable = embeddableWrapper.embeddable;
 
-  const [initialInteractiveState, setInitialInteractiveState] = useState({});
+  const [initialInteractiveState, setInitialInteractiveState] = useState();
+  const [answerMeta, setAnswerMeta] = useState();
 
   // A one-time grab of the initial user state. We don't currently support live-updating the embeddable
   // with new user state from the database.
   // Although the request to start watching the data happens in app.ts, we have to assume that the
   // initialInteractiveState may be delayed for network reasons, and so this listener may return after
   // if the embeddable has already loaded. In that case, the embeddble will rerender.
-  getCurrentDBValue(interactiveStatePath(embeddable.ref_id), setInitialInteractiveState);
+  getCurrentDBValue(localAnswerPath(embeddable.ref_id), (wrappedAnswer) => {
+    setInitialInteractiveState(wrappedAnswer.interactiveState);
+    setAnswerMeta(wrappedAnswer.meta);
+  });
 
   let qComponent;
   if (embeddable.type === "MwInteractive" || embeddable.type === "ManagedInteractive") {
-    qComponent = <ManagedInteractive embeddable={embeddable} initialInteractiveState={initialInteractiveState} questionNumber={questionNumber} />;
+    qComponent = <ManagedInteractive embeddable={embeddable} initialInteractiveState={initialInteractiveState} questionNumber={questionNumber} initialAnswerMeta={answerMeta} />;
   } else if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.component_label === "windowShade") {
     qComponent = teacherEditionMode ? <EmbeddablePlugin embeddable={embeddable} /> : undefined;
   } else if (embeddable.type === "Embeddable::Xhtml") {

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -7,7 +7,14 @@ describe("IframeRuntime component", () => {
     const stubFunction = () => {
       // do nothing.
     };
-    const wrapper = shallow(<IframeRuntime url={"https://www.google.com/"} authoredState={null} interactiveState={null} setInteractiveState={stubFunction} setNewHint={stubFunction} />);
+    const wrapper = shallow(
+      <IframeRuntime
+        url={"https://www.google.com/"}
+        authoredState={null}
+        initialInteractiveState={null}
+        setInteractiveState={stubFunction}
+        setNewHint={stubFunction}
+      />);
     expect(wrapper.find('[data-cy="iframe-runtime"]').length).toBe(1);
   });
 });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -14,7 +14,7 @@ interface ILogRequest {
 interface IProps {
   url: string;
   authoredState: any;
-  interactiveState: any;
+  initialInteractiveState: any;
   setInteractiveState: (state: any) => void;
   report?: boolean;
   proposedHeight?: number;
@@ -23,7 +23,7 @@ interface IProps {
 }
 
 export const IframeRuntime: React.FC<IProps> =
-  ({ url, authoredState, interactiveState, setInteractiveState, report, proposedHeight, containerWidth, setNewHint }) => {
+  ({ url, authoredState, initialInteractiveState, setInteractiveState, report, proposedHeight, containerWidth, setNewHint }) => {
   const [ heightFromInteractive, setHeightFromInteractive ] = useState(0);
   const [ ARFromSupportedFeatures, setARFromSupportedFeatures ] = useState(0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -33,9 +33,9 @@ export const IframeRuntime: React.FC<IProps> =
   // it reloads the iframe each time it's called, it's not a great experience for user when that happens while he is
   // interacting with the iframe (e.g. typing in textarea). And interactiveState is being updated very often,
   // as well as setInteractiveState that is generated during each render of the parent component.
-  const interactiveStateRef = useRef<any>(interactiveState);
+  const interactiveStateRef = useRef<any>(initialInteractiveState);
   const setInteractiveStateRef = useRef<((state: any) => void)>(setInteractiveState);
-  interactiveStateRef.current = interactiveState;
+  interactiveStateRef.current = initialInteractiveState;
   setInteractiveStateRef.current = setInteractiveState;
 
   useEffect(() => {
@@ -78,7 +78,7 @@ export const IframeRuntime: React.FC<IProps> =
         phoneRef.current.disconnect();
       }
     };
-  }, [url, authoredState, report, setNewHint]);
+  }, [url, authoredState, report, initialInteractiveState, setNewHint]);
 
   const heightFromSupportedFeatures = ARFromSupportedFeatures && containerWidth ? containerWidth / ARFromSupportedFeatures : 0;
   // There are several options for specifying the iframe height. Check if we have height specified by interactive (from IframePhone

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -28,15 +28,6 @@ export const IframeRuntime: React.FC<IProps> =
   const [ ARFromSupportedFeatures, setARFromSupportedFeatures ] = useState(0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const phoneRef = useRef<IframePhone>();
-  // Why is interativeState and setInteractiveState kept in refs? So it's not necessary to declare these variables as
-  // useEffect's dependencies. Theoretically this useEffect callback is perfectly fine either way, but since
-  // it reloads the iframe each time it's called, it's not a great experience for user when that happens while he is
-  // interacting with the iframe (e.g. typing in textarea). And interactiveState is being updated very often,
-  // as well as setInteractiveState that is generated during each render of the parent component.
-  const interactiveStateRef = useRef<any>(initialInteractiveState);
-  const setInteractiveStateRef = useRef<((state: any) => void)>(setInteractiveState);
-  interactiveStateRef.current = initialInteractiveState;
-  setInteractiveStateRef.current = setInteractiveState;
 
   useEffect(() => {
     const initInteractive = () => {
@@ -45,7 +36,7 @@ export const IframeRuntime: React.FC<IProps> =
         return;
       }
       phone.addListener("interactiveState", (newInteractiveState: any) => {
-        setInteractiveStateRef.current?.(newInteractiveState);
+        setInteractiveState(newInteractiveState);
       });
       phone.addListener("height", (newHeight: number) => {
         setHeightFromInteractive(newHeight);
@@ -61,8 +52,7 @@ export const IframeRuntime: React.FC<IProps> =
       phone.post("initInteractive", {
         mode: report ? "report" : "runtime",
         authoredState,
-        // This is a trick not to depend on interactiveState.
-        interactiveState: interactiveStateRef.current
+        interactiveState: initialInteractiveState
       });
     };
 
@@ -78,7 +68,7 @@ export const IframeRuntime: React.FC<IProps> =
         phoneRef.current.disconnect();
       }
     };
-  }, [url, authoredState, report, initialInteractiveState, setNewHint]);
+  }, [url, authoredState, report, initialInteractiveState, setInteractiveState, setNewHint]);
 
   const heightFromSupportedFeatures = ARFromSupportedFeatures && containerWidth ? containerWidth / ARFromSupportedFeatures : 0;
   // There are several options for specifying the iframe height. Check if we have height specified by interactive (from IframePhone

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -28,6 +28,8 @@ export const IframeRuntime: React.FC<IProps> =
   const [ ARFromSupportedFeatures, setARFromSupportedFeatures ] = useState(0);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const phoneRef = useRef<IframePhone>();
+  const setInteractiveStateRef = useRef<((state: any) => void)>(setInteractiveState);
+  setInteractiveStateRef.current = setInteractiveState;
 
   useEffect(() => {
     const initInteractive = () => {
@@ -36,7 +38,7 @@ export const IframeRuntime: React.FC<IProps> =
         return;
       }
       phone.addListener("interactiveState", (newInteractiveState: any) => {
-        setInteractiveState(newInteractiveState);
+        setInteractiveStateRef.current(newInteractiveState);
       });
       phone.addListener("height", (newHeight: number) => {
         setHeightFromInteractive(newHeight);
@@ -68,7 +70,7 @@ export const IframeRuntime: React.FC<IProps> =
         phoneRef.current.disconnect();
       }
     };
-  }, [url, authoredState, report, initialInteractiveState, setInteractiveState, setNewHint]);
+  }, [url, authoredState, report, initialInteractiveState, setNewHint]);
 
   const heightFromSupportedFeatures = ARFromSupportedFeatures && containerWidth ? containerWidth / ARFromSupportedFeatures : 0;
   // There are several options for specifying the iframe height. Check if we have height specified by interactive (from IframePhone

--- a/src/components/activity-page/managed-interactive/managed-interactive.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.test.tsx
@@ -52,7 +52,7 @@ describe("IframeRuntime component", () => {
       type: "ManagedInteractive",
       ref_id: "314-ManagedInteractive"
     };
-    const wrapper = shallow(<ManagedInteractive embeddable={sampleEmbeddable} questionNumber={1} />);
+    const wrapper = shallow(<ManagedInteractive embeddable={sampleEmbeddable} initialInteractiveState={null} questionNumber={1} />);
     expect(wrapper.find('[data-cy="managed-interactive"]').length).toBe(1);
   });
 });

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -11,6 +11,7 @@ import "./managed-interactive.scss";
 interface IProps {
   embeddable: IManagedInteractive | IMwInteractive;
   questionNumber?: number;
+  initialInteractiveState: any;     // user state that existed in DB when embeddable was first loaded
 }
 
 const kDefaultAspectRatio = 4 / 3;
@@ -21,7 +22,7 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
       // TODO: handle interactive state
     };
 
-    const { embeddable, questionNumber } = props;
+    const { embeddable, questionNumber, initialInteractiveState } = props;
     const questionName = embeddable.name ? `: ${embeddable.name}` : "";
     // in older iframe interactive embeddables, we get url, native_width, native_height, etc. directly off
     // of the embeddable object. On newer managed/library interactives, this data is in library_interactive.data.
@@ -90,7 +91,7 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
         <IframeRuntime
           url={url}
           authoredState={embeddable.authored_state}
-          interactiveState={embeddable.interactiveState}
+          initialInteractiveState={initialInteractiveState}
           setInteractiveState={handleNewInteractiveState}
           proposedHeight={proposedHeight}
           containerWidth={containerWidth}

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useCallback } from "react";
 import { IframeRuntime } from "./iframe-runtime";
 import useResizeObserver from "@react-hook/resize-observer";
-import { IManagedInteractive, IMwInteractive, LibraryInteractiveData } from "../../../types";
+import { IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
+import { IManagedInteractive, IMwInteractive, LibraryInteractiveData, IExportableAnswerMetadata } from "../../../types";
+import { getAnswerWithMetadata } from "../../../utilities/embeddable-utils";
 import IconQuestion from "../../../assets/svg-icons/icon-question.svg";
 import IconArrowUp from "../../../assets/svg-icons/icon-arrow-up.svg";
 import { renderHTML } from "../../../utilities/render-html";
@@ -12,14 +14,15 @@ interface IProps {
   embeddable: IManagedInteractive | IMwInteractive;
   questionNumber?: number;
   initialInteractiveState: any;     // user state that existed in DB when embeddable was first loaded
+  initialAnswerMeta?: IExportableAnswerMetadata;   // saved metadata for that initial user state
 }
 
 const kDefaultAspectRatio = 4 / 3;
 
 export const ManagedInteractive: React.FC<IProps> = (props) => {
 
-    const handleNewInteractiveState = (state: any) => {
-      // TODO: handle interactive state
+    const handleNewInteractiveState = (state: IRuntimeMetadata) => {
+      const exportableAnswer = getAnswerWithMetadata(state, props.embeddable as IManagedInteractive, props.initialAnswerMeta);
     };
 
     const { embeddable, questionNumber, initialInteractiveState } = props;

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -3,6 +3,7 @@ import { IframeRuntime } from "./iframe-runtime";
 import useResizeObserver from "@react-hook/resize-observer";
 import { IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
 import { IManagedInteractive, IMwInteractive, LibraryInteractiveData, IExportableAnswerMetadata } from "../../../types";
+import { createOrUpdateAnswer } from "../../../firebase-db";
 import { getAnswerWithMetadata } from "../../../utilities/embeddable-utils";
 import IconQuestion from "../../../assets/svg-icons/icon-question.svg";
 import IconArrowUp from "../../../assets/svg-icons/icon-arrow-up.svg";
@@ -23,6 +24,9 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
 
     const handleNewInteractiveState = (state: IRuntimeMetadata) => {
       const exportableAnswer = getAnswerWithMetadata(state, props.embeddable as IManagedInteractive, props.initialAnswerMeta);
+      if (exportableAnswer) {
+        createOrUpdateAnswer(exportableAnswer);
+      }
     };
 
     const { embeddable, questionNumber, initialInteractiveState } = props;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -13,7 +13,7 @@ import { WarningBanner } from "./warning-banner";
 import { CompletionPageContent } from "./activity-completion/completion-page-content";
 import { queryValue } from "../utilities/url-query";
 import { fetchPortalData } from "../portal-api";
-import { signInWithToken, watchAnswers, initializeDB } from "../firebase-db";
+import { signInWithToken, watchAnswers, initializeDB, setPortalData } from "../firebase-db";
 import { Activity } from "../types";
 import { createPluginNamespace } from "../lara-plugin/index";
 import { loadPluginScripts } from "../utilities/plugin-utils";
@@ -51,7 +51,8 @@ export class App extends React.PureComponent<IProps, IState> {
         const portalData = await fetchPortalData();
         await initializeDB(portalData.database.appName);
         await signInWithToken(portalData.database.rawFirebaseJWT);
-        watchAnswers(portalData);
+        setPortalData(portalData);
+        watchAnswers();
       }
 
       // page 0 is introduction, inner pages start from 1 and match page.position in exported activity

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -47,6 +47,12 @@ export class App extends React.PureComponent<IProps, IState> {
       const activityPath = queryValue("activity") || kDefaultActivity;
       const activity: Activity = await getActivityDefinition(activityPath);
 
+      // page 0 is introduction, inner pages start from 1 and match page.position in exported activity
+      const currentPage = Number(queryValue("page")) || 0;
+
+      const showThemeButtons = queryValue("themeButtons")?.toLowerCase() === "true";
+      const teacherEditionMode = queryValue("mode")?.toLowerCase( )=== "teacher-edition";
+
       if (queryValue("token")) {
         const portalData = await fetchPortalData();
         await initializeDB(portalData.database.appName);
@@ -54,13 +60,6 @@ export class App extends React.PureComponent<IProps, IState> {
         setPortalData(portalData);
         watchAnswers();
       }
-
-      // page 0 is introduction, inner pages start from 1 and match page.position in exported activity
-      const currentPage = Number(queryValue("page")) || 0;
-
-      const showThemeButtons = queryValue("themeButtons")?.toLowerCase() === "true";
-      const teacherEditionMode = queryValue("mode")?.toLowerCase( )=== "teacher-edition";
-
       this.setState({activity, currentPage, showThemeButtons, teacherEditionMode});
 
       if (teacherEditionMode) {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -51,7 +51,7 @@ export class App extends React.PureComponent<IProps, IState> {
         const portalData = await fetchPortalData();
         await initializeDB(portalData.database.appName);
         await signInWithToken(portalData.database.rawFirebaseJWT);
-        watchAnswers(portalData, this.handleAnswersUpdated);
+        watchAnswers(portalData);
       }
 
       // page 0 is introduction, inner pages start from 1 and match page.position in exported activity
@@ -173,43 +173,4 @@ export class App extends React.PureComponent<IProps, IState> {
   private handleChangePage = (page: number) => {
     this.setState({currentPage: page});
   }
-
-  // updates `state.activity` to add `interactiveState` to embeddables
-  private handleAnswersUpdated = (answers: firebase.firestore.DocumentData[]) => {
-    // this is annoying and possibly a bug? Embeddables are coming through with `refId`'s such
-    // as "404-ManagedInteractive", while answers are coming through with `question_id`'s such
-    // as "managed_interactive_404"
-    const questionIdToRefId = (questionId: string) => {
-      const snakeCaseRegEx = /(\D*)_(\d*)/gm;
-      const parsed = snakeCaseRegEx.exec(questionId);
-      if (parsed && parsed.length) {
-        const [ , embeddableType, embeddableId] = parsed;
-        const camelCased = embeddableType.split("_").map(str => str.charAt(0).toUpperCase() + str.slice(1)).join("");
-        return `${embeddableId}-${camelCased}`;
-      }
-      return questionId;
-    };
-
-    const getInteractiveState = (answer: firebase.firestore.DocumentData) => {
-      const reportState = JSON.parse(answer.report_state);
-      return JSON.parse(reportState.interactiveState);
-    };
-
-    // restructure answers to key off question_id
-    const questionAnswers: {[id: string]: firebase.firestore.DocumentData} = {};
-    answers.forEach(answer => questionAnswers[questionIdToRefId(answer.question_id)] = getInteractiveState(answer));
-
-    const newActivityState = JSON.parse(JSON.stringify(this.state.activity)) as Activity;   // clone
-    newActivityState.pages.forEach((page) => {
-      page.embeddables.forEach((embeddableWrapper) => {
-        const refId = embeddableWrapper.embeddable.ref_id;
-        if (questionAnswers[refId]) {
-          embeddableWrapper.embeddable.interactiveState = questionAnswers[refId];
-        }
-      });
-    });
-
-    this.setState({activity: newActivityState});
-  }
-
 }

--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -35,7 +35,7 @@ describe("Firestore", () => {
       platformUserId: "1",
       resourceLinkId: "2",
       resourceUrl: "http://example/resource",
-      toolId: "https://example",
+      toolId: "activity-player.concord.org",
       userType: "learner"
     });
 
@@ -71,7 +71,7 @@ describe("Firestore", () => {
       run_key: "",
       source_key: "localhost",
       submitted: null,
-      tool_id: "https://example",
+      tool_id: "activity-player.concord.org",
       type: "open_response_answer",
     }, {merge: true});
   });

--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -1,0 +1,80 @@
+import { IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
+import { setPortalData, createOrUpdateAnswer } from "./firebase-db";
+import { DefaultManagedInteractive } from "./test-utils/model-for-tests";
+import { getAnswerWithMetadata } from "./utilities/embeddable-utils";
+import { IExportableAnswerMetadata } from "./types";
+import firebase from "firebase";
+import { mockFirestore } from "./test-utils/firestore-mock";
+
+(firebase as any).firestore = mockFirestore;
+
+describe("Firestore", () => {
+
+
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    firebase.firestore();
+  });
+
+  it("creates answers with the correct metadata", () => {
+    setPortalData({
+      contextId: "context-id",
+      database: {
+        appName: "report-service-dev",
+        sourceKey: "localhost",
+        rawFirebaseJWT: "abc"
+      },
+      offering: {
+        id: 1,
+        activityUrl: "http://example/activities/1",
+        rubricUrl: ""
+      },
+      platformId: "https://example",
+      platformUserId: "1",
+      resourceLinkId: "2",
+      resourceUrl: "http://example/resource",
+      toolId: "https://example",
+      toolUserId: "https://example/users/1",
+      userType: "learner"
+    });
+
+    const embeddable = {
+      ...DefaultManagedInteractive,
+      authored_state: `{"version":1,"questionType":"open_response","prompt":"<p>Write something:</p>"}`,
+      ref_id: "123-ManagedInteractive"
+    };
+
+    const interactiveState: IRuntimeMetadata = {
+      answerType: "open_response_answer",
+      answerText: "test"
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableAnswerMetadata;
+
+    createOrUpdateAnswer(exportableAnswer);
+
+    expect(mockFirestore().doc).toHaveBeenCalledWith(`sources/localhost/answers/${exportableAnswer.id}`);
+    expect(mockFirestore().doc().set).toHaveBeenCalledWith({
+      answer: "test",
+      answer_text: "test",
+      context_id: "context-id",
+      id: exportableAnswer.id,
+      platform_id: "https://example",
+      platform_user_id: "1",
+      question_id: "managed_interactive_123",
+      question_type: "open_response",
+      remote_endpoint: "",
+      report_state: "{\"mode\":\"report\",\"authoredState\":\"{\\\"version\\\":1,\\\"questionType\\\":\\\"open_response\\\",\\\"prompt\\\":\\\"<p>Write something:</p>\\\"}\",\"interactiveState\":\"{\\\"answerType\\\":\\\"open_response_answer\\\",\\\"answerText\\\":\\\"test\\\"}\",\"version\":1}",
+      resource_link_id: "2",
+      resource_url: "http://example/resource",
+      run_key: "",
+      source_key: "localhost",
+      submitted: null,
+      tool_id: "https://example",
+      tool_user_id: "https://example/users/1",
+      type: "open_response_answer",
+    }, {merge: true});
+  });
+});

--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -36,7 +36,6 @@ describe("Firestore", () => {
       resourceLinkId: "2",
       resourceUrl: "http://example/resource",
       toolId: "https://example",
-      toolUserId: "https://example/users/1",
       userType: "learner"
     });
 
@@ -73,7 +72,6 @@ describe("Firestore", () => {
       source_key: "localhost",
       submitted: null,
       tool_id: "https://example",
-      tool_user_id: "https://example/users/1",
       type: "open_response_answer",
     }, {merge: true});
   });

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -185,7 +185,6 @@ export function createOrUpdateAnswer(answer: IExportableAnswerMetadata) {
     tool_id: portalData.toolId,
     resource_url: portalData.resourceUrl,
     run_key: "",
-    tool_user_id: portalData.toolUserId,
   };
 
   return firebase.firestore()

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -14,6 +14,8 @@ import { IPortalData } from "./portal-api";
 export type FirebaseAppName = "report-service-dev" | "report-service-pro";
 export const DEFAULT_FIREBASE_APP: FirebaseAppName = "report-service-pro";
 
+let portalData: IPortalData;
+
 // The LocalDB stores the data fetched from the DB by the `watchX` methods. The data gets added to keys
 // such as `${refId}/interactiveState`, which can that be listened to by listeners. By keeping this
 // local copy, we can provide listeners with data even if the listener is added after the data is fetched.
@@ -74,9 +76,17 @@ export const signInWithToken = async (rawFirestoreJWT: string) => {
   return firebase.auth().signInWithCustomToken(rawFirestoreJWT);
 };
 
+export const setPortalData = (_portalData: IPortalData) => {
+  portalData = _portalData;
+};
+
 type DocumentsListener = (docs: firebase.firestore.DocumentData[]) => void;
 
-const watchCollection = (path: string, portalData: IPortalData, listener: DocumentsListener) => {
+const watchCollection = (path: string, listener: DocumentsListener) => {
+  if (!portalData) {
+    throw new Error("Must set portal data first");
+  }
+
   let query = firebase.firestore().collection(path)
     .where("platform_id", "==", portalData.platformId)
     .where("resource_link_id", "==", portalData.resourceLinkId);

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -201,7 +201,7 @@ export const watchAnswers = () => {
 
 export function createOrUpdateAnswer(answer: IExportableAnswerMetadata) {
   if (!portalData) {
-    throw new Error("Must set portal data first");
+    return;
   }
 
   const postAnswer: LTIRuntimeAnswerMetadata = {

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -11,14 +11,18 @@ import * as firebase from "firebase";
 import "firebase/firestore";
 import { IPortalData } from "./portal-api";
 import { answersQuestionIdToRefId } from "./utilities/embeddable-utils";
+import { IExportableAnswerMetadata, LTIRuntimeAnswerMetadata } from "./types";
 
 export type FirebaseAppName = "report-service-dev" | "report-service-pro";
 export const DEFAULT_FIREBASE_APP: FirebaseAppName = "report-service-pro";
 
 let portalData: IPortalData;
 
+const answersPath = (answerId?: string) =>
+  `sources/${portalData?.database.sourceKey}/answers${answerId ? "/" + answerId : ""}`;
+
 // The LocalDB stores the data fetched from the DB by the `watchX` methods. The data gets added to keys
-// such as `${refId}/interactiveState`, which can that be listened to by listeners. By keeping this
+// such as `${refId}/answers`, which can that be listened to by listeners. By keeping this
 // local copy, we can provide listeners with data even if the listener is added after the data is fetched.
 interface LocalDB {
   [path: string]: any;
@@ -26,7 +30,7 @@ interface LocalDB {
 
 const localDB: LocalDB = {};
 
-export const interactiveStatePath = (refId: string) => `${refId}/interactiveState`;
+export const localAnswerPath = (refId: string) => `${refId}/answers`;
 
 export type DBChangeListener = (value: any) => void;
 
@@ -90,13 +94,10 @@ const watchCollection = (path: string, listener: DocumentsListener) => {
 
   let query = firebase.firestore().collection(path)
     .where("platform_id", "==", portalData.platformId)
-    .where("resource_link_id", "==", portalData.resourceLinkId);
+    .where("resource_link_id", "==", portalData.resourceLinkId)
+    .where("context_id", "==", portalData.contextId);
   if (portalData.userType === "learner") {
     query = query.where("platform_user_id", "==", portalData.platformUserId.toString());
-  } else {
-    // "context_id" is theoretically redundant here, since we already filter by resource_link_id,
-    // but that lets us use context_id value in the Firestore security rules.
-    query = query.where("context_id", "==", portalData.contextId);
   }
 
   query.onSnapshot((snapshot: firebase.firestore.QuerySnapshot<firebase.firestore.DocumentData>) => {
@@ -156,12 +157,38 @@ const handleAnswersUpdated = (answers: firebase.firestore.DocumentData[]) => {
   answers.forEach(answer => {
     const refId = answersQuestionIdToRefId(answer.question_id);
     const interactiveState = getInteractiveState(answer);
-    notifyListeners(interactiveStatePath(refId), interactiveState);
-    localDB[interactiveStatePath(refId)] = interactiveState;
+    const wrappedAnswer = {
+      meta: answer,
+      interactiveState
+    };
+    notifyListeners(localAnswerPath(refId), wrappedAnswer);
+    localDB[localAnswerPath(refId)] = wrappedAnswer;
   });
 };
 
 export const watchAnswers = () => {
-  const answersPath = `sources/${portalData.database.sourceKey}/answers`;
-  watchCollection(answersPath, handleAnswersUpdated);
+  watchCollection(answersPath(), handleAnswersUpdated);
 };
+
+export function createOrUpdateAnswer(answer: IExportableAnswerMetadata) {
+  if (!portalData) {
+    throw new Error("Must set portal data first");
+  }
+
+  const postAnswer: LTIRuntimeAnswerMetadata = {
+    ...answer,
+    platform_id: portalData.platformId,
+    platform_user_id: portalData.platformUserId.toString(),
+    context_id: portalData.contextId,
+    resource_link_id: portalData.resourceLinkId,
+    source_key: portalData.database.sourceKey,
+    tool_id: portalData.toolId,
+    resource_url: portalData.resourceUrl,
+    run_key: "",
+    tool_user_id: portalData.toolUserId,
+  };
+
+  return firebase.firestore()
+      .doc(answersPath(answer.id))
+      .set(postAnswer, {merge: true});
+}

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -78,10 +78,13 @@ interface FirebaseData {
   rawFirebaseJWT: string;
 }
 
-export interface IPortalData extends ILTIPartial{
+export interface IPortalData extends ILTIPartial {
   offering: OfferingData;
   userType: "teacher" | "learner";
   database: FirebaseData;
+  toolId: string;
+  resourceUrl: string;
+  toolUserId: string;
 }
 
 interface BasePortalJWT {
@@ -322,6 +325,7 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
   if (portalJWT.user_type !== "learner") {
     throw new Error("Only student logins are currently supported");
   }
+
   const portal = parseUrl(basePortalUrl).host;
 
   const classInfoUrl = portalJWT.class_info_url;
@@ -349,6 +353,9 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
     platformId: firebaseJWT.claims.platform_id,
     platformUserId: firebaseJWT.claims.platform_user_id.toString(),
     contextId: classInfo.classHash,
+    toolId: "https://" + sourceKey,
+    resourceUrl: offeringData.activityUrl,
+    toolUserId: firebaseJWT.claims.user_id,
     database: {
       appName: firebaseAppName,
       sourceKey,

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -352,7 +352,7 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
     platformId: firebaseJWT.claims.platform_id,
     platformUserId: firebaseJWT.claims.platform_user_id.toString(),
     contextId: classInfo.classHash,
-    toolId: "https://" + sourceKey,
+    toolId: window.location.hostname,
     resourceUrl: offeringData.activityUrl,
     database: {
       appName: firebaseAppName,

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -84,7 +84,6 @@ export interface IPortalData extends ILTIPartial {
   database: FirebaseData;
   toolId: string;
   resourceUrl: string;
-  toolUserId: string;
 }
 
 interface BasePortalJWT {
@@ -355,7 +354,6 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
     contextId: classInfo.classHash,
     toolId: "https://" + sourceKey,
     resourceUrl: offeringData.activityUrl,
-    toolUserId: firebaseJWT.claims.user_id,
     database: {
       appName: firebaseAppName,
       sourceKey,

--- a/src/test-utils/firestore-mock.ts
+++ b/src/test-utils/firestore-mock.ts
@@ -1,0 +1,23 @@
+const docData = { data: "MOCK_DATA" };
+const docResult = {
+  // simulate firestore get doc.data() function
+  data: () => docData
+};
+const get = jest.fn(() => Promise.resolve(docResult));
+const set = jest.fn();
+const doc = jest.fn(() => {
+  return {
+    set,
+    get
+  };
+});
+const mockFirestore = () => {
+  return { doc };
+};
+mockFirestore.FieldValue = {
+  serverTimestamp: () => {
+    return "MOCK_TIME";
+  }
+};
+
+export { mockFirestore };

--- a/src/test-utils/model-for-tests.ts
+++ b/src/test-utils/model-for-tests.ts
@@ -1,4 +1,4 @@
-import { Embeddable, EmbeddableWrapper, Page, Activity } from "../types";
+import { Embeddable, EmbeddableWrapper, Page, Activity, LibraryInteractive, IManagedInteractive } from "../types";
 
 export const DefaultTestEmbeddable: Embeddable = {
   type: "MwInteractive",
@@ -43,4 +43,30 @@ export const DefaultTestActivity: Activity = {
   plugins: [],
   type: "LightweightActivity",
   pages: [],
+};
+
+export const DefaultLibraryInteractive: LibraryInteractive = {
+  hash: "",
+  data: {
+    base_url: "",
+    click_to_play: false,
+    enable_learner_state: true,
+    full_window: false,
+    has_report_url: false,
+    native_height: 1,
+    native_width: 1,
+    no_snapshots: false,
+    show_delete_data_button: false,
+    customizable: false,
+    authorable: false
+  }
+};
+
+export const DefaultManagedInteractive: IManagedInteractive = {
+  library_interactive: DefaultLibraryInteractive,
+  type: "ManagedInteractive",
+  ref_id: "",
+  name: "",
+  is_hidden: false,
+  is_full_width: false
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,3 +139,64 @@ export interface Activity {
   export_site?: string | null;
   pages: Page[];
 }
+
+export interface IReportState {
+  version?: number;
+  mode: "report";
+  authoredState: string;
+  interactiveState: string;
+}
+
+export interface ILTIPartial {
+  platform_id: string;      // portal
+  platform_user_id: string;
+  context_id: string;       // class hash
+  resource_link_id: string;  // offering ID
+  resource_url: string;
+  run_key: string;
+  source_key: string;
+  tool_id: string;
+  tool_user_id: string;
+}
+
+/**
+ * cf. IRunTimeMetadataBase, from
+ * https://github.com/concord-consortium/lara/blob/master/lara-typescript/src/interactive-api-client/metadata-types.ts#L47
+ * and partial export code at
+ * https://github.com/concord-consortium/lara/blob/c40304a14ef495acdf4f9fd09ea892c7cc98247b/app/models/interactive_run_state.rb#L110
+ */
+export interface IExportalbleAnswerMetadataBase {
+  remote_endpoint: string;
+  question_id: string;
+  question_type: string;
+  id: string;
+  type: string;
+  answer_text?: string;
+  answer?: any;
+  submitted: boolean | null;
+  report_state: string;
+}
+
+export interface IExportableInteractiveAnswerMetadata extends IExportalbleAnswerMetadataBase {
+  type: "interactive_state";
+  answer: string;
+}
+
+export interface IExportableOpenResponseAnswerMetadata extends IExportalbleAnswerMetadataBase {
+  type: "open_response_answer";
+  answer: string;
+}
+
+export interface IExportableMultipleChoiceAnswerMetadata extends IExportalbleAnswerMetadataBase {
+  type: "multiple_choice_answer";
+  answer: {
+    choice_ids: string[];
+  }
+}
+
+export type IExportableAnswerMetadata =
+  IExportableInteractiveAnswerMetadata |
+  IExportableOpenResponseAnswerMetadata |
+  IExportableMultipleChoiceAnswerMetadata;
+
+export interface LTIRuntimeAnswerMetadata extends ILTIPartial, IExportalbleAnswerMetadataBase { }

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,10 @@ export interface IReportState {
   interactiveState: string;
 }
 
+/**
+ * To match LARA we would normally also include a tool_user_id, but the activity player
+ * keeps no user ids of its own.
+ */
 export interface ILTIPartial {
   platform_id: string;      // portal
   platform_user_id: string;
@@ -156,7 +160,6 @@ export interface ILTIPartial {
   run_key: string;
   source_key: string;
   tool_id: string;
-  tool_user_id: string;
 }
 
 /**

--- a/src/utilities/embeddable-utils.test.ts
+++ b/src/utilities/embeddable-utils.test.ts
@@ -1,0 +1,136 @@
+import { IRuntimeMetadata, IRuntimeInteractiveMetadata, IRuntimeMultipleChoiceMetadata } from "@concord-consortium/lara-interactive-api";
+import { answersQuestionIdToRefId, refIdToAnswersQuestionId, getAnswerWithMetadata } from "./embeddable-utils";
+import { DefaultManagedInteractive } from "../test-utils/model-for-tests";
+import { IManagedInteractive, IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata, IExportableAnswerMetadata } from "../types";
+
+
+describe("Embeddable utility functions", () => {
+  it("correctly converts from answer's question-id to ref_id", () => {
+    expect(answersQuestionIdToRefId("managed_interactive_123")).toBe("123-ManagedInteractive");
+    expect(answersQuestionIdToRefId("mw_interactive_123")).toBe("123-MwInteractive");
+    expect(answersQuestionIdToRefId("123-NotSnakeCase")).toBe("123-NotSnakeCase");
+  });
+
+  it("correctly converts from ref_id to answer's question-id", () => {
+    expect(refIdToAnswersQuestionId("123-ManagedInteractive")).toBe("managed_interactive_123");
+    expect(refIdToAnswersQuestionId("123-MwInteractive")).toBe("mw_interactive_123");
+    expect(refIdToAnswersQuestionId("not_camel_Case_123")).toBe("not_camel_Case_123");
+  });
+
+  it("can create an exportable answer for an open response embeddable", () => {
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: `{"version":1,"questionType":"open_response","prompt":"<p>Write something:</p>"}`,
+      ref_id: "123-ManagedInteractive"
+    };
+
+    const interactiveState: IRuntimeMetadata = {
+      answerType: "open_response_answer",
+      answerText: "test"
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableOpenResponseAnswerMetadata;
+
+    expect(exportableAnswer).toBeDefined();
+
+    expect(exportableAnswer.remote_endpoint).toBe("");
+    expect(exportableAnswer.question_id).toBe("managed_interactive_123");
+    expect(exportableAnswer.question_type).toBe("open_response");
+    expect(exportableAnswer.id).toBeDefined();          // random uuid
+    expect(exportableAnswer.type).toBe("open_response_answer");
+    expect(exportableAnswer.answer_text).toBe("test");
+    expect(exportableAnswer.answer).toBe("test");
+    expect(exportableAnswer.submitted).toBeNull();
+    const expectedReport = JSON.stringify({
+      mode: "report",
+      authoredState: `{"version":1,"questionType":"open_response","prompt":"<p>Write something:</p>"}`,
+      interactiveState: `{"answerType":"open_response_answer","answerText":"test"}`,
+      version: 1
+    });
+    expect(exportableAnswer.report_state).toBe(expectedReport);
+  });
+
+  it("can create an exportable answer for a generic interactive embeddable", () => {
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: `{"version":1,"questionType":"my_question_type"}`
+    };
+
+    interface IInteractiveState extends IRuntimeInteractiveMetadata {
+      myState: string;
+    }
+    const interactiveState: IInteractiveState = {
+      answerType: "interactive_state",
+      myState: "<state />"
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableInteractiveAnswerMetadata;
+
+    expect(exportableAnswer.question_type).toBe("my_question_type");
+    expect(exportableAnswer.type).toBe("interactive_state");
+    expect(exportableAnswer.answer_text).toBeUndefined();
+    const expectedReport = JSON.stringify({
+      mode: "report",
+      authoredState: `{"version":1,"questionType":"my_question_type"}`,
+      interactiveState: `{"answerType":"interactive_state","myState":"<state />"}`,
+      version: 1
+    });
+    expect(exportableAnswer.report_state).toBe(expectedReport);
+    expect(exportableAnswer.answer).toBe(expectedReport);
+  });
+
+  it("can create an exportable answer for a submittable multiple choice embeddable", () => {
+    const authoredState = `{"version":1,"questionType":"multiple_choice","choices":[{"id":"1","content":"A","correct":false},{"id":"2","content":"B","correct":false}],"prompt":""}`;
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: authoredState
+    };
+
+    const interactiveState: IRuntimeMultipleChoiceMetadata = {
+      answerType: "multiple_choice_answer",
+      selectedChoiceIds: ["1"]
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableInteractiveAnswerMetadata;
+
+    expect(exportableAnswer.question_type).toBe("multiple_choice");
+    expect(exportableAnswer.type).toBe("multiple_choice_answer");
+    expect(exportableAnswer.answer_text).toBeUndefined();
+    const expectedReport = JSON.stringify({
+      mode: "report",
+      authoredState: authoredState,
+      interactiveState: `{"answerType":"multiple_choice_answer","selectedChoiceIds":["1"]}`,
+      version: 1
+    });
+    expect(exportableAnswer.report_state).toBe(expectedReport);
+    expect(exportableAnswer.answer).toStrictEqual({"choice_ids": ["1"]});
+  });
+
+  it("can create an exportable answer, keeping the id of an existing answer meta", () => {
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: `{"version":1,"questionType":"open_response","prompt":"<p>Write something:</p>"}`,
+      ref_id: "123-ManagedInteractive"
+    };
+
+    const interactiveState: IRuntimeMetadata = {
+      answerType: "open_response_answer",
+      answerText: "test"
+    };
+
+    const originalAnswer: IExportableAnswerMetadata = {
+      type: "open_response_answer",
+      remote_endpoint: "",
+      question_id: "managed_interactive_123",
+      question_type: "open_response",
+      id: "open_response_answer_123",
+      submitted: null,
+      report_state: "",
+      answer: ""
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable, originalAnswer) as IExportableOpenResponseAnswerMetadata;
+
+    expect(exportableAnswer.id).toBe("open_response_answer_123");
+  });
+});

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -47,6 +47,7 @@ export const getAnswerWithMetadata = (
       answer: interactiveState.answerText
     } as IExportableOpenResponseAnswerMetadata;
   } else {
+    // note we don't current support has_report_url
     exportableAnswer = {
       ...exportableAnswerBase,
       answer: reportStateJSON
@@ -57,10 +58,12 @@ export const getAnswerWithMetadata = (
 };
 
 /**
- * this is annoying and possibly a bug? Embeddables are coming through with `refId`'s such
- * as "404-ManagedInteractive", while answers are coming through with `question_id`'s such
- * as "managed_interactive_404". This transforms the answer's version to the embeddable's version.
+ * Embeddables are coming through with `refId`'s such as "404-ManagedInteractive", while answers
+ * are coming through with `question_id`'s such as "managed_interactive_404".
  *
+ * See https://www.pivotaltracker.com/n/projects/736901/stories/174065787
+ *
+ * This transforms the answer's version to the embeddable's version.
  * "managed_interactive_404" => "404-ManagedInteractive"
  */
 export const answersQuestionIdToRefId = (questionId: string) => {

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -1,0 +1,89 @@
+import { v4 as uuidv4 } from "uuid";
+import { IAuthoringMetadata, IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
+import { IExportableAnswerMetadata, IManagedInteractive, IReportState, IExportableMultipleChoiceAnswerMetadata, IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata } from "../types";
+
+export const getAnswerWithMetadata = (
+    interactiveState: IRuntimeMetadata,
+    embeddable: IManagedInteractive,
+    oldAnswerMeta?: IExportableAnswerMetadata): (IExportableAnswerMetadata | void) => {
+
+  if (!embeddable.authored_state) return;
+
+  const authoredState = JSON.parse(embeddable.authored_state) as IAuthoringMetadata;
+  const reportState: IReportState = {
+    mode: "report",
+    authoredState: embeddable.authored_state,
+    interactiveState: JSON.stringify(interactiveState)
+  };
+  if ((authoredState as any).version) {
+    reportState.version = (authoredState as any).version;
+  }
+
+  const reportStateJSON = JSON.stringify(reportState);
+
+  const exportableAnswerBase = {
+    remote_endpoint: "",
+    question_id: refIdToAnswersQuestionId(embeddable.ref_id),
+    question_type: authoredState.questionType,
+    id: oldAnswerMeta ? oldAnswerMeta.id : uuidv4(),
+    type: interactiveState.answerType,
+    answer_text: interactiveState.answerText,
+    submitted: typeof interactiveState.submitted === "boolean" ? interactiveState.submitted : null,
+    report_state: reportStateJSON
+  };
+
+  // from https://github.com/concord-consortium/lara/blob/c40304a14ef495acdf4f9fd09ea892c7cc98247b/app/models/interactive_run_state.rb#L139
+  let exportableAnswer;
+  if (interactiveState.answerType === "multiple_choice_answer") {
+    exportableAnswer = {
+      ...exportableAnswerBase,
+      answer: {
+        choice_ids: interactiveState.selectedChoiceIds
+      }
+    } as IExportableMultipleChoiceAnswerMetadata;
+  } else if (interactiveState.answerType === "open_response_answer") {
+    exportableAnswer = {
+      ...exportableAnswerBase,
+      answer: interactiveState.answerText
+    } as IExportableOpenResponseAnswerMetadata;
+  } else {
+    exportableAnswer = {
+      ...exportableAnswerBase,
+      answer: reportStateJSON
+    } as IExportableInteractiveAnswerMetadata;
+  }
+
+  return exportableAnswer;
+};
+
+/**
+ * this is annoying and possibly a bug? Embeddables are coming through with `refId`'s such
+ * as "404-ManagedInteractive", while answers are coming through with `question_id`'s such
+ * as "managed_interactive_404". This transforms the answer's version to the embeddable's version.
+ *
+ * "managed_interactive_404" => "404-ManagedInteractive"
+ */
+export const answersQuestionIdToRefId = (questionId: string) => {
+  const snakeCaseRegEx = /(\D*)_(\d*)/g;
+  const parsed = snakeCaseRegEx.exec(questionId);
+  if (parsed && parsed.length) {
+    const [ , embeddableType, embeddableId] = parsed;
+    const camelCased = embeddableType.split("_").map(str => str.charAt(0).toUpperCase() + str.slice(1)).join("");
+    return `${embeddableId}-${camelCased}`;
+  }
+  return questionId;
+};
+
+/**
+ * "404-ManagedInteractive" => "managed_interactive_404"
+ */
+export const refIdToAnswersQuestionId = (refId: string) => {
+  const refIdRegEx = /(\d*)-(\D*)/g;
+  const parsed = refIdRegEx.exec(refId);
+  if (parsed && parsed.length) {
+    const [ , embeddableId, embeddableType] = parsed;
+    const snakeCased = embeddableType.replace(/(?!^)([A-Z])/g, "_$1").toLowerCase();
+    return `${snakeCased}_${embeddableId}`;
+  }
+  return refId;
+};


### PR DESCRIPTION
This adds the ability to save back interactive state, either from interactives with existing state or creating new state.

This can be tested by assigning the activity Activity Player Saving to a class and running it.

As part of this work, the [report-service-dev rules](https://console.firebase.google.com/project/report-service-dev/database/firestore/rules) were updated to allow learners to create and update answers. We will need to copy these rules over to report-service-pro if we bring this in.

I have a few questions about some of the metadata that gets sent up, these may need to be addressed before this is brought in. @scytacki perhaps you could take a look.

```
Answers saved to the Firestore database:

{
      ...
      // if we don't have an old id, I create a uuid. Old answers have ids like "open_response_answer_1234". I
      //  can't tell if there's any reason to have a readable id
      id: "...",

      // these are coming from the jwt
      platform_id: "https://learn.staging.concord.org",
      platform_user_id: "67",

      // db source. If we need old data this is set in a url parameter, otherwise we use our own url
      source_key: "activity-player.concord.org" | "authoring.staging.concord.org"

      // unsure where this is coming from. I added "https://" to the source-key, since old answers
      // show "https://authoring.staging.concord.org". Possibly this should be the current url regardless of
      // the source, however.
      tool_id: "https://" + sourceKey,

      // In the JWT claims there is a `platform_user_id`, used above, and a `user_id`, which I use below. This
      // is a url to the user in the portal.
      // However, in old answers this looks like "2399" instead of this url, which is presumably the user number
      // in LARA itself. I don't see this value for this user in any of the information received from the portal
      tool_user_id: "https://learn.staging.concord.org/users/67",

      // this used to be a nice clean url like "https://authoring.staging.concord.org/activities/20648", but is
      // now a great big activity url with parameters 
      resource_url: "https://activity-player.concord.org/branch/save-interactive-state/?activity=https%3A%2F%2Fauthoring.staging.concord .....",

      // unsure where this comes from, or if it is needed before we get to anonymous users
      run_key: "",
}
```