### PR TITLE
Save anonymous  data using runKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,18 @@ Inside of your `package.json` file:
 
 * activity={id|url}: load sample-activity {id} or load json from specified url
 * page={n}:          load page n, where 0 is the activity introduction and 1 is the first page
+* themeButtons:      whether to show theme buttons
+* mode={mode}:       sets mode. Values: "teacher-edition"
 
 #### User data loading:
 * firebase-app={id}: needed to load data from the correct firebase app
 * token={n}:         set by the portal when launching external activity, to authenticate with portal API
 * domain={n}:        set by the portal when launching external activity
+* report-source={id}: which source collection to sava data to in firestore (defaults to own hostname)
+* runkey={uuid}:     set by the app if we are running in anonymous datasaving mode
+* preview:           prevent running in anonymous datasaving mode
+* enableFirestorePersistence: uses local offline firestore cache only
+* clearFirestorePersistence: clears local offline firestore cache
 
 ## License
 

--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,6 @@
   "video": false,
   "fixturesFolder": "src/data",
   "defaultCommandTimeout": 8000,
-  "projectId": "voj5ej"
+  "projectId": "voj5ej",
+  "chromeWebSecurity": false
 }

--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -1,4 +1,5 @@
 import ActivityPage from "../support/elements/activity-page";
+import { getIframeBody } from "../support/elements/iframe";
 
 const activityPage = new ActivityPage;
 
@@ -29,6 +30,15 @@ context("Test the overall app", () => {
       activityPage.getNavPage(3).click();
       activityPage.getSecondaryEmbeddable("text-box").eq(1).scrollIntoView()
         .should("be.visible").and("contain","Duis vitae ultrices augue, eu fermentum elit.");
+    });
+  });
+  describe("Question Interactives",()=>{
+    it("verify we can load a managed interactive",()=>{
+      cy.visit("?activity=sample-activity-1&preview");
+      activityPage.getNavPage(2).click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
+      getIframeBody("body").find("[data-cy=choices-container]").should("be.visible");
     });
   });
 });

--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -4,7 +4,7 @@ const activityPage = new ActivityPage;
 
 context("Test the overall app", () => {
   before(() => {
-    cy.visit("?activity=sample-activity-multiple-layout-types");
+    cy.visit("?activity=sample-activity-multiple-layout-types&preview");
     activityPage.getPage(2).click();
   });
   describe("Sidebar",() => {

--- a/cypress/integration/data-saving-anonymous.ts
+++ b/cypress/integration/data-saving-anonymous.ts
@@ -1,0 +1,67 @@
+import { v4 as uuidv4 } from "uuid";
+import ActivityPage from "../support/elements/activity-page";
+import { getIframeBody } from "../support/elements/iframe";
+
+const activityPage = new ActivityPage;
+
+context("Saving and loading data as an anonymous user", () => {
+
+  describe("Setting the run key", () => {
+    it("will set the run key if we are not in preview mode", () => {
+      cy.visit("?activity=sample-activity-1&firebase-app=report-service-dev");
+      activityPage.getNavPage(2).click();
+      cy.url().should("include", "runKey");
+    });
+
+    it("will not set the run key if we are in preview mode", () => {
+      cy.visit("?activity=sample-activity-1&preview");
+      cy.url().should("not.include", "runKey");
+    });
+  });
+
+  describe("Saving and loading data", () => {
+    const runKey = uuidv4();
+
+    it("we can use a runKey to retreive data previously persisted", () => {
+      const activityUrl = "?activity=sample-activity-1&firebase-app=report-service-dev&enableFirestorePersistence&runKey=" + runKey;
+
+      cy.visit(activityUrl);
+      activityPage.getNavPage(2).click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
+      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).click({force: true});
+
+      // unfortuntely we have to wait for the data to be posted to firestore, which happens after a
+      // delay to prevent spamming the database.
+      // The fastest and most reliable way to kick it off seems to be 1. blur, 2. wait, 3. navigate away
+      cy.get("[data-cy=profile-nav-header").click({force: true});
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(2000);
+      activityPage.getNavPage(1).click();
+
+      cy.visit(activityUrl);
+      activityPage.getNavPage(2).click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
+      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).should("be.checked");
+    });
+
+    it("we can remove a runKey and we will no l0nger see our data", () => {
+      const activityUrl = "?activity=sample-activity-1&firebase-app=report-service-dev&enableFirestorePersistence&runKey=" + runKey;
+
+      cy.visit(activityUrl);
+      activityPage.getNavPage(2).click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
+      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).should("be.checked");
+
+      const activityUrlNoRunkey = "?activity=sample-activity-1&firebase-app=report-service-dev&enableFirestorePersistence";
+
+      cy.visit(activityUrlNoRunkey);
+      activityPage.getNavPage(2).click();
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
+      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).should("not.be.checked");
+    });
+  });
+});

