### PR TITLE
Set tab title based on activity page

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -5,7 +5,7 @@ import { ActivityNavHeader } from "./activity-header/activity-nav-header";
 import { ActivityPageContent } from "./activity-page/activity-page-content";
 import { IntroductionPageContent } from "./activity-introduction/introduction-page-content";
 import { Footer } from "./activity-introduction/footer";
-import { ActivityLayouts, PageLayouts, numQuestionsOnPreviousPages, enableReportButton } from "../utilities/activity-utils";
+import { ActivityLayouts, PageLayouts, numQuestionsOnPreviousPages, enableReportButton, setDocumentTitle } from "../utilities/activity-utils";
 import { getActivityDefinition } from "../lara-api";
 import { ThemeButtons } from "./theme-buttons";
 import { SinglePageContent } from "./single-page/single-page-content";
@@ -59,6 +59,7 @@ export class App extends React.PureComponent<IProps, IState> {
       const useAnonymousRunKey = !queryValue("token") && !queryValueBoolean("preview") && !teacherEditionMode;
 
       const newState: Partial<IState> = {activity, currentPage, showThemeButtons, teacherEditionMode};
+      setDocumentTitle(activity, currentPage);
 
       if (queryValue("token")) {
         const portalData = await fetchPortalData();
@@ -187,5 +188,6 @@ export class App extends React.PureComponent<IProps, IState> {
 
   private handleChangePage = (page: number) => {
     this.setState({currentPage: page});
+    setDocumentTitle(this.state.activity, page);
   }
 }

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -111,6 +111,6 @@ export const setDocumentTitle = (activity: Activity | undefined, pageNumber: num
   if (activity) {
     document.title = pageNumber === 0
       ? activity.name
-      : `Page ${pageNumber} ${activity.pages[pageNumber - 1].name ? activity.pages[pageNumber - 1].name : activity.name}`;
+      : `Page ${pageNumber} ${activity.pages[pageNumber - 1].name || activity.name}`;
   }
 };

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -102,7 +102,15 @@ export const setAppBackgroundImage = (backgroundImageUrl?: string) => {
   const gradient = "linear-gradient(to bottom, #fff, rgba(255,255,255,0), rgba(255,255,255,0))";
   const el = document.querySelector(".app") as HTMLElement;
   el && ( backgroundImageUrl
-                    ? el.style.setProperty("background-image", backgroundImageUrl) 
+                    ? el.style.setProperty("background-image", backgroundImageUrl)
                     : el.style.setProperty("background-image", gradient)
         );
+};
+
+export const setDocumentTitle = (activity: Activity | undefined, pageNumber: number) => {
+  if (activity) {
+    document.title = pageNumber === 0
+      ? activity.name
+      : `Page ${pageNumber} ${activity.pages[pageNumber - 1].name ? activity.pages[pageNumber - 1].name : activity.name}`;
+  }
 };


### PR DESCRIPTION
This PR updates the document title displayed in the browser tab based on the activity page.  The following rules are used:
- the home page shows the activity name
- subsequent pages show " Page X " followed by either the page name (if it exists) or the activity name (if the page name is not defined).