### PR TITLE
Show hi-res image in modal image interactive

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -63,8 +63,13 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
       const state = safeJsonParseIfString(authored_state) || {};
       // enable modal support for activity player only
       state.modalSupported = true;
+      if (showModal) {
+        // adding isShowingModal to authored state allows image interactive to know if it is modal and subsequently
+        // decide to show a low or high res image.
+        state.isShowingModal = true;
+      }
       return state;
-    }, [authored_state]);
+    }, [authored_state, showModal]);
     const linkedInteractives = useRef((embeddable.type === "ManagedInteractive") && embeddable.linked_interactives?.length
                                   ? embeddable.linked_interactives.map(link => ({ id: link.ref_id, label: link.label }))
                                   : undefined);

--- a/src/data/sample-question-interactive-complex.json
+++ b/src/data/sample-question-interactive-complex.json
@@ -909,6 +909,87 @@
           "section": "interactive_box"
         }
       ]
+    },
+    {
+      "additional_sections": {},
+      "embeddable_display_mode": "stacked",
+      "is_completion": false,
+      "is_hidden": false,
+      "layout": "l-6040",
+      "name": null,
+      "position": 11,
+      "show_header": true,
+      "show_info_assessment": true,
+      "show_interactive": false,
+      "show_sidebar": false,
+      "sidebar": null,
+      "sidebar_title": "Did you know?",
+      "toggle_info_assessment": false,
+      "embeddables": [
+        {
+          "embeddable": {
+            "content": "<p>This page contains an image with a low-res and hi-res version.</p>",
+            "is_callout": true,
+            "is_full_width": true,
+            "is_hidden": false,
+            "name": "",
+            "type": "Embeddable::Xhtml",
+            "ref_id": "226562-Embeddable::Xhtml"
+          },
+          "section": "header_block"
+        },
+        {
+          "embeddable": {
+            "name": "Sample Image",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"scaling\":\"fitWidth\",\"url\":\"https://upload.wikimedia.org/wikipedia/commons/4/4a/Pixelated_Georgia_Flag.v4.png\",\"highResUrl\":\"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b7/Georgia_state_flag.png/1920px-Georgia_state_flag.png\",\"altText\":\"Georgia state flag\",\"caption\":\"Georgia state flag\"}",
+            "is_hidden": false,
+            "is_full_width": true,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": null,
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "d3021e60ed42e1e90031676b9db83210e39b5c6a",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/image/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "",
+                "enable_learner_state": false,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Image Interactive (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": true,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "585-ManagedInteractive",
+            "linked_interactives": []
+          },
+          "section": null
+        }
+      ]
     }
   ],
   "plugins": [],


### PR DESCRIPTION
This PR adds the ability to pass a flag in the authored state of an image question interactive so that the interactive can know if it is being shown in modal or non-modal form.  The image question interactive uses this to determine if it should show the high resolution version of the image (if available).