### PR TITLE
174068640 te wrapper

### DIFF
--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -20,6 +20,7 @@ interface IProps {
   onPageChange: (page: number) => void;
   page: Page;
   pageNumber: number;
+  teacherEditionMode?: boolean;
   totalPreviousQuestions: number;
 }
 
@@ -150,6 +151,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
                 pageLayout={this.props.page.layout}
                 questionNumber={isQuestion(embeddableWrapper) ? questionNumber : undefined}
                 linkedPluginEmbeddable={linkedPluginEmbeddable}
+                teacherEditionMode={this.props.teacherEditionMode}
               />
             );
           })

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import { Embeddable } from "./embeddable";
 import { BottomButtons } from "./bottom-buttons";
 import { PageLayouts, EmbeddableSections, isQuestion, getPageSectionQuestionCount,
-         VisibleEmbeddables, getVisibleEmbeddablesOnPage } from "../../utilities/activity-utils";
+         VisibleEmbeddables, getVisibleEmbeddablesOnPage, getLinkedPluginEmbeddable } from "../../utilities/activity-utils";
 import { SidebarWrapper } from "../page-sidebar/sidebar-wrapper";
 import { renderHTML } from "../../utilities/render-html";
 import IconChevronRight from "../../assets/svg-icons/icon-chevron-right.svg";
 import IconChevronLeft from "../../assets/svg-icons/icon-chevron-left.svg";
+import { Page, EmbeddableWrapper } from "../../types";
 
 import "./activity-page-content.scss";
-import { Page, EmbeddableWrapper } from "../../types";
 
 const kPinMargin = 20;
 
@@ -141,6 +141,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
             if (isQuestion(embeddableWrapper)) {
               questionNumber++;
             }
+            const linkedPluginEmbeddable = getLinkedPluginEmbeddable(this.props.page, embeddableWrapper.embeddable.ref_id);
             return (
               <Embeddable
                 key={`embeddable ${i}`}
@@ -148,6 +149,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
                 isPageIntroduction={i === 0 && section === EmbeddableSections.Introduction}
                 pageLayout={this.props.page.layout}
                 questionNumber={isQuestion(embeddableWrapper) ? questionNumber : undefined}
+                linkedPluginEmbeddable={linkedPluginEmbeddable}
               />
             );
           })

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -1,22 +1,24 @@
-import React from "react";
+import React, { useRef, useEffect }  from "react";
 import { TextBox } from "./text-box/text-box";
 import { ManagedInteractive } from "./managed-interactive/managed-interactive";
 import { ActivityLayouts, PageLayouts } from "../../utilities/activity-utils";
 import { EmbeddablePlugin } from "./plugins/embeddable-plugin";
+import { initializePlugin } from "../../utilities/plugin-utils";
+import { EmbeddableWrapper, IEmbeddablePlugin } from "../../types";
 
 import "./embeddable.scss";
