### PR TITLE
174286142 sidebar plugin

### DIFF
--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -3,7 +3,6 @@ import { Embeddable } from "./embeddable";
 import { BottomButtons } from "./bottom-buttons";
 import { PageLayouts, EmbeddableSections, isQuestion, getPageSectionQuestionCount,
          VisibleEmbeddables, getVisibleEmbeddablesOnPage, getLinkedPluginEmbeddable } from "../../utilities/activity-utils";
-import { SidebarWrapper } from "../page-sidebar/sidebar-wrapper";
 import { renderHTML } from "../../utilities/render-html";
 import { accessibilityClick } from "../../utilities/accessibility-helper";
 import IconChevronRight from "../../assets/svg-icons/icon-chevron-right.svg";
@@ -81,9 +80,6 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
           onNext={!isLastActivityPage ? this.handleNext : undefined}
           onGenerateReport={enableReportButton ? this.handleReport : undefined}
         />
-        {page.show_sidebar &&
-          <SidebarWrapper sidebars={[{ content: page.sidebar, title: page.sidebar_title }]} />
-        }
       </div>
     );
   }

--- a/src/components/activity-page/plugins/embeddable-plugin-sidetip.test.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin-sidetip.test.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { EmbeddablePluginSideTip } from "./embeddable-plugin-sidetip";
+import { shallow } from "enzyme";
+import { IEmbeddablePlugin } from "../../../types";
+
+describe("Embeddable Sidetip component", () => {
+  it("renders component", () => {
+    const embeddable: IEmbeddablePlugin = {
+      "plugin": {
+        "description": null,
+        "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"this is a sidetip\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
+        "approved_script_label": "teacherEditionTips",
+        "component_label": "sideTip"
+      },
+      "is_hidden": false,
+      "is_full_width": false,
+      "type": "Embeddable::EmbeddablePlugin",
+      "ref_id": "2991-Embeddable::EmbeddablePlugin"
+    };
+    const wrapper = shallow(<EmbeddablePluginSideTip embeddable={embeddable}/>);
+    expect(wrapper.find('[data-cy="embeddable-plugin-sidetip"]').length).toBe(1);
+  });
+});

--- a/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
@@ -18,6 +18,6 @@ export const EmbeddablePluginSideTip: React.FC<IProps> = (props) => {
   }, [embeddable]);
 
   return (
-    <div className="embeddable-plugin-sidetip" ref={embeddableDivTarget} />
+    <div className="embeddable-plugin-sidetip" data-cy="embeddable-plugin-sidetip"  ref={embeddableDivTarget} />
   );
 };

--- a/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
@@ -4,19 +4,18 @@ import { IEmbeddablePlugin } from "../../../types";
 
 interface IProps {
   embeddable: IEmbeddablePlugin;
-  teacherEditionMode?: boolean;
 }
 
 export const EmbeddablePluginSideTip: React.FC<IProps> = (props) => {
-  const { embeddable, teacherEditionMode } = props;
+  const { embeddable } = props;
 
   const embeddableDivTarget = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (embeddableDivTarget.current && teacherEditionMode) {
+    if (embeddableDivTarget.current) {
       initializePlugin(embeddable, undefined, embeddableDivTarget.current, undefined);
     }
-  }, [embeddable, teacherEditionMode]);
+  }, [embeddable]);
 
   return (
     <div className="embeddable-plugin-sidetip" ref={embeddableDivTarget} />

--- a/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
@@ -1,0 +1,24 @@
+import React, { useRef, useEffect }  from "react";
+import { initializePlugin } from "../../../utilities/plugin-utils";
+import { IEmbeddablePlugin } from "../../../types";
+
+interface IProps {
+  embeddable: IEmbeddablePlugin;
+  teacherEditionMode?: boolean;
+}
+
+export const EmbeddablePluginSideTip: React.FC<IProps> = (props) => {
+  const { embeddable, teacherEditionMode } = props;
+
+  const embeddableDivTarget = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (embeddableDivTarget.current && teacherEditionMode) {
+      initializePlugin(embeddable, undefined, embeddableDivTarget.current, undefined);
+    }
+  }, [embeddable, teacherEditionMode]);
+
+  return (
+    <div className="embeddable-plugin-sidetip" ref={embeddableDivTarget} />
+  );
+};

--- a/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
@@ -1,6 +1,7 @@
-import React, { useRef, useEffect }  from "react";
+import React, { useContext, useEffect, useRef }  from "react";
 import { initializePlugin } from "../../../utilities/plugin-utils";
 import { IEmbeddablePlugin } from "../../../types";