--- a/cypress/integration/data-saving-anonymous.ts
+++ b/cypress/integration/data-saving-anonymous.ts
@@ -22,7 +22,7 @@ context("Saving and loading data as an anonymous user", () => {
   describe("Saving and loading data", () => {
     const runKey = uuidv4();
 
-    it("we can use a runKey to retreive data previously persisted", () => {
+    it("we can use a runKey to retrieve data previously persisted", () => {
       const activityUrl = "?activity=sample-activity-1&firebase-app=report-service-dev&enableFirestorePersistence&runKey=" + runKey;
 
       cy.visit(activityUrl);
@@ -31,7 +31,7 @@ context("Saving and loading data as an anonymous user", () => {
       cy.wait(500);
       getIframeBody("body").find("[data-cy=choices-container] input").eq(1).click({force: true});
 
-      // unfortuntely we have to wait for the data to be posted to firestore, which happens after a
+      // unfortunately we have to wait for the data to be posted to firestore, which happens after a
       // delay to prevent spamming the database.
       // The fastest and most reliable way to kick it off seems to be 1. blur, 2. wait, 3. navigate away
       cy.get("[data-cy=profile-nav-header").click({force: true});
@@ -46,7 +46,7 @@ context("Saving and loading data as an anonymous user", () => {
       getIframeBody("body").find("[data-cy=choices-container] input").eq(1).should("be.checked");
     });
 
-    it("we can remove a runKey and we will no l0nger see our data", () => {
+    it("we can remove a runKey and we will no longer see our data", () => {
       const activityUrl = "?activity=sample-activity-1&firebase-app=report-service-dev&enableFirestorePersistence&runKey=" + runKey;
 
       cy.visit(activityUrl);

--- a/cypress/integration/load-activities.test.ts
+++ b/cypress/integration/load-activities.test.ts
@@ -5,29 +5,29 @@ context("Loading activities", () => {
 
   describe("Loading sample activities", () => {
     it("can open one sample activity", () => {
-      cy.visit("?activity=sample-activity-1");
+      cy.visit("?activity=sample-activity-1&preview");
       cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
     });
 
     it("can open a different sample activity", () => {
-      cy.visit("?activity=sample-activity-multiple-layout-types");
+      cy.visit("?activity=sample-activity-multiple-layout-types&preview");
       cy.get("[data-cy=activity-summary]").should("contain", "Sample Layout Types");
     });
   });
 
   describe("Loading pages", () => {
     it("can open the introduction page by default", () => {
-      cy.visit("?activity=sample-activity-1");
+      cy.visit("?activity=sample-activity-1&preview");
       cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
     });
 
     it("can load page 0", () => {
-      cy.visit("?activity=sample-activity-multiple-layout-types&page=0");
+      cy.visit("?activity=sample-activity-multiple-layout-types&page=0&preview");
       cy.get("[data-cy=activity-summary]").should("contain", "Sample Layout Types");
     });
 
     it("can load page 4", () => {
-      cy.visit("?activity=sample-activity-multiple-layout-types&page=4");
+      cy.visit("?activity=sample-activity-multiple-layout-types&page=4&preview");
       activityPage.getSecondaryEmbeddable("text-box").eq(1).scrollIntoView()
         .should("be.visible").and("contain","Duis vitae ultrices augue, eu fermentum elit.");
     });

--- a/cypress/integration/workspace.test.ts
+++ b/cypress/integration/workspace.test.ts
@@ -1,6 +1,6 @@
 context("Test the overall app", () => {
   before(() => {
-    cy.visit("");
+    cy.visit("/?preview");
   });
 
   describe("header",()=>{

--- a/cypress/support/elements/iframe.js
+++ b/cypress/support/elements/iframe.js
@@ -1,0 +1,21 @@
+export const getIframeDocument = (outerSelector) => {
+  return cy.get(outerSelector)
+  .get("iframe")
+  // Cypress yields jQuery element, which has the real
+  // DOM element under property "0".
+  // From the real DOM iframe element we can get
+  // the "document" element, it is stored in "contentDocument" property
+  // Cypress "its" command can access deep properties using dot notation
+  // https://on.cypress.io/its
+  .its("0.contentDocument").should("exist");
+};
+
+export const getIframeBody = (outerSelector) => {
+  // get the document
+  return getIframeDocument(outerSelector)
+  // automatically retries until body is loaded
+  .its("body").should("not.be.undefined")
+  // wraps "body" DOM element to allow
+  // chaining more Cypress commands, like ".find(...)"
+  .then(cy.wrap);
+};

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test:debug": "node --nolazy --inspect-brk ./node_modules/.bin/jest --runInBand --no-cache",
     "test:watch": "jest --watch",
     "test:coverage:watch": "jest --coverage --watchAll",
-    "test:cypress": "cypress run",
+    "test:cypress": "cypress run data-saving-anonymous",
     "test:cypress:open": "cypress open",
     "test:full": "npm-run-all test test:cypress"
   },

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -11,7 +11,7 @@ import { ThemeButtons } from "./theme-buttons";
 import { SinglePageContent } from "./single-page/single-page-content";
 import { WarningBanner } from "./warning-banner";
 import { CompletionPageContent } from "./activity-completion/completion-page-content";
-import { queryValue } from "../utilities/url-query";
+import { queryValue, queryValueBoolean } from "../utilities/url-query";
 import { fetchPortalData } from "../portal-api";
 import { signInWithToken, watchAnswers, initializeDB, setPortalData, initializeAnonymousDB } from "../firebase-db";
 import { Activity } from "../types";
@@ -53,13 +53,15 @@ export class App extends React.PureComponent<IProps, IState> {
       const showThemeButtons = queryValue("themeButtons")?.toLowerCase() === "true";
       const teacherEditionMode = queryValue("mode")?.toLowerCase( )=== "teacher-edition";
 
+      const useAnonymousRunKey = !queryValue("token") && !queryValueBoolean("preview") && !teacherEditionMode;
+
       if (queryValue("token")) {
         const portalData = await fetchPortalData();
         await initializeDB(portalData.database.appName);
         await signInWithToken(portalData.database.rawFirebaseJWT);
         setPortalData(portalData);
         watchAnswers();
-      } else {
+      } else if (useAnonymousRunKey) {
         await initializeAnonymousDB();
         watchAnswers();
       }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -13,7 +13,7 @@ import { WarningBanner } from "./warning-banner";
 import { CompletionPageContent } from "./activity-completion/completion-page-content";
 import { queryValue } from "../utilities/url-query";
 import { fetchPortalData } from "../portal-api";
-import { signInWithToken, watchAnswers, initializeDB, setPortalData } from "../firebase-db";
+import { signInWithToken, watchAnswers, initializeDB, setPortalData, initializeAnonymousDB } from "../firebase-db";
 import { Activity } from "../types";
 import { createPluginNamespace } from "../lara-plugin/index";
 import { loadPluginScripts } from "../utilities/plugin-utils";
@@ -58,6 +58,9 @@ export class App extends React.PureComponent<IProps, IState> {
         await initializeDB(portalData.database.appName);
         await signInWithToken(portalData.database.rawFirebaseJWT);
         setPortalData(portalData);
+        watchAnswers();
+      } else {
+        await initializeAnonymousDB();
         watchAnswers();
       }
       this.setState({activity, currentPage, showThemeButtons, teacherEditionMode});

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -50,7 +50,7 @@ export class App extends React.PureComponent<IProps, IState> {
       // page 0 is introduction, inner pages start from 1 and match page.position in exported activity
       const currentPage = Number(queryValue("page")) || 0;
 
-      const showThemeButtons = queryValue("themeButtons")?.toLowerCase() === "true";
+      const showThemeButtons = queryValueBoolean("themeButtons");
       const teacherEditionMode = queryValue("mode")?.toLowerCase( )=== "teacher-edition";
 
       const useAnonymousRunKey = !queryValue("token") && !queryValueBoolean("preview") && !teacherEditionMode;

--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -20,6 +20,7 @@ describe("Firestore", () => {
 
   it("creates answers with the correct metadata", () => {
     setPortalData({
+      type: "authenticated",
       contextId: "context-id",
       database: {
         appName: "report-service-dev",

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -362,6 +362,11 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
   // query parameter.
   const sourceKey = queryValue("report-source") || parseUrl(offeringData.activityUrl.toLowerCase()).hostname;
 
+  // for the tool id we want to distinguish activity-player branches, incase this is ever helpful for
+  // dealing with mis-matched data when we load data in originally saved on another branch.
+  // This is currently unused for the purpose of saving and loading data
+  const toolId = window.location.hostname + window.location.pathname;
+
   const rawPortalData: IPortalData = {
     type: "authenticated",
     offering: offeringData,
@@ -370,7 +375,7 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
     platformId: firebaseJWT.claims.platform_id,
     platformUserId: firebaseJWT.claims.platform_user_id.toString(),
     contextId: classInfo.classHash,
-    toolId: window.location.hostname,
+    toolId,
     resourceUrl: offeringData.activityUrl,
     database: {
       appName: firebaseAppName,
@@ -390,9 +395,6 @@ export const anonymousPortalData = () => {
   }
 
   const hostname = window.location.hostname;
-  // for the tool id we want to distinguish activity-player branches, incase this is ever helpful for
-  // dealing with mis-matched data when we load data in originally saved on another branch.
-  // This is currently unused for the purpose of saving and loading data
   const toolId = hostname + window.location.pathname;
   // just save the host and loaded activity-url as the resourceUrl, omitting any other url parameters.
   // This is currently unused for the purpose of saving and loading data

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -383,8 +383,11 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
 
 // metadata for saving and loading work for anonymous users, not actually loaded from the portal
 export const anonymousPortalData = () => {
-  const runKey = queryValue("runKey") || uuidv4();
-  setQueryValue("runKey", runKey);
+  let runKey = queryValue("runKey");
+  if (!runKey) {
+    runKey = uuidv4();
+    setQueryValue("runKey", runKey);
+  }
 
   const hostname = window.location.hostname;
   // for the tool id we want to distinguish activity-player branches, incase this is ever helpful for

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -1,7 +1,10 @@
 import jwt from "jsonwebtoken";
 import superagent from "superagent";
-import { queryValue } from "./utilities/url-query";
-import { FirebaseAppName, DEFAULT_FIREBASE_APP } from "./firebase-db";
+import { v4 as uuidv4 } from "uuid";
+import { queryValue, setQueryValue } from "./utilities/url-query";
+import { FirebaseAppName } from "./firebase-db";
+
+export const DEFAULT_FIREBASE_APP: FirebaseAppName = "report-service-pro";
 
 interface PortalClassOffering {
   className: string;
@@ -79,11 +82,25 @@ interface FirebaseData {
 }
 
 export interface IPortalData extends ILTIPartial {
+  type: "authenticated";
   offering: OfferingData;
   userType: "teacher" | "learner";
   database: FirebaseData;
   toolId: string;
   resourceUrl: string;
+}
+
+export interface IAnonymousPortalData {
+  type: "anonymous";
+  userType: "learner";
+  runKey: string;
+  resourceUrl: string;
+  toolId: string;
+  toolUserId: "anonymous";
+  database: {
+    appName: FirebaseAppName,
+    sourceKey: string;
+  };
 }
 
 interface BasePortalJWT {
@@ -346,6 +363,7 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
   const sourceKey = queryValue("report-source") || parseUrl(offeringData.activityUrl.toLowerCase()).hostname;
 
   const rawPortalData: IPortalData = {
+    type: "authenticated",
     offering: offeringData,
     resourceLinkId: offeringData.id.toString(),
     userType: firebaseJWT.claims.user_type,
@@ -358,6 +376,34 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
       appName: firebaseAppName,
       sourceKey,
       rawFirebaseJWT,
+    }
+  };
+  return rawPortalData;
+};
+
+// metadata for saving and loading work for anonymous users, not actually loaded from the portal
+export const anonymousPortalData = () => {
+  const runKey = queryValue("runKey") || uuidv4();
+  setQueryValue("runKey", runKey);
+
+  const hostname = window.location.hostname;
+  // for the tool id we want to distinguish activity-player branches, incase this is ever helpful for
+  // dealing with mis-matched data when we load data in originally saved on another branch.
+  // This is currently unused for the purpose of saving and loading data
+  const toolId = hostname + window.location.pathname;
+  // just save the host and loaded activity-url as the resourceUrl, omitting any other url parameters.
+  // This is currently unused for the purpose of saving and loading data
+  const resourceUrl = hostname + "?activity=" + queryValue("activity");
+  const rawPortalData: IAnonymousPortalData = {
+    type: "anonymous",
+    userType: "learner",
+    runKey,
+    resourceUrl,
+    toolId,
+    toolUserId: "anonymous",
+    database: {
+      appName: firebaseAppName,
+      sourceKey: hostname
     }
   };
   return rawPortalData;

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,14 @@ export interface ILTIPartial {
   tool_id: string;
 }
 
+export interface IAnonymousMetadataPartial {
+  resource_url: string;
+  run_key: string;
+  source_key: string;
+  tool_id: string;
+  tool_user_id: "anonymous";
+}
+
 /**
  * cf. IRunTimeMetadataBase, from
  * https://github.com/concord-consortium/lara/blob/master/lara-typescript/src/interactive-api-client/metadata-types.ts#L47
@@ -203,3 +211,5 @@ export type IExportableAnswerMetadata =
   IExportableMultipleChoiceAnswerMetadata;
 
 export interface LTIRuntimeAnswerMetadata extends ILTIPartial, IExportalbleAnswerMetadataBase { }
+
+export interface AnonymousRuntimeAnswerMetadata extends IAnonymousMetadataPartial, IExportalbleAnswerMetadataBase { }

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,7 +176,7 @@ export interface IAnonymousMetadataPartial {
  * and partial export code at
  * https://github.com/concord-consortium/lara/blob/c40304a14ef495acdf4f9fd09ea892c7cc98247b/app/models/interactive_run_state.rb#L110
  */
-export interface IExportalbleAnswerMetadataBase {
+export interface IExportableAnswerMetadataBase {
   remote_endpoint: string;
   question_id: string;
   question_type: string;
@@ -188,17 +188,17 @@ export interface IExportalbleAnswerMetadataBase {
   report_state: string;
 }
 
-export interface IExportableInteractiveAnswerMetadata extends IExportalbleAnswerMetadataBase {
+export interface IExportableInteractiveAnswerMetadata extends IExportableAnswerMetadataBase {
   type: "interactive_state";
   answer: string;
 }
 
-export interface IExportableOpenResponseAnswerMetadata extends IExportalbleAnswerMetadataBase {
+export interface IExportableOpenResponseAnswerMetadata extends IExportableAnswerMetadataBase {
   type: "open_response_answer";
   answer: string;
 }
 
-export interface IExportableMultipleChoiceAnswerMetadata extends IExportalbleAnswerMetadataBase {
+export interface IExportableMultipleChoiceAnswerMetadata extends IExportableAnswerMetadataBase {
   type: "multiple_choice_answer";
   answer: {
     choice_ids: string[];
@@ -210,6 +210,6 @@ export type IExportableAnswerMetadata =
   IExportableOpenResponseAnswerMetadata |
   IExportableMultipleChoiceAnswerMetadata;
 
-export interface LTIRuntimeAnswerMetadata extends ILTIPartial, IExportalbleAnswerMetadataBase { }
+export interface LTIRuntimeAnswerMetadata extends ILTIPartial, IExportableAnswerMetadataBase { }
 
-export interface AnonymousRuntimeAnswerMetadata extends IAnonymousMetadataPartial, IExportalbleAnswerMetadataBase { }
+export interface AnonymousRuntimeAnswerMetadata extends IAnonymousMetadataPartial, IExportableAnswerMetadataBase { }

--- a/src/utilities/url-query.ts
+++ b/src/utilities/url-query.ts
@@ -14,3 +14,18 @@ export const queryValue = (prop: string): string | undefined => {
   }
   return val;
 };
+
+/**
+ * Append or modify a query parameter value, by default using `replaceState` to update in place
+ * without a reload or history push, but optionally with a reload.
+ */
+export const setQueryValue = (prop: string, value: any, reload = false) => {
+  const parsed = queryString.parse(location.search);
+  parsed[prop] = value;
+  const newQueryString = queryString.stringify(parsed);
+  if (reload) {
+    location.search = queryString.stringify(parsed);
+  } else {
+    window.history.replaceState(null, "", "?" + newQueryString);
+  }
+};

--- a/src/utilities/url-query.ts
+++ b/src/utilities/url-query.ts
@@ -16,6 +16,17 @@ export const queryValue = (prop: string): string | undefined => {
 };
 
 /**
+ * returns `true` if prop is present, or has any value except "false"
+ */
+export const queryValueBoolean = (prop: string): boolean => {
+  const query = queryString.parse(window.location.search, {parseBooleans: true});
+  const val = query[prop];
+  if (val === false) return false;
+  // if prop is present, it will be `null`, which we will count as `true`
+  return val !== undefined;
+};
+
+/**
  * Append or modify a query parameter value, by default using `replaceState` to update in place
  * without a reload or history push, but optionally with a reload.
  */


### PR DESCRIPTION
This continues from #39 and only includes the commits from "Allow anonymous saving and loading with runKey" onward.

If we load an activity url

1. without a `token=` parameter from the portal
2. without `mode=teacher-edition`
3. without `preview`

we will create a random `runKey` and use this to save and load data from the portal, unauthenticated, using the new firestore rules introduced in https://github.com/concord-consortium/report-service/pull/30.

This also adds some round-trip saving and loading tests, using local offline firestore.