### PR TITLE
Add API support for plugins to send custom messages to interactives

### DIFF
--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -41,3 +41,33 @@ context("Test the overall app", () => {
     });
   });
 });
+
+context("Test the teacher edition plugin", () => {
+  describe("text page 1 teacher edition features", () => {
+    before(() => {
+      cy.visit("?mode=teacher-edition&activity=sample-activity-plugins");
+      cy.wait(1000);
+      activityPage.getPage(1).click();
+    });
+    it("should show teacher edition banner", () => {
+      cy.get(".teacher-edition-banner").should("be.visible");
+    });
+    it("should have the right number of decorated interactives and window shades", () => {
+      cy.get(".question-wrapper--questionWrapper--TETipsPluginV1").should("have.length", 3);
+      cy.get(".window-shade--windowShade--TETipsPluginV1").should("have.length", 1);
+    });
+  });
+  describe("text page 2 teacher edition features", () => {
+    before(() => {
+      cy.visit("?mode=teacher-edition&activity=sample-activity-plugins");
+      cy.wait(1000);
+      activityPage.getPage(2).click();
+    });
+    it("should show teacher edition banner", () => {
+      cy.get(".teacher-edition-banner").should("be.visible");
+    });
+    it("should have the right number of window shades", () => {
+      cy.get(".window-shade--windowShade--TETipsPluginV1").should("have.length", 4);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22056,6 +22056,12 @@
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
+    "utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "dev": true
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2",
     "url-loader": "^4.1.0",
+    "utility-types": "^3.10.0",
     "wait-on": "^5.2.0",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -19,9 +19,11 @@ describe("IframeRuntime component", () => {
         authoredState={null}
         initialInteractiveState={null}
         setInteractiveState={stubFunction}
+        setSupportedFeatures={stubFunction}
         setNewHint={stubFunction}
         getFirebaseJWT={firebaseJWTStub}
         toggleModal={stubFunction}
+        setSendCustomMessage={stubFunction}
       />);
     expect(getByTestId("iframe-runtime")).toBeDefined();
   });

--- a/src/components/activity-page/managed-interactive/managed-interactive.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.test.tsx
@@ -52,7 +52,13 @@ describe("ManagedInteractive component", () => {
       type: "ManagedInteractive",
       ref_id: "314-ManagedInteractive"
     };
-    const wrapper = shallow(<ManagedInteractive embeddable={sampleEmbeddable} initialInteractiveState={null} questionNumber={1} />);
+    const wrapper = shallow(<ManagedInteractive
+                              embeddable={sampleEmbeddable}
+                              initialInteractiveState={null}
+                              questionNumber={1}
+                              setSupportedFeatures={() => { /* nop */ }}
+                              setSendCustomMessage={() => { /* nop */ }}
+                              />);
     expect(wrapper.find('[data-cy="managed-interactive"]').length).toBe(1);
   });
 });

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useContext, useMemo, useRef } from "react
 import Modal from "react-modal";
 import { IframeRuntime } from "./iframe-runtime";
 import useResizeObserver from "@react-hook/resize-observer";
-import { IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
+import { ICustomMessage, IRuntimeMetadata, ISupportedFeatures } from "@concord-consortium/lara-interactive-api";
 import { PortalDataContext } from "../../portal-data-context";
 import { IManagedInteractive, IMwInteractive, LibraryInteractiveData, IExportableAnswerMetadata } from "../../../types";
 import { createOrUpdateAnswer } from "../../../firebase-db";
@@ -21,6 +21,8 @@ interface IProps {
   questionNumber?: number;
   initialInteractiveState: any;     // user state that existed in DB when embeddable was first loaded
   initialAnswerMeta?: IExportableAnswerMetadata;   // saved metadata for that initial user state
+  setSupportedFeatures: (container: HTMLElement, features: ISupportedFeatures) => void;
+  setSendCustomMessage: (sender: (message: ICustomMessage) => void) => void;
 }
 
 const kDefaultAspectRatio = 4 / 3;
@@ -42,7 +44,7 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
       return handleGetFirebaseJWT({ firebase_app: firebaseApp, ...others }, portalData);
     }, [portalData]);
 