-import { EmbeddableWrapper } from "../../types";
 
 interface IProps {
   activityLayout?: number;
   embeddableWrapper: EmbeddableWrapper;
   isPageIntroduction: boolean;
+  linkedPluginEmbeddable?: IEmbeddablePlugin;
   pageLayout: string;
   questionNumber?: number;
 }
 
 export const Embeddable: React.FC<IProps> = (props) => {
-  const { activityLayout, embeddableWrapper, isPageIntroduction, pageLayout, questionNumber } = props;
+  const { activityLayout, embeddableWrapper, isPageIntroduction, linkedPluginEmbeddable, pageLayout, questionNumber } = props;
   const embeddable = embeddableWrapper.embeddable;
 
   let qComponent;
@@ -30,9 +32,24 @@ export const Embeddable: React.FC<IProps> = (props) => {
 
   const staticWidth = pageLayout === PageLayouts.FortySixty || pageLayout === PageLayouts.SixtyForty || pageLayout === PageLayouts.Responsive;
   const singlePageLayout = activityLayout === ActivityLayouts.SinglePage;
+
+  const embeddableWrapperDivTarget = useRef<HTMLInputElement>(null);
+  const embeddableDivTarget = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (embeddableWrapperDivTarget.current && embeddableDivTarget.current && linkedPluginEmbeddable) {
+      initializePlugin(linkedPluginEmbeddable, embeddable, embeddableWrapperDivTarget.current, embeddableDivTarget.current);
+    }
+  }, [linkedPluginEmbeddable, embeddable]);
+
   return (
-    <div className={`embeddable ${embeddableWrapper.embeddable.is_full_width || staticWidth || singlePageLayout ? "full-width" : "reduced-width"}`} data-cy="embeddable">
-      { qComponent || <div>Content type not supported</div> }
+    <div
+      className={`embeddable ${embeddableWrapper.embeddable.is_full_width || staticWidth || singlePageLayout ? "full-width" : "reduced-width"}`}
+      data-cy="embeddable"
+    >
+      { linkedPluginEmbeddable && <div ref={embeddableWrapperDivTarget}></div> }
+      <div ref={embeddableDivTarget}>
+        { qComponent || <div>Content type not supported</div> }
+      </div>
     </div>
   );
 };

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -15,19 +15,22 @@ interface IProps {
   linkedPluginEmbeddable?: IEmbeddablePlugin;
   pageLayout: string;
   questionNumber?: number;
+  teacherEditionMode?: boolean;
 }
 
 export const Embeddable: React.FC<IProps> = (props) => {
-  const { activityLayout, embeddableWrapper, isPageIntroduction, linkedPluginEmbeddable, pageLayout, questionNumber } = props;
+  const { activityLayout, embeddableWrapper, isPageIntroduction, linkedPluginEmbeddable, pageLayout, questionNumber, teacherEditionMode } = props;
   const embeddable = embeddableWrapper.embeddable;
 
   let qComponent;
   if (embeddable.type === "MwInteractive" || embeddable.type === "ManagedInteractive") {
     qComponent = <ManagedInteractive embeddable={embeddable} questionNumber={questionNumber} />;
   } else if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.component_label === "windowShade") {
-    qComponent = <EmbeddablePlugin embeddable={embeddable} />;
+    qComponent = teacherEditionMode ? <EmbeddablePlugin embeddable={embeddable} /> : undefined;
   } else if (embeddable.type === "Embeddable::Xhtml") {
     qComponent = <TextBox embeddable={embeddable} isPageIntroduction={isPageIntroduction} />;
+  } else {
+    qComponent = <div>Content type not supported</div>;
   }
 
   const staticWidth = pageLayout === PageLayouts.FortySixty || pageLayout === PageLayouts.SixtyForty || pageLayout === PageLayouts.Responsive;
@@ -36,7 +39,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
   const embeddableWrapperDivTarget = useRef<HTMLInputElement>(null);
   const embeddableDivTarget = useRef<HTMLInputElement>(null);
   useEffect(() => {
-    if (embeddableWrapperDivTarget.current && embeddableDivTarget.current && linkedPluginEmbeddable) {
+    if (embeddableWrapperDivTarget.current && embeddableDivTarget.current && linkedPluginEmbeddable && teacherEditionMode) {
       initializePlugin(linkedPluginEmbeddable, embeddable, embeddableWrapperDivTarget.current, embeddableDivTarget.current);
     }
   }, [linkedPluginEmbeddable, embeddable]);
@@ -49,7 +52,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
     >
       { linkedPluginEmbeddable && <div ref={embeddableWrapperDivTarget}></div> }
       <div ref={embeddableDivTarget}>
-        { qComponent || <div>Content type not supported</div> }
+        { qComponent }
       </div>
     </div>
   );

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -45,6 +45,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
     <div
       className={`embeddable ${embeddableWrapper.embeddable.is_full_width || staticWidth || singlePageLayout ? "full-width" : "reduced-width"}`}
       data-cy="embeddable"
+      key={embeddableWrapper.embeddable.ref_id}
     >
       { linkedPluginEmbeddable && <div ref={embeddableWrapperDivTarget}></div> }
       <div ref={embeddableDivTarget}>

--- a/src/components/activity-page/plugins/embeddable-plugin.test.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { EmbeddablePlugin } from "./embeddable-plugin";
+import { shallow } from "enzyme";
+import { IEmbeddablePlugin } from "../../../types";
+
+describe("Embeddable component", () => {
+  it("renders component", () => {
+    const embeddable: IEmbeddablePlugin = {
+      "plugin": {
+        "description": null,
+        "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"theoryAndBackground\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"this is a windowshade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+        "approved_script_label": "teacherEditionTips",
+        "component_label": "windowShade"
+      },
+      "is_hidden": false,
+      "is_full_width": false,
+      "type": "Embeddable::EmbeddablePlugin",
+      "ref_id": "2991-Embeddable::EmbeddablePlugin"
+    };
+    const wrapper = shallow(<EmbeddablePlugin embeddable={embeddable}/>);
+    expect(wrapper.find('[data-cy="embeddable-plugin"]').length).toBe(1);
+  });
+});