+import { LaraGlobalContext } from "../../lara-global-context";
 
 interface IProps {
   embeddable: IEmbeddablePlugin;
@@ -11,11 +12,16 @@ export const EmbeddablePluginSideTip: React.FC<IProps> = (props) => {
 
   const embeddableDivTarget = useRef<HTMLInputElement>(null);
 
+  const LARA = useContext(LaraGlobalContext);
   useEffect(() => {
-    if (embeddableDivTarget.current) {
-      initializePlugin(embeddable, undefined, embeddableDivTarget.current, undefined);
+    if (LARA && embeddableDivTarget.current) {
+      initializePlugin({
+        LARA,
+        embeddable,
+        embeddableContainer: embeddableDivTarget.current
+      });
     }
-  }, [embeddable]);
+  }, [LARA, embeddable]);
 
   return (
     <div className="embeddable-plugin-sidetip" data-cy="embeddable-plugin-sidetip"  ref={embeddableDivTarget} />

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -19,6 +19,7 @@ import { initializeLara, LaraGlobalType } from "../lara-plugin/index";
 import { LaraGlobalContext } from "./lara-global-context";
 import { loadPluginScripts } from "../utilities/plugin-utils";
 import { TeacherEditionBanner }  from "./teacher-edition-banner";
+import { ExpandableContainer } from "./expandable-content/expandable-container";
 
 import "./app.scss";
 
@@ -149,6 +150,14 @@ export class App extends React.PureComponent<IProps, IState> {
           <Footer
             fullWidth={fullWidth}
             projectId={activity.project_id}
+          />
+        }
+        { (activity.layout !== ActivityLayouts.SinglePage && currentPage !== 0 && !activity.pages[currentPage - 1].is_completion) &&
+          <ExpandableContainer
+            activity={activity}
+            pageNumber={currentPage}
+            page={activity.pages.filter((page) => !page.is_hidden)[currentPage - 1]}
+            teacherEditionMode={this.state.teacherEditionMode}
           />
         }
       </React.Fragment>

--- a/src/components/expandable-content/expandable-container.scss
+++ b/src/components/expandable-content/expandable-container.scss
@@ -1,0 +1,108 @@
+@import "../vars.scss";
+
+.expandable-container {
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+
+.sidebar-mod {
+  position: fixed;
+  text-align: left;
+  background-color: #fff;
+  opacity: 0;
+  z-index: 1000;
+
+  @media screen and (min-width: 1024px) {
+    right: -800px;
+    width: 800px;
+  }
+
+  transition: 0.4s right,
+              0.4s z-index,
+              1.0s opacity,
+              0.20s 0.05s ease box-shadow;
+
+  &.visible {
+    opacity: 1;
+  }
+
+  &.expanded {
+    right: 0 !important;
+    z-index: 2000;
+
+    box-shadow: -3px 2px 15px rgba(0, 0, 0, 0.3),
+                0 0 0 8000px rgba(68, 68, 68, 0.1),
+                0 0 0 8000px rgba(255, 255, 255, 0.7);
+
+  }
+}
+
+.sidebar-hdr {
+  cursor: pointer;
+  min-height: 79px;
+  text-align: center;
+  padding: 8px;
+  position: absolute;
+  width: 85px;
+  left: -85px;
+  box-sizing: border-box;
+
+  &:hover {
+    box-shadow: -2px 2px 10px rgba(0, 0, 0, 0.3);
+  }
+
+  .h5 {
+    // text-transform: uppercase;
+    text-transform: none;
+    color: #fff;
+    font-size: 14px;
+    line-height: 1.15;
+    margin: 0;
+    margin-top: 0.2em;
+  }
+}//sidebar-hdr
+
+.sidebar-bd {
+  overflow: hidden;
+  font-size: 16px;
+  background-color: transparent;
+
+  .h4 {
+    font-size: 24px;
+    font-weight: 400;
+    margin-bottom: 14px;
+  }
+
+  .sidebar-content {
+    overflow: auto;
+    min-height: 100px;
+  }
+
+  .title-bar {
+    color: #fff;
+    font-size: 20px;
+    padding: 7px;
+    text-align: center;
+  }
+}
+
+.sidebar-bd-close {
+  position: absolute;
+  top: 9px;
+  right: 9px;
+  height: 25px;
+  width: 25px;
+  padding: 0;
+  border: none;
+  background: url(../../assets/svg-icons/icon-close.svg);
+  background-repeat: no-repeat;
+  cursor: pointer;
+  background-color: transparent;
+}
+
+.default-icon {
+  font-size: 24px;
+  color: #fff;
+  opacity:0.7;
+}

--- a/src/components/expandable-content/expandable-container.test.tsx
+++ b/src/components/expandable-content/expandable-container.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ExpandableContainer } from "./expandable-container";
+import { shallow } from "enzyme";
+import { Activity } from "../../types";
+import { SidebarWrapper } from "../page-sidebar/sidebar-wrapper";
+import { EmbeddablePluginSideTip } from "../activity-page/plugins/embeddable-plugin-sidetip";
+import _activityPlugins from "../../data/sample-activity-plugins.json";
+
+const activityPlugins = _activityPlugins as Activity;
+
+describe("Expandable container component", () => {
+  it("renders component", () => {
+    const wrapper = shallow(<ExpandableContainer activity={activityPlugins} page={activityPlugins.pages[0]} pageNumber={1} teacherEditionMode={true} />);
+    expect(wrapper.find('[data-cy="expandable-container"]').length).toBe(1);
+  });
+  it("renders component content", () => {
+    const wrapper = shallow(<ExpandableContainer activity={activityPlugins} page={activityPlugins.pages[2]} pageNumber={3} teacherEditionMode={true} />);
+    expect(wrapper.find('[data-cy="expandable-container"]').length).toBe(1);
+    expect(wrapper.find('[data-cy="expandable-container"]').length).toBe(1);
+    expect(wrapper.find('[data-cy="expandable-container"]').length).toBe(1);
+    expect(wrapper.find(SidebarWrapper).length).toBe(1);
+    expect(wrapper.find(EmbeddablePluginSideTip).length).toBe(2);
+  });
+});

--- a/src/components/expandable-content/expandable-container.tsx
+++ b/src/components/expandable-content/expandable-container.tsx
@@ -23,7 +23,7 @@ export const ExpandableContainer: React.FC<IProps> = (props) => {
   const verticalOffset = kExpandableContentTop + sideTips.length * (kExpandableItemHeight + kExpandableContentMargin);
   const sidebars = getPageSideBars(activity, page);
   return (
-    <div className="expandable-container" id="expandable-container" key={pageNumber}>
+    <div className="expandable-container" id="expandable-container" key={pageNumber} data-cy="expandable-container">
       { teacherEditionMode && sideTips.map((sideTip: any) =>
           <EmbeddablePluginSideTip
             key={sideTip.embeddable.ref_id}

--- a/src/components/expandable-content/expandable-container.tsx
+++ b/src/components/expandable-content/expandable-container.tsx
@@ -1,0 +1,39 @@
+import React  from "react";
+import { Page, Activity } from "../../types";
+import { SidebarWrapper } from "../page-sidebar/sidebar-wrapper";
+import { EmbeddablePluginSideTip } from "../activity-page/plugins/embeddable-plugin-sidetip";
+import { getPageSideTipEmbeddables, getPageSideBars } from "../../utilities/activity-utils";
+
+import "./expandable-container.scss";
+
+const kExpandableContentMargin = 19;
+const kExpandableItemHeight = 79;
+
+interface IProps {
+  activity: Activity;
+  page: Page;
+  pageNumber: number;
+  teacherEditionMode?: boolean;
+}
+
+export const ExpandableContainer: React.FC<IProps> = (props) => {
+  const { activity, page, pageNumber, teacherEditionMode } = props;
+  const activityHeader = document.getElementsByClassName("activity-header");
+  const contentTopPosition = activityHeader[0].getBoundingClientRect().top;
+  const sideTips = getPageSideTipEmbeddables(page);
+  const verticalOffset = contentTopPosition + sideTips.length * (kExpandableItemHeight + kExpandableContentMargin);
+  const sidebars = getPageSideBars(activity, page);
+  return (
+    <div className="expandable-container" id="expandable-container" key={pageNumber}>
+      { teacherEditionMode && sideTips.map((sideTip: any) =>
+          <EmbeddablePluginSideTip
+            key={sideTip.embeddable.ref_id}
+            embeddable={sideTip.embeddable}
+          />)
+      }
+      { sidebars.length > 0 &&
+        <SidebarWrapper sidebars={sidebars} verticalOffset={verticalOffset} />
+      }
+    </div>
+  );
+};

--- a/src/components/expandable-content/expandable-container.tsx
+++ b/src/components/expandable-content/expandable-container.tsx
@@ -6,6 +6,7 @@ import { getPageSideTipEmbeddables, getPageSideBars } from "../../utilities/acti
 
 import "./expandable-container.scss";
 
+const kExpandableContentTop = 152;
 const kExpandableContentMargin = 19;
 const kExpandableItemHeight = 79;
 
@@ -18,10 +19,8 @@ interface IProps {
 
 export const ExpandableContainer: React.FC<IProps> = (props) => {
   const { activity, page, pageNumber, teacherEditionMode } = props;
-  const activityHeader = document.getElementsByClassName("activity-header");
-  const contentTopPosition = activityHeader[0].getBoundingClientRect().top;
   const sideTips = getPageSideTipEmbeddables(page);
-  const verticalOffset = contentTopPosition + sideTips.length * (kExpandableItemHeight + kExpandableContentMargin);
+  const verticalOffset = kExpandableContentTop + sideTips.length * (kExpandableItemHeight + kExpandableContentMargin);
   const sidebars = getPageSideBars(activity, page);
   return (
     <div className="expandable-container" id="expandable-container" key={pageNumber}>

--- a/src/components/page-sidebar/sidebar-panel.scss
+++ b/src/components/page-sidebar/sidebar-panel.scss
@@ -21,8 +21,7 @@
       fill: white;
       width: 24px;
       height: 18px;
-      position: relative;
-      right: 30px;
+      margin-right: 9px;
       border-radius: 5px;
       cursor: pointer;
 

--- a/src/components/page-sidebar/sidebar-tab.scss
+++ b/src/components/page-sidebar/sidebar-tab.scss
@@ -5,14 +5,14 @@
   width: 75px;
   min-height: 70px;
   text-align: center;
-  padding: 8px;
+  padding: 5px;
   border-radius: 3px 0 0 3px;
   background-color: $cc-orange-light1;
   fill: white;
   display: flex;
   flex-direction: column;
   justify-items: center;
-  left: -91px;
+  left: -85px;
   position: absolute;
 
   &:hover {
@@ -36,7 +36,7 @@
       transform: rotate(180deg);
     }
   }
-  
+
   .tab-name {
     color: white;
     font-weight: normal;

--- a/src/components/page-sidebar/sidebar-wrapper.test.tsx
+++ b/src/components/page-sidebar/sidebar-wrapper.test.tsx
@@ -6,7 +6,7 @@ import { shallow } from "enzyme";
 describe("Sidebar Container component", () => {
   it("renders container component", () => {
     const sidebars: SidebarConfiguration[] = [{content: "sidebar", title: "sidebar1"}, {content: "sidebar", title: "sidebar2"}];
-    const wrapper = shallow(<SidebarWrapper sidebars={sidebars}/>);
+    const wrapper = shallow(<SidebarWrapper sidebars={sidebars} verticalOffset={200} />);
     expect(wrapper.find(Sidebar).length).toBe(2);
   });
 });

--- a/src/components/page-sidebar/sidebar-wrapper.tsx
+++ b/src/components/page-sidebar/sidebar-wrapper.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Sidebar } from "./sidebar";
 
-const kSidebarTop = 200;
 const kSidebarOffset = 100;
 
 export interface SidebarConfiguration {
@@ -11,6 +10,7 @@ export interface SidebarConfiguration {
 
 interface IProps {
   sidebars: SidebarConfiguration[];
+  verticalOffset: number;
 }
 
 interface IState {
@@ -23,7 +23,7 @@ export class SidebarWrapper extends React.PureComponent<IProps, IState> {
     this.state = { showSidebarContent: new Array(props.sidebars.length).fill(false) };
   }
   render() {
-    const { sidebars } = this.props;
+    const { sidebars, verticalOffset } = this.props;
     return (
       <React.Fragment>
         {sidebars.map((sidebar: SidebarConfiguration, index: number) => (
@@ -33,7 +33,7 @@ export class SidebarWrapper extends React.PureComponent<IProps, IState> {
             handleShowSidebar={this.setShowSidebarContent}
             index={index}
             show={this.state.showSidebarContent[index]}
-            style={{ top: kSidebarTop + kSidebarOffset * index}}
+            style={{ top: verticalOffset + kSidebarOffset * index}}
             title={sidebar.title}
           />
         ))}

--- a/src/components/page-sidebar/sidebar.scss
+++ b/src/components/page-sidebar/sidebar.scss
@@ -6,7 +6,7 @@
   align-items: flex-start;
   position: fixed;
   top: 200px;
-  right: -490px;
+  right: -500px;
   border-radius: 0 0 0 8px;
   width: 500px;
   transition: 0.4s right, 0.4s z-index, 1.0s opacity, 0.20s 0.05s ease box-shadow;

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { ActivityLayouts, PageLayouts, isQuestion, VisibleEmbeddables, getVisibleEmbeddablesOnPage } from "../../utilities/activity-utils";
 import { Embeddable } from "../activity-page/embeddable";
-import { SidebarWrapper, SidebarConfiguration } from "../page-sidebar/sidebar-wrapper";
 import { RelatedContent } from "./related-content";
 import { SubmitButton } from "./submit-button";
 
@@ -44,15 +43,6 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
     );
   };
 
-  const renderSidebars = () => {
-    const sidebars: SidebarConfiguration[] = activity.pages.filter((page) => page.show_sidebar).map((page) => (
-      {content: page.sidebar, title: page.sidebar_title }
-    ));
-    return (
-      <SidebarWrapper sidebars={sidebars}/>
-    );
-  };
-
   return (
     <div className="single-page-content" data-cy="single-page-content">
       {activity.pages.filter((page) => !page.is_hidden).map((page, index: number) => (
@@ -60,7 +50,6 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
       ))}
       { activity.related && <RelatedContent relatedContentText={activity.related} /> }
       { activity.show_submit_button && <SubmitButton/> }
-      { renderSidebars() }
     </div>
   );
 };

--- a/src/data/sample-activity-plugins.json
+++ b/src/data/sample-activity-plugins.json
@@ -31,6 +31,18 @@
       "embeddables": [
         {
           "embeddable": {
+            "content": "<p>This page contains:</p>\r\n<ul>\r\n<li>3 questions with TE wrappers showing each wrapper location</li>\r\n<li>mc question with hint</li>\r\n<li>window shade</li>\r\n<li>side tip</li>\r\n</ul>",
+            "is_callout": false,
+            "is_full_width": true,
+            "is_hidden": false,
+            "name": "",
+            "type": "Embeddable::Xhtml",
+            "ref_id": "272135-Embeddable::Xhtml"
+          },
+          "section": "header_block"
+        },
+        {
+          "embeddable": {
             "plugin": {
               "description": null,
               "author_data": "{\"tipType\":\"questionWrapper\",\"questionWrapper\":{\"correctExplanation\":\"correct\",\"distractorsExplanation\":\"distractor\",\"exemplar\":\"this is an exemplar\",\"teacherTip\":\"this is a teacher tip with top location\",\"teacherTipImageOverlay\":\"\",\"location\":\"top\"}}",
@@ -123,7 +135,8 @@
               }
             },
             "type": "ManagedInteractive",
-            "ref_id": "413-ManagedInteractive"
+            "ref_id": "413-ManagedInteractive",
+            "linked_interactives": []
           },
           "section": null
         },
@@ -173,7 +186,8 @@
               }
             },
             "type": "ManagedInteractive",
-            "ref_id": "414-ManagedInteractive"
+            "ref_id": "414-ManagedInteractive",
+            "linked_interactives": []
           },
           "section": null
         },
@@ -223,7 +237,8 @@
               }
             },
             "type": "ManagedInteractive",
-            "ref_id": "415-ManagedInteractive"
+            "ref_id": "415-ManagedInteractive",
+            "linked_interactives": []
           },
           "section": null
         },
@@ -233,7 +248,7 @@
             "url_fragment": null,
             "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}],\"prompt\":\"<p>this MC has a hint</p>\",\"hint\":\"<p>I&#x27;m a hint</p>\"}",
             "is_hidden": false,
-            "is_full_width": false,
+            "is_full_width": true,
             "show_in_featured_question_report": true,
             "inherit_aspect_ratio_method": true,
             "custom_aspect_ratio_method": "DEFAULT",
@@ -273,7 +288,8 @@
               }
             },
             "type": "ManagedInteractive",
-            "ref_id": "406-ManagedInteractive"
+            "ref_id": "406-ManagedInteractive",
+            "linked_interactives": []
           },
           "section": null
         },
