### PR TITLE
Add unique key to embeddable to insure initial state is set properly

### DIFF
--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -146,7 +146,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
             const linkedPluginEmbeddable = getLinkedPluginEmbeddable(this.props.page, embeddableWrapper.embeddable.ref_id);
             return (
               <Embeddable
-                key={`embeddable ${i}`}
+                key={`embeddable-${embeddableWrapper.embeddable.ref_id}`}
                 embeddableWrapper={embeddableWrapper}
                 isPageIntroduction={i === 0 && section === EmbeddableSections.Introduction}
                 pageLayout={this.props.page.layout}


### PR DESCRIPTION
Add a unique key to the page embeddable to ensure that we properly load the component and set the initial interactive state.