### PR TITLE
Fix theme colors broken by recent css-loader update

### DIFF
--- a/cypress/integration/theme-buttons.test.ts
+++ b/cypress/integration/theme-buttons.test.ts
@@ -1,0 +1,44 @@
+// https://stackoverflow.com/a/33184805
+function getColorCSS(c: string) {
+    const elt = document.createElement("div");
+    elt.style.color = c;
+    return elt.style.color.replace(/\s+/,"").toLowerCase();
+}
+function isValidColor(c: string) {
+  return !!getColorCSS(c);
+}
+
+const themeIds = [
+  "teal",
+  "orange",
+  "cbio",
+  "waters",
+  "interactions",
+  "image"
+];
+
+context("Test theme buttons", () => {
+  before(() => {
+    cy.visit("/?themeButtons&preview");
+  });
+
+  describe("Theme buttons",()=>{
+    it("render when appropriate",()=>{
+      themeIds.forEach(id => {
+        cy.get(`[data-cy=theme-button-${id}]`).should("be.visible");
+      });
+    });
+
+    it("have access to imported text colors", () => {
+      themeIds.forEach(id => {
+        cy.get(`[data-cy=theme-button-${id}]`)
+          .then(elt => {
+            // verify that values imported from .scss files are imported successfully
+            // will fail if css-loader is not configured appropriately in webpack.config.js
+            expect(isValidColor(Cypress.$(elt).data("light-text-color"))).to.equal(true);
+            expect(isValidColor(Cypress.$(elt).data("dark-text-color"))).to.equal(true);
+          });
+      });
+    });
+  });
+});

--- a/src/components/theme-buttons.test.tsx
+++ b/src/components/theme-buttons.test.tsx
@@ -8,33 +8,33 @@ describe("Theme Button component", () => {
     expect(wrapper.find('[data-cy="theme-buttons"]').length).toBe(1);
 
     const tealButton = wrapper.find('[data-cy="theme-button-teal"]');
-    tealButton.simulate("click");
+    tealButton.simulate("click", { target: { dataset: { id: "teal" } } });
     let primary = document.documentElement.style.getPropertyValue("--theme-primary-color");
     expect(primary).toBe("#0592af");
 
     const orangeButton = wrapper.find('[data-cy="theme-button-orange"]');
-    orangeButton.simulate("click");
+    orangeButton.simulate("click", { target: { dataset: { id: "orange" } } });
     primary = document.documentElement.style.getPropertyValue("--theme-primary-color");
     expect(primary).toBe("#ff8415");
 
     const cbioButton = wrapper.find('[data-cy="theme-button-cbio"]');
-    cbioButton.simulate("click");
+    cbioButton.simulate("click", { target: { dataset: { id: "cbio" } } });
     primary = document.documentElement.style.getPropertyValue("--theme-primary-color");
     expect(primary).toBe("#008fd7");
 
     const watersButton = wrapper.find('[data-cy="theme-button-waters"]');
-    watersButton.simulate("click");
+    watersButton.simulate("click", { target: { dataset: { id: "waters" } } });
     primary = document.documentElement.style.getPropertyValue("--theme-primary-color");
     expect(primary).toBe("#007c8B");
 
     const interactionsButton = wrapper.find('[data-cy="theme-button-interactions"]');
-    interactionsButton.simulate("click");
+    interactionsButton.simulate("click", { target: { dataset: { id: "interactions" } } });
     primary = document.documentElement.style.getPropertyValue("--theme-primary-color");
     expect(primary).toBe("#414546");
     // expect(setAppBackgroundImage).toHaveBeenCalled();
 
     const imageButton = wrapper.find('[data-cy="theme-button-image"]');
-    imageButton.simulate("click");
+    imageButton.simulate("click", { target: { dataset: { id: "image" } } });
     // expect(setAppBackgroundImage).toHaveBeenCalled();
   });
 });

--- a/src/components/theme-buttons.tsx
+++ b/src/components/theme-buttons.tsx
@@ -2,45 +2,82 @@
 // and is not intended to be displayed in a production release.
 // Add this component to enable buttons to toggle color theme.
 import React from "react";
-import { setThemeColors } from "../utilities/theme-utils";
 import { setAppBackgroundImage } from "../utilities/activity-utils";
-
+import { setThemeColors } from "../utilities/theme-utils";
+import colors from "../components/vars.scss";
 import "./theme-buttons.scss";
 