--- a/src/components/activity-page/plugins/embeddable-plugin.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.tsx
@@ -9,13 +9,13 @@ interface IProps {
 }
 
 export const EmbeddablePlugin: React.FC<IProps> = (props) => {
-    const { embeddable: { plugin } } = props;
+    const { embeddable } = props;
     const divTarget = useRef<HTMLInputElement>(null);
     useEffect(() => {
-      if (divTarget.current && plugin) {
-        initializePlugin(divTarget.current, plugin.author_data);
+      if (divTarget.current && embeddable) {
+        initializePlugin(embeddable, undefined, divTarget.current, undefined);
       }
-    }, [plugin]);
+    }, [embeddable]);
     return (
       <div className="plugin-container" ref={divTarget}/>
     );

--- a/src/components/activity-page/plugins/embeddable-plugin.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.tsx
@@ -17,6 +17,6 @@ export const EmbeddablePlugin: React.FC<IProps> = (props) => {
       }
     }, [embeddable]);
     return (
-      <div className="plugin-container" ref={divTarget} data-cy="embeddable-plugin" />
+      <div className="plugin-container" ref={divTarget} data-cy="embeddable-plugin" key={embeddable.ref_id} />
     );
   };

--- a/src/components/activity-page/plugins/embeddable-plugin.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.tsx
@@ -17,6 +17,6 @@ export const EmbeddablePlugin: React.FC<IProps> = (props) => {
       }
     }, [embeddable]);
     return (
-      <div className="plugin-container" ref={divTarget}/>
+      <div className="plugin-container" ref={divTarget} data-cy="embeddable-plugin" />
     );
   };

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -121,6 +121,7 @@ export class App extends React.PureComponent<IProps, IState> {
                   onPageChange={this.handleChangePage}
                   page={activity.pages.filter((page) => !page.is_hidden)[currentPage - 1]}
                   totalPreviousQuestions={totalPreviousQuestions}
+                  teacherEditionMode={this.state.teacherEditionMode}
                 />
         }
         { (activity.layout === ActivityLayouts.SinglePage || currentPage === 0) &&
@@ -138,6 +139,7 @@ export class App extends React.PureComponent<IProps, IState> {
       <React.Fragment>
         <SinglePageContent
           activity={activity}
+          teacherEditionMode={this.state.teacherEditionMode}
         />
       </React.Fragment>
     );

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -10,10 +10,11 @@ import { Activity, Page } from "../../types";
 
 interface IProps {
   activity: Activity;
+  teacherEditionMode?: boolean;
 }
 
 export const SinglePageContent: React.FC<IProps> = (props) => {
-  const { activity } = props;
+  const { activity, teacherEditionMode } = props;
   let questionNumber = 0;
   let embeddableNumber = 0;
 
@@ -35,6 +36,7 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
                 isPageIntroduction={questionNumber === 0}
                 pageLayout={PageLayouts.FullWidth}
                 questionNumber={isQuestion(embeddableWrapper) ? questionNumber : undefined}
+                teacherEditionMode={teacherEditionMode}
               />
             );
           })