-    const { embeddable, questionNumber, initialInteractiveState } = props;
+    const { embeddable, questionNumber, initialInteractiveState, setSupportedFeatures, setSendCustomMessage } = props;
     const { authored_state } = embeddable;
     const [showModal, setShowModal] = useState(false);
     // both Modal and inline versions of interactive should reflect the same state
@@ -123,12 +125,14 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
         authoredState={authoredState}
         initialInteractiveState={iframeInteractiveState.current}
         setInteractiveState={handleNewInteractiveState}
+        setSupportedFeatures={setSupportedFeatures}
         linkedInteractives={linkedInteractives.current}
         proposedHeight={proposedHeight}
         containerWidth={containerWidth}
         setNewHint={setNewHint}
         getFirebaseJWT={getFirebaseJWT}
         toggleModal={toggleModal}
+        setSendCustomMessage={setSendCustomMessage}
       />;
 
     return (

--- a/src/components/activity-page/plugins/embeddable-plugin.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.tsx
@@ -1,6 +1,8 @@
-import React, { useRef, useEffect } from "react";
+import React, { useContext, useEffect, useRef } from "react";
 import { IEmbeddablePlugin } from "../../../types";
-import { initializePlugin } from "../../../utilities/plugin-utils";
+import { initializePlugin, IPartialEmbeddablePluginContext, validateEmbeddablePluginContextForPlugin
+        } from "../../../utilities/plugin-utils";
+import { LaraGlobalContext } from "../../lara-global-context";
 
 import "./embeddable-plugin.scss";
 
@@ -11,11 +13,18 @@ interface IProps {
 export const EmbeddablePlugin: React.FC<IProps> = (props) => {
     const { embeddable } = props;
     const divTarget = useRef<HTMLInputElement>(null);
+    const LARA = useContext(LaraGlobalContext);
     useEffect(() => {
-      if (divTarget.current && embeddable) {
-        initializePlugin(embeddable, undefined, divTarget.current, undefined);
+      const pluginContext: IPartialEmbeddablePluginContext = {
+        LARA,
+        embeddable,
+        embeddableContainer: divTarget.current || undefined
+      };
+      const validPluginContext = validateEmbeddablePluginContextForPlugin(pluginContext);
+      if (validPluginContext) {
+        initializePlugin(validPluginContext);
       }
-    }, [embeddable]);
+    }, [LARA, embeddable]);
     return (
       <div className="plugin-container" ref={divTarget} data-cy="embeddable-plugin" key={embeddable.ref_id} />
     );

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -15,7 +15,8 @@ import { queryValue, queryValueBoolean } from "../utilities/url-query";
 import { fetchPortalData, IPortalData } from "../portal-api";
 import { signInWithToken, watchAnswers, initializeDB, setPortalData, initializeAnonymousDB } from "../firebase-db";
 import { Activity } from "../types";
-import { createPluginNamespace } from "../lara-plugin/index";
+import { initializeLara, LaraGlobalType } from "../lara-plugin/index";
+import { LaraGlobalContext } from "./lara-global-context";
 import { loadPluginScripts } from "../utilities/plugin-utils";
 import { TeacherEditionBanner }  from "./teacher-edition-banner";
 
@@ -34,6 +35,8 @@ interface IState {
 interface IProps {}
 
 export class App extends React.PureComponent<IProps, IState> {
+
+  private LARA: LaraGlobalType;
 
   public constructor(props: IProps) {
     super(props);
@@ -79,8 +82,8 @@ export class App extends React.PureComponent<IProps, IState> {
       this.setState(newState as IState);
 
       if (teacherEditionMode) {
-        createPluginNamespace();
-        loadPluginScripts(activity);
+        this.LARA = initializeLara();
+        loadPluginScripts(this.LARA, activity);
       }
 
     } catch (e) {
@@ -90,14 +93,16 @@ export class App extends React.PureComponent<IProps, IState> {
 
   render() {
     return (
-      <PortalDataContext.Provider value={this.state.portalData}>
-        <div className="app">
-          <WarningBanner/>
-          { this.state.teacherEditionMode && <TeacherEditionBanner/>}
-          { this.renderActivity() }
-          { this.state.showThemeButtons && <ThemeButtons/>}
-        </div>
-      </PortalDataContext.Provider>
+      <LaraGlobalContext.Provider value={this.LARA}>
+        <PortalDataContext.Provider value={this.state.portalData}>
+          <div className="app">
+            <WarningBanner/>
+            { this.state.teacherEditionMode && <TeacherEditionBanner/>}
+            { this.renderActivity() }
+            { this.state.showThemeButtons && <ThemeButtons/>}
+          </div>
+        </PortalDataContext.Provider>
+      </LaraGlobalContext.Provider>
     );
   }
 

--- a/src/components/lara-global-context.ts
+++ b/src/components/lara-global-context.ts
@@ -1,0 +1,5 @@
+import React from "react";
+import { LaraGlobalType } from "../lara-plugin";
+
+export const LaraGlobalContext = React.createContext<LaraGlobalType | undefined>(undefined);
+LaraGlobalContext.displayName = "LaraGlobalContext";

--- a/src/lara-plugin/.eslintrc.js
+++ b/src/lara-plugin/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
       "@typescript-eslint/ban-ts-comment": "off",
       "@typescript-eslint/no-non-null-assertion": "off",
       "@typescript-eslint/prefer-optional-chain": "off",
-      "no-console": ["warn", { allow: ["warn", "error", "group", "groupEnd", "dir", "info"] }],
+      "no-console": "off",
       "no-duplicate-imports": "off",
       "no-debugger": "error",
       "prefer-object-spread": "off"

--- a/src/lara-plugin/events/index.spec.ts
+++ b/src/lara-plugin/events/index.spec.ts
@@ -1,5 +1,5 @@
 import * as events from "./index";
-import { IInteractiveAvailableEvent } from "./index";
+import { IInteractiveAvailableEvent, IInteractiveSupportedFeaturesEvent } from "./index";
 
 describe("Events helper", () => {
   describe("Log event", () => {
@@ -24,6 +24,19 @@ describe("Events helper", () => {
       expect(handler).toHaveBeenNthCalledWith(1, e);
       events.offInteractiveAvailable(handler);
       events.emitInteractiveAvailable(e);
+      expect(handler).toHaveBeenNthCalledWith(1, e);
+    });
+  });
+
+  describe("InteractiveSupportedFeatures event", () => {
+    it("provides working API for event handling", () => {
+      const handler = jest.fn();
+      events.onInteractiveSupportedFeatures(handler);
+      const e: IInteractiveSupportedFeaturesEvent = { container: document.createElement("div"), supportedFeatures: {} };
+      events.emitInteractiveSupportedFeatures(e);
+      expect(handler).toHaveBeenNthCalledWith(1, e);
+      events.offInteractiveSupportedFeatures(handler);
+      events.emitInteractiveSupportedFeatures(e);
       expect(handler).toHaveBeenNthCalledWith(1, e);
     });
   });

--- a/src/lara-plugin/events/index.ts
+++ b/src/lara-plugin/events/index.ts
@@ -1,3 +1,4 @@
+import { ISupportedFeatures } from "@concord-consortium/lara-interactive-api";
 import { EventEmitter2 } from "eventemitter2";
 
 /**
@@ -35,6 +36,25 @@ export interface IInteractiveAvailableEvent {
  */
 export type IInteractiveAvailableEventHandler = (event: IInteractiveAvailableEvent) => void;
 
+/**
+ * Data passed to InteractiveSupportedFeatures event handlers.
+ */
+export interface IInteractiveSupportedFeaturesEvent {
+  /**
+   * Interactive container of the interactive that was just started.
+   */
+  container: HTMLElement;
+  /**
+   * Supported features
+   */
+  supportedFeatures: ISupportedFeatures;
+}
+
+/**
+ * SupportedFeatures event handler.
+ */
+export type IInteractiveSupportedFeaturesEventHandler = (event: IInteractiveSupportedFeaturesEvent) => void;
+
 const emitter = new EventEmitter2({
   maxListeners: Infinity
 });
@@ -57,4 +77,14 @@ export const onInteractiveAvailable = (handler: IInteractiveAvailableEventHandle
 };
 export const offInteractiveAvailable = (handler: IInteractiveAvailableEventHandler) => {
   emitter.off("interactiveAvailable", handler);
+};
+
+export const emitInteractiveSupportedFeatures = (event: IInteractiveSupportedFeaturesEvent) => {
+  emitter.emit("interactiveSupportedFeatures", event);
+};
+export const onInteractiveSupportedFeatures = (handler: IInteractiveSupportedFeaturesEventHandler) => {
+  emitter.on("interactiveSupportedFeatures", handler);
+};
+export const offInteractiveSupportedFeatures = (handler: IInteractiveSupportedFeaturesEventHandler) => {
+  emitter.off("interactiveSupportedFeatures", handler);
 };

--- a/src/lara-plugin/index.ts
+++ b/src/lara-plugin/index.ts
@@ -3,27 +3,44 @@
 import * as PluginAPI from "./plugin-api";
 // LARA_CODE import * as InteractiveAPI from "./interactive-api-parent";
 import * as Plugins from "./plugins";
-// LARA_CODE import * as Events from "./events";
+import * as Events from "./events";
 // LARA_CODE import * as PageItemAuthoring from "./page-item-authoring";
 
-export {
-  PluginAPI as PluginAPI_V3,
-  // LARA_CODE InteractiveAPI,
-  Plugins,
-  // LARA_CODE Events,
-  // LARA_CODE PageItemAuthoring
-};
+export interface LaraGlobalType {
+  PluginAPI_V3: typeof PluginAPI;
+  Plugins: typeof Plugins;
+  Events: typeof Events;
+}
+
+// export {
+//   PluginAPI as PluginAPI_V3,
+//   // LARA_CODE InteractiveAPI,
+//   Plugins,
+//   // LARA_CODE Events,
+//   // LARA_CODE PageItemAuthoring
+// };
+
+export function initializeLara(): LaraGlobalType {
+  const LARA: LaraGlobalType = {
+    PluginAPI_V3: PluginAPI,
+    Plugins,
+    Events
+  };
+  // plugins require this global
+  (window as any).LARA = LARA;
+  return LARA;
+}
 
 // ACTIVITY_PLAYER_CODE: wrap namespace creation into function createPluginNamespace
-export const createPluginNamespace = () => {
-  // add empty LARA namespace to window
-  (window as any).LARA = {};
+// export const createPluginNamespace = () => {
+//   // add empty LARA namespace to window
+//   (window as any).LARA = {};
 
-  // Note that LARA namespace is defined for the first time by V2 API. Once V2 is removed, this code should also be
-  // removed and "library": "LARA" option in webpack.config.js should be re-enabled.
-  (window as any).LARA.PluginAPI_V3 = PluginAPI;
-  (window as any).LARA.Plugins = Plugins;
-  // LARA_CODE (window as any).LARA.Events = Events;
-  // LARA_CODE (window as any).LARA.InteractiveAPI = InteractiveAPI;
-  // LARA_CODE (window as any).LARA.PageItemAuthoring = PageItemAuthoring;
-};
+//   // Note that LARA namespace is defined for the first time by V2 API. Once V2 is removed, this code should also be
+//   // removed and "library": "LARA" option in webpack.config.js should be re-enabled.
+//   (window as any).LARA.PluginAPI_V3 = PluginAPI;
+//   (window as any).LARA.Plugins = Plugins;
+//   // LARA_CODE (window as any).LARA.Events = Events;
+//   // LARA_CODE (window as any).LARA.InteractiveAPI = InteractiveAPI;
+//   // LARA_CODE (window as any).LARA.PageItemAuthoring = PageItemAuthoring;
+// };

--- a/src/lara-plugin/index.ts
+++ b/src/lara-plugin/index.ts
@@ -12,35 +12,24 @@ export interface LaraGlobalType {
   Events: typeof Events;
 }
 
-// export {
-//   PluginAPI as PluginAPI_V3,
-//   // LARA_CODE InteractiveAPI,
-//   Plugins,
-//   // LARA_CODE Events,
-//   // LARA_CODE PageItemAuthoring
-// };
+export {
+  PluginAPI as PluginAPI_V3,
+  // LARA_CODE InteractiveAPI,
+  Plugins,
+  Events,
+  // LARA_CODE PageItemAuthoring
+};
 
+// Note that LARA namespace is defined for the first time by V2 API. Once V2 is removed, this code should also be
+// removed and "library": "LARA" option in webpack.config.js should be re-enabled.
+(window as any).LARA || ((window as any).LARA = {});  // create if it doesn't exist
+(window as any).LARA.PluginAPI_V3 = PluginAPI;
+(window as any).LARA.Plugins = Plugins;
+(window as any).LARA.Events = Events;
+// LARA_CODE (window as any).LARA.InteractiveAPI = InteractiveAPI;
+// LARA_CODE (window as any).LARA.PageItemAuthoring = PageItemAuthoring;
+
+// for clients that don't require LARA to be a global on window
 export function initializeLara(): LaraGlobalType {
-  const LARA: LaraGlobalType = {
-    PluginAPI_V3: PluginAPI,
-    Plugins,
-    Events
-  };
-  // plugins require this global
-  (window as any).LARA = LARA;
-  return LARA;
+  return (window as any).LARA;
 }
-
-// ACTIVITY_PLAYER_CODE: wrap namespace creation into function createPluginNamespace
-// export const createPluginNamespace = () => {
-//   // add empty LARA namespace to window
-//   (window as any).LARA = {};
-
-//   // Note that LARA namespace is defined for the first time by V2 API. Once V2 is removed, this code should also be
-//   // removed and "library": "LARA" option in webpack.config.js should be re-enabled.
-//   (window as any).LARA.PluginAPI_V3 = PluginAPI;
-//   (window as any).LARA.Plugins = Plugins;
-//   // LARA_CODE (window as any).LARA.Events = Events;
-//   // LARA_CODE (window as any).LARA.InteractiveAPI = InteractiveAPI;
-//   // LARA_CODE (window as any).LARA.PageItemAuthoring = PageItemAuthoring;
-// };

--- a/src/lara-plugin/plugin-api/types.ts
+++ b/src/lara-plugin/plugin-api/types.ts
@@ -1,8 +1,6 @@
-import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
 import { ILogData, IInteractiveAvailableEventHandler, IInteractiveSupportedFeaturesEventHandler } from "../events";
-// ACTIVITY_PLAYER_CODE:
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { IPortalClaims, IJwtClaims, IJwtResponse } from "../shared/types";
+import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
+import { IJwtResponse } from "../shared/types";
 
 // Export some shared types.
 export { IPortalClaims, IJwtClaims, IJwtResponse } from "../shared/types";

--- a/src/lara-plugin/plugin-api/types.ts
+++ b/src/lara-plugin/plugin-api/types.ts
@@ -1,4 +1,5 @@
-import { ILogData, IInteractiveAvailableEventHandler } from "../events";
+import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
+import { ILogData, IInteractiveAvailableEventHandler, IInteractiveSupportedFeaturesEventHandler } from "../events";
 // ACTIVITY_PLAYER_CODE:
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { IPortalClaims, IJwtClaims, IJwtResponse } from "../shared/types";
@@ -115,6 +116,19 @@ export interface IEmbeddableRuntimeContext {
   onInteractiveAvailable: (handler: IInteractiveAvailableEventHandler) => void;
   /** True if the interactive is immediately available */
   interactiveAvailable: boolean;
+  /****************************************************************************
+   Function that subscribes provided handler to event that gets called when the interactive's supported features are
+   are available.
+
+   @param handler Event handler function.
+   ****************************************************************************/
+  onInteractiveSupportedFeatures: (handler: IInteractiveSupportedFeaturesEventHandler) => void;
+  /****************************************************************************
+   Function that sends a custom message to the embeddable.
+
+   @param message The message to be sent
+   ****************************************************************************/
+  sendCustomMessage: (message: ICustomMessage) => void;
 }
 
 export interface IPluginAuthoringContext {

--- a/src/lara-plugin/plugins/embeddable-runtime-context.spec.ts
+++ b/src/lara-plugin/plugins/embeddable-runtime-context.spec.ts
@@ -1,6 +1,6 @@
 import { generateEmbeddableRuntimeContext } from "./embeddable-runtime-context";
 import { IInteractiveState } from "../plugin-api";
-import { emitInteractiveAvailable } from "../events";
+import { emitInteractiveAvailable, emitInteractiveSupportedFeatures } from "../events";
 // ACTIVITY_PLAYER_CODE:
 import fetch from "jest-fetch-mock";
 // LARA_CODE import * as fetch from "jest-fetch-mock";
@@ -130,6 +130,27 @@ describe("Embeddable runtime context helper", () => {
       const event = { container: embeddableContext.container, available: true };
       emitInteractiveAvailable(event);
       expect(handler).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe("#onInteractiveSupportedFeatures", () => {
+    it("accepts handler and calls it when this particular interactive specifies its supported features", () => {
+      const runtimeContext = generateEmbeddableRuntimeContext(embeddableContext);
+      const handler = jest.fn();
+      runtimeContext.onInteractiveSupportedFeatures(handler);
+      // Different container => different interactive. Handler should not be called.
+      emitInteractiveSupportedFeatures({ container: document.createElement("div"), supportedFeatures: {} });
+      expect(handler).toHaveBeenCalledTimes(0);
+      const event = { container: embeddableContext.container, supportedFeatures: {} };
+      emitInteractiveSupportedFeatures(event);
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe("#sendCustomMessage", () => {
+    it("provides sendCustomMessage function", () => {
+      const runtimeContext = generateEmbeddableRuntimeContext(embeddableContext);
+      runtimeContext.sendCustomMessage({ type: "foo", content: { bar: true } });
     });
   });
 });

--- a/src/lara-plugin/plugins/embeddable-runtime-context.ts
+++ b/src/lara-plugin/plugins/embeddable-runtime-context.ts
@@ -2,8 +2,8 @@ import { IEmbeddableRuntimeContext, IInteractiveState } from "../plugin-api";
 import { onInteractiveAvailable, IInteractiveAvailableEvent, IInteractiveAvailableEventHandler,
         onInteractiveSupportedFeatures, IInteractiveSupportedFeaturesEvent, IInteractiveSupportedFeaturesEventHandler
         } from "../events";
-import { IEmbeddableContextOptions } from "./plugin-context";
 import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
+import { IEmbeddableContextOptions } from "./plugin-context";
 
 const getInteractiveState = (interactiveStateUrl: string | null): Promise<IInteractiveState> | null => {
   if (!interactiveStateUrl) {
@@ -31,7 +31,7 @@ const getReportingUrl = (
       return null;
     }
     catch (error) {
-      // LARA_CODE tslint:disable-next-line:no-console
+      // tslint:disable-next-line:no-console
       console.error(error);
       return null;
     }

--- a/src/lara-plugin/plugins/embeddable-runtime-context.ts
+++ b/src/lara-plugin/plugins/embeddable-runtime-context.ts
@@ -1,6 +1,9 @@
 import { IEmbeddableRuntimeContext, IInteractiveState } from "../plugin-api";
-import { onInteractiveAvailable, IInteractiveAvailableEvent, IInteractiveAvailableEventHandler } from "../events";
+import { onInteractiveAvailable, IInteractiveAvailableEvent, IInteractiveAvailableEventHandler,
+        onInteractiveSupportedFeatures, IInteractiveSupportedFeaturesEvent, IInteractiveSupportedFeaturesEventHandler
+        } from "../events";
 import { IEmbeddableContextOptions } from "./plugin-context";
+import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
 
 const getInteractiveState = (interactiveStateUrl: string | null): Promise<IInteractiveState> | null => {
   if (!interactiveStateUrl) {
@@ -50,6 +53,17 @@ export const generateEmbeddableRuntimeContext = (context: IEmbeddableContextOpti
         }
       });
     },
-    interactiveAvailable: context.interactiveAvailable
+    onInteractiveSupportedFeatures: (handler: IInteractiveSupportedFeaturesEventHandler) => {
+      // Add generic listener and filter events to limit them just to this given embeddable.
+      onInteractiveSupportedFeatures((event: IInteractiveSupportedFeaturesEvent) => {
+        if (event.container === context.container) {
+          handler(event);
+        }
+      });
+    },
+    interactiveAvailable: context.interactiveAvailable,
+    sendCustomMessage: (message: ICustomMessage) => {
+      context.sendCustomMessage?.(message);
+    }
   };
 };

--- a/src/lara-plugin/plugins/plugin-context.ts
+++ b/src/lara-plugin/plugins/plugin-context.ts
@@ -2,6 +2,7 @@ import { IPluginRuntimeContext, IJwtResponse, IClassInfo, IPluginAuthoringContex
 import { ILogData } from "../events";
 import { generateEmbeddableRuntimeContext } from "./embeddable-runtime-context";
 // ACTIVITY_PLAYER_CODE:
+import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
 import $ from "jquery";
 // LARA_CODE import * as $ from "jquery";
 
@@ -84,6 +85,8 @@ export interface IEmbeddableContextOptions {
   interactiveStateUrl: string | null;
   /** True if the interactive is immediately available for use */
   interactiveAvailable: boolean;
+  /** Callback function which plugin can use to send custom messages to interactive */
+  sendCustomMessage?: (message: ICustomMessage) => void;
 }
 
 const ajaxPromise = (url: string, data: any): Promise<string> => {

--- a/src/lara-plugin/plugins/plugin-context.ts
+++ b/src/lara-plugin/plugins/plugin-context.ts
@@ -1,8 +1,8 @@
 import { IPluginRuntimeContext, IJwtResponse, IClassInfo, IPluginAuthoringContext } from "../plugin-api";
 import { ILogData } from "../events";
+import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
 import { generateEmbeddableRuntimeContext } from "./embeddable-runtime-context";
 // ACTIVITY_PLAYER_CODE:
-import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
 import $ from "jquery";
 // LARA_CODE import * as $ from "jquery";
 

--- a/src/lara-plugin/plugins/plugins.spec.ts
+++ b/src/lara-plugin/plugins/plugins.spec.ts
@@ -31,7 +31,7 @@ describe("Plugins", () => {
       expect(registerPlugin({runtimeClass, authoringClass})).toEqual(false);
       // @ts-ignore
       expect(registerPlugin("anotherTest")).toEqual(false); // missing constructor
-      // LARA_CODE tslint:disable-next-line:no-console
+      // tslint:disable-next-line:no-console
       expect(console.error).toHaveBeenCalledTimes(2);
     });
 
@@ -120,6 +120,7 @@ describe("Plugins", () => {
       initPlugin("testPlugin2", authoringContextOptions);
       expect(runtimeConstructor).toHaveBeenCalledTimes(1);
       expect(authoringConstructor).toHaveBeenCalledTimes(1);
+      // tslint:disable-next-line:no-console
       expect(console.error).toHaveBeenCalledTimes(2);
     });
   });

--- a/src/lara-plugin/plugins/plugins.ts
+++ b/src/lara-plugin/plugins/plugins.ts
@@ -5,13 +5,13 @@ import {
 } from "./plugin-context";
 
 const pluginError = (e: string, other: any) => {
-  // LARA_CODE tslint:disable-next-line:no-console
+  // tslint:disable-next-line:no-console
   console.group("LARA Plugin Error");
-  // LARA_CODE tslint:disable-next-line:no-console
+  // tslint:disable-next-line:no-console
   console.error(e);
-  // LARA_CODE tslint:disable-next-line:no-console
+  // tslint:disable-next-line:no-console
   console.dir(other);
-  // LARA_CODE tslint:disable-next-line:no-console
+  // tslint:disable-next-line:no-console
   console.groupEnd();
 };
 
@@ -23,7 +23,6 @@ const pluginClasses: { [label: string]: IRegisterPluginOptions } = {};
  * to override the plugin's passed label.  This removes the previous need for the plugin's label to
  * match the label in LARA's database.
  */
-// LARA_CODE let nextPluginLabel: string = "";
 let nextPluginLabel = "";
 export const setNextPluginLabel = (override: string) => {
   nextPluginLabel = override;
@@ -55,10 +54,10 @@ const initRuntimePlugin = (label: string, options: IPluginRuntimeContextOptions)
     } catch (e) {
       pluginError(e, options);
     }
-    // LARA_CODE tslint:disable-next-line:no-console
+    // tslint:disable-next-line:no-console
     console.info("Plugin", label, "is now registered");
   } else {
-    // LARA_CODE tslint:disable-next-line:no-console
+    // tslint:disable-next-line:no-console
     console.error("No plugin registered for label:", label);
   }
 };
@@ -73,10 +72,10 @@ const initAuthoringPlugin = (label: string, options: IPluginAuthoringContextOpti
     } catch (e) {
       pluginError(e, options);
     }
-    // LARA_CODE tslint:disable-next-line:no-console
+    // tslint:disable-next-line:no-console
     console.info("Plugin", label, "is now registered");
   } else {
-    // LARA_CODE tslint:disable-next-line:no-console
+    // tslint:disable-next-line:no-console
     console.error("No plugin registered for label:", label);
   }
 };
@@ -91,19 +90,23 @@ const initAuthoringPlugin = (label: string, options: IPluginAuthoringContextOpti
  ***************************************************************************/
 export const registerPlugin = (options: IRegisterPluginOptions): boolean => {
   if (nextPluginLabel === "") {
+    // tslint:disable-next-line:no-console
     console.error("nextPluginLabel not set via #setNextPluginLabel before plugin loaded!");
     return false;
   }
   const {runtimeClass, authoringClass} = options;
   if (typeof runtimeClass !== "function") {
+    // tslint:disable-next-line:no-console
     console.error("Plugin did not provide a runtime constructor", nextPluginLabel);
     return false;
   }
   if (typeof authoringClass !== "function") {
+    // tslint:disable-next-line:no-console
     console.warn(`Plugin did not provide an authoring constructor. This is ok if "guiAuthoring"
                   is not set for this component.`, nextPluginLabel);
 }
   if (pluginClasses[nextPluginLabel]) {
+    // tslint:disable-next-line:no-console
     console.error("Duplicate Plugin for label", nextPluginLabel);
     return false;
   } else {


### PR DESCRIPTION
- add proper typing for `LARA` globals
- ActivityPlayer references `LARA` globals via `React` context rather than `window.LARA`
- add `onInteractiveSupportedFeatures` and `sendCustomMessage` to `IEmbeddableRuntimeContext`
- add `sendCustomMessage` to `IEmbeddableContextOptions`
- update plugin initialization to use proper types and support `sendCustomMessage`
- `setSupportedFeatures` and `setSendCustomMessage` callbacks managed by `<Embeddable>` => `<ManagedInteractive>` => `<IframeRuntime>`

[[#173989045]](https://www.pivotaltracker.com/story/show/173989045)

[LARA #631](https://github.com/concord-consortium/lara/pull/631) contains the corresponding LARA changes.

Note that while there is no plugin code using these features yet I'm opening up the PR for review so as to get feedback on the implementation of the API and whether there's anything I missed.