+interface ITheme {
+  id: string;
+  label: string;
+  primaryColor?: string;
+  secondaryColor?: string;
+  backgroundImage?: string;
+}
+const kThemes: ITheme[] = [
+  {
+    id: "teal",
+    label: "Teal",
+    primaryColor: "#0592af",
+    secondaryColor: "#ff8415"
+  },
+  {
+    id: "orange",
+    label: "Orange",
+    primaryColor: "#ff8415",
+    secondaryColor: "#0592af"
+  },
+  {
+    id: "cbio",
+    label: "CBio",
+    primaryColor: "#008fd7",
+    secondaryColor: "#f15a24"
+  },
+  {
+    id: "waters",
+    label: "Waters",
+    primaryColor: "#007c8B",
+    secondaryColor: "#e86e2f"
+  },
+  {
+    id: "interactions",
+    label: "Interactions",
+    primaryColor: "#414546",
+    secondaryColor: "#2f70b0"
+  },
+  {
+    id: "image",
+    label: "Image",
+    backgroundImage: `url("https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Hubble%27s_Wide_View_of_%27Mystic_Mountain%27_in_Infrared.jpg/678px-Hubble%27s_Wide_View_of_%27Mystic_Mountain%27_in_Infrared.jpg")`
+  }
+];
+const kThemeMap: Record<string, ITheme> = {};
+kThemes.forEach(theme => kThemeMap[theme.id] = theme);
+
 export const ThemeButtons: React.FC = () => {
-  const imageUrl  = `url("https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Hubble%27s_Wide_View_of_%27Mystic_Mountain%27_in_Infrared.jpg/678px-Hubble%27s_Wide_View_of_%27Mystic_Mountain%27_in_Infrared.jpg")`;
-  const handleTealTheme = () => {
-    setThemeColors("#0592af", "#ff8415");
-    setAppBackgroundImage();
-  };
-  const handleOrangeTheme = () => {
-    setThemeColors("#ff8415", "#0592af");
-    setAppBackgroundImage();
-  };
-  const handleCBioTheme = () => {
-    setThemeColors("#008fd7", "#f15a24");
-    setAppBackgroundImage();
-  };
-  const handleWatersTheme = () => {
-    setThemeColors("#007c8B", "#e86e2f");
-    setAppBackgroundImage();
-  };
-  const handleInteractionsTheme = () => {
-    setThemeColors("#414546", "#2f70b0");
-    setAppBackgroundImage();
-  };
-  const handleImagesBackground = () => {
-    setAppBackgroundImage(imageUrl);
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const button = e.target as HTMLButtonElement;
+    const id = button.dataset.id;
+    const theme = id ? kThemeMap[id] : undefined;
+    if (theme) {
+      if (theme.primaryColor && theme.secondaryColor) {
+        setThemeColors(theme.primaryColor, theme.secondaryColor);
+      }
+      setAppBackgroundImage(theme.backgroundImage);
+    }
   };
 
   return (
     <div className="theme-buttons" data-cy="theme-buttons">
-      <button className="button" onClick={handleTealTheme} data-cy="theme-button-teal">teal</button>
-      <button className="button" onClick={handleOrangeTheme} data-cy="theme-button-orange">orange</button>
-      <button className="button" onClick={handleCBioTheme} data-cy="theme-button-cbio">cbio</button>
-      <button className="button" onClick={handleWatersTheme} data-cy="theme-button-waters">waters</button>
-      <button className="button" onClick={handleInteractionsTheme} data-cy="theme-button-interactions">interactions</button>
-      <button className="button" onClick={handleImagesBackground} data-cy="theme-button-image">image</button>
+      {kThemes.map(theme => (
+        <button className="button" key={theme.id} onClick={handleClick}
+                data-id={theme.id} data-cy={`theme-button-${theme.id}`}
+                data-light-text-color={colors.lightFontColor}
+                data-dark-text-color={colors.darkFontColor} >
+          {theme.label}
+        </button>
+      ))}
     </div>
   );
 };

--- a/src/utilities/theme-utils.test.ts
+++ b/src/utilities/theme-utils.test.ts
@@ -1,5 +1,7 @@
 import { colorShade, setThemeColors } from "./theme-utils";
-import colors from "../components/vars.scss";
+// note: importing from .scss files doesn't work in unit tests,
+// because the import is handled by webpack, so the full bundle is required.
+// import colors from "../components/vars.scss";
 
 describe("Theme utility functions", () => {
   it("determines if color shades are computed", () => {
@@ -15,19 +17,19 @@ describe("Theme utility functions", () => {
     const primary = document.documentElement.style.getPropertyValue("--theme-primary-color");
     const primaryHover = document.documentElement.style.getPropertyValue("--theme-primary-hover-color");
     const primaryActive = document.documentElement.style.getPropertyValue("--theme-primary-active-color");
-    const primaryText = document.documentElement.style.getPropertyValue("--theme-primary-text-color");
+    // const primaryText = document.documentElement.style.getPropertyValue("--theme-primary-text-color");
     const secondary = document.documentElement.style.getPropertyValue("--theme-secondary-color");
     const secondaryHover = document.documentElement.style.getPropertyValue("--theme-secondary-hover-color");
     const secondaryActive = document.documentElement.style.getPropertyValue("--theme-secondary-active-color");
-    const secondaryText = document.documentElement.style.getPropertyValue("--theme-secondary-text-color");
+    // const secondaryText = document.documentElement.style.getPropertyValue("--theme-secondary-text-color");
     expect(primary).toBe("#ff8415");
     expect(primaryHover).toBe("#eb7001");
     expect(primaryActive).toBe("#d75c00");
-    expect(primaryText).toBe(colors.darkFontColor);
+    // expect(primaryText).toBe(colors.darkFontColor);
     expect(secondary).toBe("#0592af");
     expect(secondaryHover).toBe("#007e9b");
     expect(secondaryActive).toBe("#006a87");
-    expect(secondaryText).toBe(colors.lightFontColor);
+    // expect(secondaryText).toBe(colors.lightFontColor);
   });
 
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,16 @@ module.exports = (env, argv) => {
           test: /\.(sa|sc|c)ss$/i,
           use: [
             devMode ? "style-loader" : MiniCssExtractPlugin.loader,
-            "css-loader",
+            {
+              loader: "css-loader",
+              options: {
+                modules: {
+                  // required for :import from scss files
+                  // cf. https://github.com/webpack-contrib/css-loader#separating-interoperable-css-only-and-css-module-features
+                  compileType: "icss"
+                }
+              }
+            },
             "postcss-loader",
             "sass-loader"
           ]


### PR DESCRIPTION
Fix css-loader configuration to support `:import` from `.scss` files
- required configuration changed with recent update to 4.3.0
- added cypress test to catch any future such configuration issue