@@ -306,17 +322,6 @@
             "ref_id": "2992-Embeddable::EmbeddablePlugin"
           },
           "section": null
-        },
-        {
-          "embeddable": {
-            "content": "<p>this page contains:</p>\r\n<ul>\r\n<li>3 questions with TE wrappers showing each wrapper location</li>\r\n<li>mc question with hint</li>\r\n<li>window shade</li>\r\n<li>side tip</li>\r\n</ul>",
-            "is_full_width": true,
-            "is_hidden": false,
-            "name": "",
-            "type": "Embeddable::Xhtml",
-            "ref_id": "272135-Embeddable::Xhtml"
-          },
-          "section": "header_block"
         }
       ]
     },
@@ -336,6 +341,18 @@
       "sidebar_title": "Did you know?",
       "toggle_info_assessment": false,
       "embeddables": [
+        {
+          "embeddable": {
+            "content": "<p>This page contains 4 window shade plugins</p>",
+            "is_callout": false,
+            "is_full_width": true,
+            "is_hidden": false,
+            "name": "",
+            "type": "Embeddable::Xhtml",
+            "ref_id": "272138-Embeddable::Xhtml"
+          },
+          "section": "header_block"
+        },
         {
           "embeddable": {
             "plugin": {
@@ -395,17 +412,143 @@
             "ref_id": "2996-Embeddable::EmbeddablePlugin"
           },
           "section": null
-        },
+        }
+      ]
+    },
+    {
+      "additional_sections": {},
+      "embeddable_display_mode": "stacked",
+      "is_completion": false,
+      "is_hidden": false,
+      "layout": "l-6040",
+      "name": null,
+      "position": 3,
+      "show_header": true,
+      "show_info_assessment": true,
+      "show_interactive": true,
+      "show_sidebar": true,
+      "sidebar": "<p>This is a page sidebar.</p>",
+      "sidebar_title": "Did you know?",
+      "toggle_info_assessment": false,
+      "embeddables": [
         {
           "embeddable": {
-            "content": "<p>This page contains 4 window shade plugins</p>",
+            "content": "<p>This page contains 2 sidetip plugins and a page sidebar.</p>",
+            "is_callout": true,
             "is_full_width": true,
             "is_hidden": false,
             "name": "",
             "type": "Embeddable::Xhtml",
-            "ref_id": "272138-Embeddable::Xhtml"
+            "ref_id": "272271-Embeddable::Xhtml"
           },
           "section": "header_block"
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"open_response\"}",
+            "is_hidden": false,
+            "is_full_width": true,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": null,
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "da655ced823a0246a5f8c5c46c90345f28f53efe",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/open-response/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "This shouldn't be used by any real activities it is still under development.",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Open Response (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": false,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "574-ManagedInteractive",
+            "linked_interactives": []
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"This is a teacher edition side tip.\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "sideTip"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3258-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"This is a teacher edition side tip with markdown.\\n\\n# Capillos iugo Palaemona sacros moenia desunt ducit\\n\\n## Sanguine decidit Iovemque natalibus venturi haberet nos\\n\\nLorem markdownum acernae pendere tegitur trepidantem facias dixit. Ignava est\\ncarbasa, et pugnae ibimus nostri si astra statuit dapes. Nec aevo forti arces\\nnon barbaque postera.\\n\\n> Veri movere. Quae Coei quo oculis illa et iram ante inpositus litora agmina\\n> ignaram Lyncides praeside est acta medullas tosti utque dicta. Caecisque ad\\n> deum frondes, est *ferrum frustra multaque* in venerit cupidine, et non piasti\\n> quoque! Tenent urget, tangunt animos nil papavera terra attonitas odorato dat\\n> [unde coagula](http://et.com/erebi-cum.php).\\n\\nSaxo vestigia esset, ad sinuataque unica, de iugulatus mille per tuum **vero**!\\nQuem decurrere viroque furit? Rapidas amens, per isque lignum volucris ut talia\\nadmoverat; aquarum Acheronte in. Fuit noctis in laudisque guttis lemnius ille\\ntetigit populi tenuissima fecere ripis stratum undas. Quoquam visa solidissima\\ntibi quaerunt: renascitur curru recens, versant ut pro.\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "sideTip"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3259-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "aspect_ratio_method": "DEFAULT",
+            "authored_state": "",
+            "click_to_play": false,
+            "click_to_play_prompt": null,
+            "enable_learner_state": false,
+            "full_window": false,
+            "has_report_url": false,
+            "image_url": null,
+            "is_full_width": true,
+            "is_hidden": false,
+            "model_library_url": null,
+            "name": "cbio",
+            "native_height": 435,
+            "native_width": 576,
+            "no_snapshots": false,
+            "show_delete_data_button": true,
+            "show_in_featured_question_report": true,
+            "url": "https://connected-bio-spaces.concord.org/",
+            "type": "MwInteractive",
+            "ref_id": "210729-MwInteractive",
+            "linked_interactives": []
+          },
+          "section": "interactive_box"
         }
       ]
     }