--- a/src/data/sample-activity-plugins.json
+++ b/src/data/sample-activity-plugins.json
@@ -398,7 +398,7 @@
         },
         {
           "embeddable": {
-            "content": "<p>This page contain 4 window shade plugins</p>",
+            "content": "<p>This page contains 4 window shade plugins</p>",
             "is_full_width": true,
             "is_hidden": false,
             "name": "",

--- a/src/data/sample-activity-plugins.json
+++ b/src/data/sample-activity-plugins.json
@@ -18,7 +18,7 @@
       "embeddable_display_mode": "stacked",
       "is_completion": false,
       "is_hidden": false,
-      "layout": "l-6040",
+      "layout": "l-full-width",
       "name": null,
       "position": 1,
       "show_header": true,
@@ -31,11 +31,209 @@
       "embeddables": [
         {
           "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"questionWrapper\",\"questionWrapper\":{\"correctExplanation\":\"correct\",\"distractorsExplanation\":\"distractor\",\"exemplar\":\"this is an exemplar\",\"teacherTip\":\"this is a teacher tip with top location\",\"teacherTipImageOverlay\":\"\",\"location\":\"top\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "questionWrapper"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3002-Embeddable::EmbeddablePlugin",
+            "embeddable_ref_id": "413-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"questionWrapper\",\"questionWrapper\":{\"correctExplanation\":\"correct\",\"distractorsExplanation\":\"distractor\",\"exemplar\":\"this is an exemplar\",\"teacherTip\":\"this is a teacher tip with sticky location\",\"teacherTipImageOverlay\":\"\",\"location\":\"stickyNote\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "questionWrapper"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3003-Embeddable::EmbeddablePlugin",
+            "embeddable_ref_id": "414-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"questionWrapper\",\"questionWrapper\":{\"correctExplanation\":\"correct\",\"distractorsExplanation\":\"distractor\",\"exemplar\":\"this is an exemplar\",\"teacherTip\":\"this is a teacher tip with bottom location\",\"teacherTipImageOverlay\":\"\",\"location\":\"bottom\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "questionWrapper"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3004-Embeddable::EmbeddablePlugin",
+            "embeddable_ref_id": "415-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}]}",
+            "is_hidden": false,
+            "is_full_width": false,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": "DEFAULT",
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "af5d1860b2d4a037ae01e3d86931a30886fcb42d",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/multiple-choice/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "A basic multiple choice interactive. This is pointing to the master branch and is in development so it shouldn't be used by real activities. \r\n",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Multiple Choice (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": true,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "413-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}]}",
+            "is_hidden": false,
+            "is_full_width": false,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": "DEFAULT",
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "af5d1860b2d4a037ae01e3d86931a30886fcb42d",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/multiple-choice/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "A basic multiple choice interactive. This is pointing to the master branch and is in development so it shouldn't be used by real activities. \r\n",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Multiple Choice (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": true,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "414-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}]}",
+            "is_hidden": false,
+            "is_full_width": false,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": "DEFAULT",
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "af5d1860b2d4a037ae01e3d86931a30886fcb42d",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/multiple-choice/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "A basic multiple choice interactive. This is pointing to the master branch and is in development so it shouldn't be used by real activities. \r\n",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Multiple Choice (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": true,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "415-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
             "name": "",
             "url_fragment": null,
             "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}],\"prompt\":\"<p>this MC has a hint</p>\",\"hint\":\"<p>I&#x27;m a hint</p>\"}",
             "is_hidden": false,
-            "is_full_width": true,
+            "is_full_width": false,
             "show_in_featured_question_report": true,
             "inherit_aspect_ratio_method": true,
             "custom_aspect_ratio_method": "DEFAULT",
@@ -111,7 +309,7 @@
         },
         {
           "embeddable": {
-            "content": "<p>this page contains:</p>\r\n<ul>\r\n<li>question with hint</li>\r\n<li>window shade</li>\r\n<li>side tip</li>\r\n</ul>",
+            "content": "<p>this page contains:</p>\r\n<ul>\r\n<li>3 questions with TE wrappers showing each wrapper location</li>\r\n<li>mc question with hint</li>\r\n<li>window shade</li>\r\n<li>side tip</li>\r\n</ul>",
             "is_full_width": true,
             "is_hidden": false,
             "name": "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,7 @@ export interface EmbeddableBase {
   is_hidden: boolean;
   is_full_width: boolean;
   ref_id: string;
+  embeddable_ref_id?: string;
 }
 
 export interface IManagedInteractive extends EmbeddableBase {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface LibraryInteractive {
 }
 
 export interface Plugin {
-  description: string;
+  description: string | null;
   author_data: string;
   approved_script_label: string;
   component_label: string;
@@ -43,7 +43,7 @@ export interface Plugin {
 
 export interface EmbeddableBase {
   type: string;
-  name: string;
+  name?: string;
   authored_state?: string | null;
   interactiveState?: any | null;
   url_fragment?: string | null,

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -45,13 +45,13 @@ export const isEmbeddableSectionHidden = (page: Page, section: string | null) =>
 export const getVisibleEmbeddablesOnPage = (page: Page) => {
   const headerEmbeddables = isEmbeddableSectionHidden(page, EmbeddableSections.Introduction)
     ? []
-    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Introduction && !e.embeddable.is_hidden);
+    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Introduction && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id);
   const interactiveEmbeddables = isEmbeddableSectionHidden(page, EmbeddableSections.Interactive)
     ? []
-    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Interactive && !e.embeddable.is_hidden);
+    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Interactive && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id);
   const infoAssessEmbeddables = isEmbeddableSectionHidden(page, null)
     ? []
-    : page.embeddables.filter((e: any) => (e.section !== EmbeddableSections.Interactive && e.section !== EmbeddableSections.Introduction && !e.embeddable.is_hidden));
+    : page.embeddables.filter((e: any) => (e.section !== EmbeddableSections.Interactive && e.section !== EmbeddableSections.Introduction && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id));
 
   return { interactiveBox: interactiveEmbeddables, headerBlock: headerEmbeddables, infoAssessment: infoAssessEmbeddables };
 };
@@ -91,4 +91,9 @@ export const numQuestionsOnPreviousPages = (currentPage: number, activity: Activ
 export const enableReportButton = (activity: Activity) => {
   const hasCompletionPage = activity.pages.find((page: any) => page.is_completion);
   return !hasCompletionPage && activity.student_report_enabled;
+};
+
+export const getLinkedPluginEmbeddable = (page: Page, id: string) => {
+  const linkedPluginEmbeddable = page.embeddables.find((e: EmbeddableWrapper) => e.embeddable.embeddable_ref_id === id);
+  return linkedPluginEmbeddable?.embeddable.type === "Embeddable::EmbeddablePlugin" ? linkedPluginEmbeddable.embeddable : undefined;
 };

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -1,4 +1,4 @@
-import { Activity } from "../types";
+import { Activity, Embeddable, IEmbeddablePlugin } from "../types";
 
 type PluginType = "TeacherEdition" | "Glossary";
 export interface PluginInfo {
@@ -13,7 +13,7 @@ export const Plugins: PluginInfo[] = [
   {
     url: "https://teacher-edition-tips-plugin.concord.org/version/v3.5.6/plugin.js",
     type: "TeacherEdition",
-    name: "teacher edition plugin",
+    name: "Teacher Edition",
     id: 0
   },
 ];
@@ -51,24 +51,32 @@ export const loadPluginScripts = (activity: Activity) => {
   });
 };
 
-export const initializePlugin = (container: HTMLElement, authoredData: string) => {
-  // TODO: will need additions based as we implement other plugin types
+export const initializePlugin = (embeddable: IEmbeddablePlugin, wrappedEmbeddable: Embeddable | undefined, embeddableContainer: HTMLElement, wrappedEmbeddableContainer: HTMLElement | undefined) => {
+  // TODO: will need to change search as we implement other plugin types
   const plugin = Plugins.find(p => p.type === "TeacherEdition");
+
+  const embeddableContext = {
+    container: wrappedEmbeddableContainer,
+    laraJson: wrappedEmbeddable,
+    interactiveStateUrl: null,
+    interactiveAvailable: true
+  };
+
   const pluginContext = {
-    name: "plugin name",
-    url: "plugin url",
-    pluginId: "plugin id",
+    name: plugin?.name,
+    url: plugin?.url,
+    pluginId: embeddable.ref_id.substring(0, embeddable.ref_id.indexOf("-")),
     embeddablePluginId: null,
-    authoredState: authoredData,
+    authoredState: embeddable.plugin?.author_data,
     learnerState: null,
     learnerStateSaveUrl: "",
-    container: container,
-    runId: "run id",
+    container: embeddableContainer,
+    runId: "",
     remoteEndpoint: null,
     userEmail: null,
     classInfoUrl: null,
     firebaseJwtUrl: "",
-    wrappedEmbeddable: null,
+    wrappedEmbeddable: wrappedEmbeddable ? embeddableContext : null,
     resourceUrl: "",
   };
   // TODO: add sophistication to handle other types


### PR DESCRIPTION
This PR adds support for embeddable wrapper teacher edition plugins.  For each embeddable, we search the page for a linked, wrapper embeddable that, if found, is passed to the `Embeddable` component.  Once we have the proper container refs in the `Embeddable` component, we call `initializePlugin` which sets up the `embeddableContext` for wrapper plugins and then instantiates the plugin.