### PR TITLE
Handle empty library interactive

### DIFF
--- a/src/components/activity-page/embeddable.test.tsx
+++ b/src/components/activity-page/embeddable.test.tsx
@@ -33,6 +33,26 @@ describe("Embeddable component", () => {
     });
   });
 
+  it("renders an empty managed interactive", async () => {
+
+    const embeddableWrapper: EmbeddableWrapper = {
+      "embeddable": {
+        ...DefaultManagedInteractive,
+        library_interactive: null // force to null for test, shouldn't be allowed on type
+      },
+      "section": "interactive_box"
+    };
+
+    let wrapper: ReactWrapper;
+    await act(async () => {
+      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} isPageIntroduction={false} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
+    });
+
+    await waitFor(() => {
+      expect(wrapper.text()).toContain("Content type not supported");
+    });
+  });
+
   it("renders a managed interactive", async () => {
     iframePhone.ParentEndpoint = jest.fn().mockImplementation(() => ({
       disconnect: jest.fn()

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -23,7 +23,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
   const embeddable = embeddableWrapper.embeddable;
 
   let qComponent;
-  if (embeddable.type === "MwInteractive" || embeddable.type === "ManagedInteractive") {
+  if (embeddable.type === "MwInteractive" || (embeddable.type === "ManagedInteractive" && embeddable.library_interactive)) {
     qComponent = <ManagedInteractive embeddable={embeddable} questionNumber={questionNumber} />;
   } else if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.component_label === "windowShade") {
     qComponent = teacherEditionMode ? <EmbeddablePlugin embeddable={embeddable} /> : undefined;

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -33,17 +33,17 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
     const questionName = embeddable.name ? `: ${embeddable.name}` : "";
     // in older iframe interactive embeddables, we get url, native_width, native_height, etc. directly off
     // of the embeddable object. On newer managed/library interactives, this data is in library_interactive.data.
-    let embeddableData: IMwInteractive | LibraryInteractiveData;
+    let embeddableData: IMwInteractive | LibraryInteractiveData | undefined;
     if (embeddable.type === "ManagedInteractive") {
-      embeddableData = embeddable.library_interactive.data;
+      embeddableData = embeddable.library_interactive?.data;
     } else {
       embeddableData = embeddable;
     }
-    const url = embeddableData.base_url || embeddableData.url || "";
+    const url = embeddableData?.base_url || embeddableData?.url || "";
     // TODO: handle different aspect ration methods
     // const aspectRatioMethod = data.aspect_ratio_method ? data.aspect_ratio_method : "";
-    const nativeHeight = embeddableData.native_height || 0;
-    const nativeWidth = embeddableData.native_width || 0;
+    const nativeHeight = embeddableData?.native_height || 0;
+    const nativeWidth = embeddableData?.native_width || 0;
     const aspectRatio = nativeHeight && nativeWidth ? nativeWidth / nativeHeight : kDefaultAspectRatio;
 
     // cf. https://www.npmjs.com/package/@react-hook/resize-observer

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export interface EmbeddableBase {
 
 export interface IManagedInteractive extends EmbeddableBase {
   type: "ManagedInteractive";
-  library_interactive: LibraryInteractive;
+  library_interactive: LibraryInteractive | null;
   show_in_featured_question_report?: boolean;
   inherit_aspect_ratio_method?: boolean;
   custom_aspect_ratio_method?: "DEFAULT" | null;


### PR DESCRIPTION
Ensure that the `library_interactive` object on a library interactive embeddable actually has content.  When authoring, a user can add a library interactive, but cancel the selection of a library type from the list. This results in an embeddable section being added to the activity page that is marked as a library interactive, but has no library interactive section (which causes the app to crash).