--- a/src/lara-plugin/plugin-api/index.ts
+++ b/src/lara-plugin/plugin-api/index.ts
@@ -1,6 +1,6 @@
 export * from "./types";
 export * from "./plugins";
-// LARA_CODE export * from "./sidebar";
+export * from "./sidebar";
 // LARA_CODE export * from "./popup";
 // LARA_CODE export * from "./decorate-content";
 // LARA_CODE export * from "./events";

--- a/src/lara-plugin/plugin-api/sidebar.spec.ts
+++ b/src/lara-plugin/plugin-api/sidebar.spec.ts
@@ -1,0 +1,76 @@
+import * as Sidebar from "./sidebar";
+// ACTIVITY_PLAYER_CODE:
+import $ from "jquery";
+// LARA_CODE import * as $ from "jquery";
+
+describe("Sidebar", () => {
+  it("should exist", () => {
+    expect(Sidebar).toBeDefined();
+  });
+
+  describe("#addSidebar", () => {
+    it("should exist", () => {
+      expect(Sidebar.addSidebar).toBeDefined();
+    });
+
+    it("should handle basic options and create DOM element with correct content", () => {
+      Sidebar.addSidebar({
+        content: $("<div id='test-sidebar'>Test sidebar</div>")[0],
+        icon: $("<div id='test-icon'>")[0],
+        handle: "Test handle",
+        titleBar: "Test title bar"
+      });
+      expect($("body").find("#test-sidebar").length).toEqual(1);
+      expect($("body").find("#test-icon").length).toEqual(1);
+      expect($("body").text()).toEqual(expect.stringContaining("Test sidebar"));
+      expect($("body").text()).toEqual(expect.stringContaining("Test handle"));
+      expect($("body").text()).toEqual(expect.stringContaining("Test title bar"));
+    });
+
+    it("returns a simple controller that can be used to open or close sidebar", () => {
+      const onOpenCallback = jest.fn();
+      const onCloseCallback = jest.fn();
+      const controller = Sidebar.addSidebar({
+        content: $("<div id='test-sidebar'>Test sidebar</div>")[0],
+        onOpen: onOpenCallback,
+        onClose: onCloseCallback
+      });
+      expect(controller.open).toBeDefined();
+      expect(controller.close).toBeDefined();
+
+      controller.open();
+      controller.open(); // nothing should happen, already open
+      expect(onOpenCallback).toHaveBeenCalledTimes(1);
+
+      controller.close();
+      controller.close(); // nothing should happen, already closed
+      expect(onCloseCallback).toHaveBeenCalledTimes(1);
+    });
+
+    describe("when user opens a sidebar", () => {
+      it("it calls onOpen callback and main element gets expanded", () => {
+        const onOpenCallback = jest.fn();
+        Sidebar.addSidebar({
+          content: $("<div id='test-sidebar'>Test sidebar</div>")[0],
+          onOpen: onOpenCallback
+        });
+        $(".sidebar-hdr").click();
+        expect(onOpenCallback).toHaveBeenCalledTimes(1);
+        expect($(".sidebar-mod.expanded").length).toEqual(1);
+      });
+    });
+
+    describe("when user closes a sidebar", () => {
+      it("it calls onClose callback", () => {
+        const onCloseCallback = jest.fn();
+        Sidebar.addSidebar({
+          content: $("<div id='test-sidebar'>Test sidebar</div>")[0],
+          onClose: onCloseCallback
+        });
+        $(".sidebar-hdr").click(); // open
+        $(".sidebar-hdr").click(); // close
+        expect(onCloseCallback).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/lara-plugin/plugin-api/sidebar.spec.ts
+++ b/src/lara-plugin/plugin-api/sidebar.spec.ts
@@ -1,7 +1,7 @@
 import * as Sidebar from "./sidebar";
 // ACTIVITY_PLAYER_CODE:
 import $ from "jquery";
-// LARA_CODE import * as $ from "jquery";
+// LARA_CODE: import * as $ from "jquery";
 
 describe("Sidebar", () => {
   it("should exist", () => {

--- a/src/lara-plugin/plugin-api/sidebar.ts
+++ b/src/lara-plugin/plugin-api/sidebar.ts
@@ -1,0 +1,176 @@
+// ACTIVITY_PLAYER_CODE:
+import $ from "jquery";
+// LARA_CODE import * as $ from "jquery";
+import "jquery-ui/ui/widgets/button";
+
+// Distance between sidebar handles (in pixels).
+const SIDEBAR_SPACER = 35;
+// Distance to the bottom edge of the window if sidebar content gets pretty tall.
+const BOTTOM_MARGIN = 30;
+
+export interface ISidebarOptions {
+  content: string | HTMLElement;
+  /** Icon can be 'default' (arrow) or an HTML element. */
+  icon?: string | HTMLElement;
+  /** Text displayed on the sidebar handle. */
+  handle?: string;
+  handleColor?: string;
+  /** Title visible after sidebar is opened by user. If it's not provided, it won't be displayed at all. */
+  titleBar?: string;
+  titleBarColor?: string;
+  width?: number;
+  padding?: number;
+  onOpen?: () => void;
+  onClose?: () => void;
+}
+
+export interface ISidebarController {
+  open: () => void;
+  close: () => void;
+}
+
+export const ADD_SIDEBAR_DEFAULT_OPTIONS = {
+  /** Arrow pointing left. */
+  icon: "default",
+  handle: "",
+  handleColor: "#aaa",
+  titleBar: undefined,
+  titleBarColor: "#bbb",
+  width: 500,
+  padding: 25
+};
+
+// List of all existing sidebars (their controllers).
+const controllers: ISidebarController[] = [];
+
+// Dynamically setup position of sidebar handles.
+const positionMultipleSidebars = () => {
+  // First, make sure that sidebars are below page navigation menu.
+  let minOffset = 0;
+  const $navMenu = $(".activity-nav-mod");
+  // Note that .activity-nav-mod might not be present in test environment.
+  if ($navMenu.length > 0) {
+    minOffset = $navMenu[0].getBoundingClientRect().bottom;
+  }
+  // Also, take into account aet of small icons displayed on the side of the page. They look like mini-sidebar handles.
+  // Not available in all the layouts, so this selector might not be present. Again, avoid overlapping.
+  const $sideNavigation = $("#nav-activity-menu");
+  if ($sideNavigation.length > 0) {
+    minOffset = Math.max(minOffset, $sideNavigation[0].getBoundingClientRect().bottom);
+  }
+  minOffset = minOffset + SIDEBAR_SPACER; // add a little margin, it looks better.
+  // Then, make sure that multiple handles don't overlap and they don't go off screen.
+  const $sidebarHdr = $(".sidebar-hdr");
+  const sidebarSpacing = ($sidebarHdr.height() || 0) + SIDEBAR_SPACER;
+  const titleBarHeight = $(".sidebar-mod .title-bar").height() || 0;
+  $(".sidebar-mod").each(function(idx) {
+    const top = minOffset + idx * sidebarSpacing;
+    $(this).css("top", top);
+    // Also, ensure that sidebar content is fully visible, even on the pretty short screens.
+    $(this).find(".sidebar-content").css("max-height", window.innerHeight - top - titleBarHeight - BOTTOM_MARGIN);
+  });
+};
+
+const closeAllSidebars = () => {
+  controllers.forEach(controller => controller.close());
+};
+
+/****************************************************************************
+ Ask LARA to add a new sidebar.
+
+ Sidebar will be added to the edge of the interactive page window. When multiple sidebars are added, there's no way
+ to specify their positions, so no assumptions should be made about current display - it might change.
+
+ Sidebar height cannot be specified. It's done on purpose to prevent issues on very short screens. It's based on the
+ provided content HTML element, but it's limited to following range:
+ - 100px is the min-height
+ - max-height is calculated dynamically and ensures that sidebar won't go off the screen
+ If the provided content is taller than the max-height of the sidebar, a sidebar content container will scroll.
+
+ It returns a simple controller that can be used to open or close sidebar.
+ ****************************************************************************/
+export const addSidebar = (_options: ISidebarOptions): ISidebarController => {
+  const options = $.extend({}, ADD_SIDEBAR_DEFAULT_OPTIONS, _options);
+  if (options.icon === "default") {
+    options.icon = $("<i class='default-icon fa fa-arrow-circle-left'>")[0] as string & HTMLElement;
+  }
+  // Generate HTML.
+  const $sidebar = $('<div class="sidebar-mod">');
+  const $handle = $('<div class="sidebar-hdr">');
+  const $body = $('<div class="sidebar-bd">');
+  // Handle.
+  if (options.icon) {
+    $handle.append(options.icon);
+  }
+  const $handleText = $('<h5 class="h5">');
+  $handle.append($handleText);
+  // Body / main container.
+  const $closeBtn = $('<button class="sidebar-bd-close">');
+  // Note that ButtonOptions interface is out of date, `icon` is a valid option in jQuery UI 1.12.
+  // @ts-ignore
+  $closeBtn.button({ icon: "ui-icon-closethick" });
+  $body.append($closeBtn);
+  const $contentContainer = $('<div class="sidebar-content">');
+  $body.append($contentContainer);
+  // Final setup.
+  $sidebar.append($handle);
+  $sidebar.append($body);
+  $("body").append($sidebar);
+  $("#sidebar-holder").append($sidebar);
+
+  // Add event handlers.
+  const isOpen = () => {
+    return $sidebar.hasClass("expanded");
+  };
+  $handle.add($closeBtn) // .add creates a set of elements, so we can apply click handler just once
+    .on("click", () => {
+      if (!isOpen()) {
+        // We're opening a sidebar. Close all the others first.
+        closeAllSidebars();
+        if (options.onOpen) {
+          options.onOpen();
+        }
+      }
+      if (isOpen() && options.onClose) {
+        options.onClose();
+      }
+      $sidebar.toggleClass("expanded");
+    });
+  // It triggers CSS transition.
+  $(".sidebar-mod").addClass("visible");
+
+  // Apply options.
+  $handleText.text(options.handle);
+  $contentContainer.append(options.content);
+  const titleBar = options.titleBar || "";
+  if (titleBar.length > 0) {
+    const $titleBar = $('<div class="title-bar">');
+    $body.prepend($titleBar);
+    $titleBar.text(titleBar);
+    $titleBar.css("background", options.titleBarColor);
+  }
+  $handle.css("background-color", options.handleColor);
+  $contentContainer.css("padding", options.padding);
+  $sidebar.css("width", options.width);
+  // Hide sidebar on load.
+  $sidebar.css("right", options.width * -1);
+
+  const controller = {
+    open() {
+      if (!isOpen()) {
+        $handle.trigger("click");
+      }
+    },
+    close() {
+      if (isOpen()) {
+        $handle.trigger("click");
+      }
+    }
+  };
+  controllers.push(controller);
+
+  positionMultipleSidebars();
+
+  // Return controller.
+  return controller;
+};

--- a/src/lara-plugin/plugin-api/sidebar.ts
+++ b/src/lara-plugin/plugin-api/sidebar.ts
@@ -1,7 +1,7 @@
 // ACTIVITY_PLAYER_CODE:
 import $ from "jquery";
 // LARA_CODE: import * as $ from "jquery";
-import "jquery-ui/ui/widgets/button";
+// LARA_CODE: import "jquery-ui/ui/widgets/button";
 
 // Distance between sidebar handles (in pixels).
 const SIDEBAR_SPACER = 35;
@@ -121,7 +121,11 @@ export const addSidebar = (_options: ISidebarOptions): ISidebarController => {
   $sidebar.append($body);
   // LARA_CODE: $("body").append($sidebar);
   // ACTIVITY_PLAYER_CODE:
-  $("#expandable-container").append($sidebar);
+  if ($("#expandable-container").length) {
+    $("#expandable-container").append($sidebar);
+  } else {
+    $("body").append($sidebar);
+  }
 
   // Add event handlers.
   const isOpen = () => {

--- a/src/lara-plugin/plugin-api/sidebar.ts
+++ b/src/lara-plugin/plugin-api/sidebar.ts
@@ -115,8 +115,7 @@ export const addSidebar = (_options: ISidebarOptions): ISidebarController => {
   // Final setup.
   $sidebar.append($handle);
   $sidebar.append($body);
-  $("body").append($sidebar);
-  $("#sidebar-holder").append($sidebar);
+  $("#sidetip-plugin-container").append($sidebar);
 
   // Add event handlers.
   const isOpen = () => {

--- a/src/lara-plugin/plugin-api/sidebar.ts
+++ b/src/lara-plugin/plugin-api/sidebar.ts
@@ -1,6 +1,6 @@
 // ACTIVITY_PLAYER_CODE:
 import $ from "jquery";
-// LARA_CODE import * as $ from "jquery";
+// LARA_CODE: import * as $ from "jquery";
 import "jquery-ui/ui/widgets/button";
 
 // Distance between sidebar handles (in pixels).
@@ -47,10 +47,14 @@ const controllers: ISidebarController[] = [];
 const positionMultipleSidebars = () => {
   // First, make sure that sidebars are below page navigation menu.
   let minOffset = 0;
-  const $navMenu = $(".activity-nav-mod");
+  // LARA_CODE: const $navMenu = $(".activity-nav-mod");
+  // ACTIVITY_PLAYER_CODE:
+  const $navMenu = $(".activity-header");
   // Note that .activity-nav-mod might not be present in test environment.
   if ($navMenu.length > 0) {
-    minOffset = $navMenu[0].getBoundingClientRect().bottom;
+    // LARA_CODE: minOffset = $navMenu[0].getBoundingClientRect().bottom;
+    // ACTIVITY_PLAYER_CODE:
+    minOffset = $navMenu[0].getBoundingClientRect().top;
   }
   // Also, take into account aet of small icons displayed on the side of the page. They look like mini-sidebar handles.
   // Not available in all the layouts, so this selector might not be present. Again, avoid overlapping.
@@ -58,7 +62,7 @@ const positionMultipleSidebars = () => {
   if ($sideNavigation.length > 0) {
     minOffset = Math.max(minOffset, $sideNavigation[0].getBoundingClientRect().bottom);
   }
-  minOffset = minOffset + SIDEBAR_SPACER; // add a little margin, it looks better.
+  // LARA_CODE: minOffset = minOffset + SIDEBAR_SPACER; // add a little margin, it looks better.
   // Then, make sure that multiple handles don't overlap and they don't go off screen.
   const $sidebarHdr = $(".sidebar-hdr");
   const sidebarSpacing = ($sidebarHdr.height() || 0) + SIDEBAR_SPACER;
@@ -108,14 +112,16 @@ export const addSidebar = (_options: ISidebarOptions): ISidebarController => {
   const $closeBtn = $('<button class="sidebar-bd-close">');
   // Note that ButtonOptions interface is out of date, `icon` is a valid option in jQuery UI 1.12.
   // @ts-ignore
-  $closeBtn.button({ icon: "ui-icon-closethick" });
+  // LARA_CODE: $closeBtn.button({ icon: "ui-icon-closethick" });
   $body.append($closeBtn);
   const $contentContainer = $('<div class="sidebar-content">');
   $body.append($contentContainer);
   // Final setup.
   $sidebar.append($handle);
   $sidebar.append($body);
-  $("#sidetip-plugin-container").append($sidebar);
+  // LARA_CODE: $("body").append($sidebar);
+  // ACTIVITY_PLAYER_CODE:
+  $("#expandable-container").append($sidebar);
 
   // Add event handlers.
   const isOpen = () => {

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -46,16 +46,20 @@ export const isEmbeddableSectionHidden = (page: Page, section: string | null) =>
 export const getVisibleEmbeddablesOnPage = (page: Page) => {
   const headerEmbeddables = isEmbeddableSectionHidden(page, EmbeddableSections.Introduction)
     ? []
-    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Introduction && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id && !isEmbeddableSideTip(e));
+    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Introduction && isVisibleEmbeddable(e));
   const interactiveEmbeddables = isEmbeddableSectionHidden(page, EmbeddableSections.Interactive)
     ? []
-    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Interactive && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id && !isEmbeddableSideTip(e));
+    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Interactive && isVisibleEmbeddable(e));
   const infoAssessEmbeddables = isEmbeddableSectionHidden(page, null)
     ? []
-    : page.embeddables.filter((e: any) => (e.section !== EmbeddableSections.Interactive && e.section !== EmbeddableSections.Introduction && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id && !isEmbeddableSideTip(e)));
+    : page.embeddables.filter((e: any) => (e.section !== EmbeddableSections.Interactive && e.section !== EmbeddableSections.Introduction && isVisibleEmbeddable(e)));
 
   return { interactiveBox: interactiveEmbeddables, headerBlock: headerEmbeddables, infoAssessment: infoAssessEmbeddables };
 };
+
+function isVisibleEmbeddable(e: EmbeddableWrapper) {
+  return !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id && !isEmbeddableSideTip(e);
+}
 
 export const isEmbeddableSideTip = (e: EmbeddableWrapper) => {
   return (e.embeddable.type === "Embeddable::EmbeddablePlugin" && e.embeddable.plugin?.component_label === "sideTip");

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -1,4 +1,5 @@
 import { Page, Activity, EmbeddableWrapper } from "../types";
+import { SidebarConfiguration } from "../components/page-sidebar/sidebar-wrapper";
 
 export enum ActivityLayouts {
   MultiplePages = 0,
@@ -45,15 +46,32 @@ export const isEmbeddableSectionHidden = (page: Page, section: string | null) =>
 export const getVisibleEmbeddablesOnPage = (page: Page) => {
   const headerEmbeddables = isEmbeddableSectionHidden(page, EmbeddableSections.Introduction)
     ? []
-    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Introduction && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id);
+    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Introduction && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id && !isEmbeddableSideTip(e));
   const interactiveEmbeddables = isEmbeddableSectionHidden(page, EmbeddableSections.Interactive)
     ? []
-    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Interactive && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id);
+    : page.embeddables.filter((e: any) => e.section === EmbeddableSections.Interactive && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id && !isEmbeddableSideTip(e));
   const infoAssessEmbeddables = isEmbeddableSectionHidden(page, null)
     ? []
-    : page.embeddables.filter((e: any) => (e.section !== EmbeddableSections.Interactive && e.section !== EmbeddableSections.Introduction && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id));
+    : page.embeddables.filter((e: any) => (e.section !== EmbeddableSections.Interactive && e.section !== EmbeddableSections.Introduction && !e.embeddable.is_hidden && !e.embeddable.embeddable_ref_id && !isEmbeddableSideTip(e)));
 
   return { interactiveBox: interactiveEmbeddables, headerBlock: headerEmbeddables, infoAssessment: infoAssessEmbeddables };
+};
+
+export const isEmbeddableSideTip = (e: EmbeddableWrapper) => {
+  return (e.embeddable.type === "Embeddable::EmbeddablePlugin" && e.embeddable.plugin?.component_label === "sideTip");
+};
+
+export const getPageSideTipEmbeddables = (page: Page) => {
+  return page.embeddables.filter((e: any) => isEmbeddableSideTip(e));
+};
+
+export const getPageSideBars = (activity: Activity, currentPage: Page) => {
+  const sidebars: SidebarConfiguration[] = activity.layout === ActivityLayouts.SinglePage
+    ? activity.pages.filter((page) => page.show_sidebar).map((page) => (
+        {content: page.sidebar, title: page.sidebar_title }
+      ))
+    : currentPage.show_sidebar? [{ content: currentPage.sidebar, title: currentPage.sidebar_title }]: [];
+  return sidebars;
 };
 
 export const getPageSectionQuestionCount = (page: Page) => {

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -29,7 +29,7 @@ export const loadPluginScripts = (LARA: LaraGlobalType, activity: Activity) => {
     if (!activity.pages[page].is_hidden) {
       for (let embeddableNum = 0; embeddableNum < activity.pages[page].embeddables.length; embeddableNum++) {
         const embeddable = activity.pages[page].embeddables[embeddableNum].embeddable;
-        if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.component_label === "windowShade") {
+        if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.approved_script_label === "teacherEditionTips") {
           const plugin = Plugins.find(p => p.type === "TeacherEdition");
           if (plugin && !usedPlugins.some(p => p.type === "TeacherEdition")) {
             usedPlugins.push(plugin);


### PR DESCRIPTION
I'm putting this in draft.  Not quite ready to open a full PR, but would like someone else to look at this.  

This PR adds teacher edition sidetips to activities.  Teacher edition sidetips are only displayed in teacher-edition mode.  For testing or running use URL params: `?preview&mode=teacher-edition&activity=sample-activity-plugins` to enter teacher edition mode and view an activity that includes sidetips.

Changes to the PR include;
- updates JSON plugin sample activity to include sidetips
- adds `sidebar.ts` from LARA
- adds `ExpandableContainer` container component which contains sidebars (defined on page) and sidetips (embeddable that is displayed outside main page content when in teacher edition mode) 
- adds `EmbeddablePluginSideTip` which is used for creating a container context for the plugin script

Some notes on this PR:
- I'm not happy with the introduction of jQuery and the implementation of the sidebar container using jQuery.  I would prefer that when `addSidebar` is called from a plugin, that we find a way to route the contents into a React component for easier layout, maintenance, and styling and for better integration with the rest of the app and other React components.
- There are some styling nuances that I punted on as it would have required a deeper dive in the jQuery code.
- There are still some potential issues when displaying the sidetips and page sidebar content (not the teacher edition tips) simultaneously.  A user can potentially click around to get both a sidebar and sidetip open at the same time (as in the current LARA).  I would prefer that we handle things like this ONLY after working out a full React implementation of the sidetips.  The work that we would need to do to fix some of these edge cases doesn't seem worth the resources at this point.  Especially since I'm hoping we can eventually rewrite this so the entire front-end is in React.