### PR TITLE
Improvements related to modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4526,9 +4526,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.6.0.tgz",
-      "integrity": "sha512-+PaHfobuJjXPd804xf7/tZSyMJZVcG7hQCeQqzePYf0ybc+HOM/yFsnKNW+uNjssKcco2YeVSq9EKQss1Zqx8Q==",
+      "version": "0.6.1-pre.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-0.6.1-pre.2.tgz",
+      "integrity": "sha512-WKvefGYM2ChfyPPt5GO65+F9VQmYf8I5Wi+BukfUn7VEPfBcDDgWyMZJzkeVdQZjbZUhchMYQ89WY7NjqX9b6g==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
-    "@concord-consortium/lara-interactive-api": "^0.6.0",
+    "@concord-consortium/lara-interactive-api": "^0.6.1-pre.2",
     "@react-hook/resize-observer": "^1.1.0",
     "dompurify": "^2.0.15",
     "firebase": "^7.20.0",

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -138,9 +138,11 @@ export const IframeRuntime: React.FC<IProps> = forwardRef((props, ref) => {
                   error: "",
                   mode: "runtime",
                   hostFeatures: {
-                    modalDialog: {
+                    modal: {
                       version: "1.0.0",
-                      imageLightbox: false
+                      lightbox: true,
+                      dialog: true,
+                      alert: false
                     }
                   },
                   globalInteractiveState: null,

--- a/src/components/activity-page/managed-interactive/lightbox.scss
+++ b/src/components/activity-page/managed-interactive/lightbox.scss
@@ -1,0 +1,15 @@
+.lightbox-content {
+  position: relative;
+}
+
+.lightbox-close-icon {
+  font-size: 20px;
+  position: absolute;
+  top: -20px;
+  right: -17px;
+  cursor: pointer;
+  color: #808080;
+  &:hover {
+    color: #5a5a5a;
+  }
+}

--- a/src/components/activity-page/managed-interactive/lightbox.tsx
+++ b/src/components/activity-page/managed-interactive/lightbox.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 import { IShowLightbox } from "@concord-consortium/lara-interactive-api";
 import ReactModal from "react-modal";
+import "./lightbox.scss";
 
 export interface IProps extends IShowLightbox {
   onClose: () => void;
@@ -80,11 +81,14 @@ export const Lightbox: React.FC<IProps> = (props) => {
   const iframeSizeOpts = getSizeOptions(props);
   return (
     <ReactModal isOpen={true} appElement={getModalContainer()} onRequestClose={onClose} style={customStyles} >
+      <div className="lightbox-content">
+      <div className="lightbox-close-icon" onClick={onClose}>✖</div>
       {
         isImage ?
         <img ref={imgRef} src={url} onLoad={imgLoaded} style={{ width: imgWidth, height: imgHeight, visibility: imgWidth === undefined ? "hidden" : "visible" }} /> :
         <iframe src={url} width={iframeSizeOpts.width} height={iframeSizeOpts.height} />
       }
+      </div>
     </ReactModal>
   );
 };

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -198,7 +198,7 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
       { !activeDialog && interactiveIframeRuntime }
       {
         activeDialog &&
-        <Modal isOpen={true} appElement={getModalContainer()} onRequestClose={handleCloseDialog}>
+        <Modal isOpen={true} appElement={getModalContainer()} onRequestClose={activeDialog.notCloseable ? undefined : handleCloseDialog}>
           { interactiveIframeRuntime }
         </Modal>
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type Mode = "runtime" | "authoring" | "report";
 
 export interface IframePhone {
-  post: (type: string, data: any) => void;
+  post: (type: string, data?: any) => void;
   addListener: (type: string, handler: (data: any) => void) => void;
   initialize: () => void;
   disconnect: () => void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,14 @@ export interface IExportableOpenResponseAnswerMetadata extends IExportableAnswer
   answer: string;
 }
 
+export interface IExportableImageQuestionAnswerMetadata extends IExportableAnswerMetadataBase {
+  type: "image_question_answer";
+  answer: {
+    text: string;
+    image_url: string;
+  }
+}
+
 export interface IExportableMultipleChoiceAnswerMetadata extends IExportableAnswerMetadataBase {
   type: "multiple_choice_answer";
   answer: {
@@ -225,7 +233,8 @@ export interface IExportableMultipleChoiceAnswerMetadata extends IExportableAnsw
 export type IExportableAnswerMetadata =
   IExportableInteractiveAnswerMetadata |
   IExportableOpenResponseAnswerMetadata |
-  IExportableMultipleChoiceAnswerMetadata;
+  IExportableMultipleChoiceAnswerMetadata |
+  IExportableImageQuestionAnswerMetadata;
 
 export interface LTIRuntimeAnswerMetadata extends ILTIPartial, IExportableAnswerMetadataBase { }
 

--- a/src/utilities/embeddable-utils.test.ts
+++ b/src/utilities/embeddable-utils.test.ts
@@ -1,8 +1,13 @@
 import { IRuntimeMetadata, IRuntimeInteractiveMetadata, IRuntimeMultipleChoiceMetadata } from "@concord-consortium/lara-interactive-api";
 import { answersQuestionIdToRefId, refIdToAnswersQuestionId, getAnswerWithMetadata } from "./embeddable-utils";
 import { DefaultManagedInteractive } from "../test-utils/model-for-tests";
-import { IManagedInteractive, IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata, IExportableAnswerMetadata } from "../types";
-
+import {
+  IManagedInteractive,
+  IExportableOpenResponseAnswerMetadata,
+  IExportableInteractiveAnswerMetadata,
+  IExportableAnswerMetadata,
+  IExportableImageQuestionAnswerMetadata
+} from "../types";
 
 describe("Embeddable utility functions", () => {
   it("correctly converts from answer's question-id to ref_id", () => {
@@ -45,6 +50,43 @@ describe("Embeddable utility functions", () => {
       mode: "report",
       authoredState: `{"version":1,"questionType":"open_response","prompt":"<p>Write something:</p>"}`,
       interactiveState: `{"answerType":"open_response_answer","answerText":"test"}`,
+      version: 1
+    });
+    expect(exportableAnswer.report_state).toBe(expectedReport);
+  });
+
+  it("can create an exportable answer for an image question embeddable", () => {
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: `{"version":1,"questionType":"image_question","prompt":"<p>Write something:</p>"}`,
+      ref_id: "123-ManagedInteractive"
+    };
+
+    const interactiveState: IRuntimeMetadata = {
+      answerType: "image_question_answer",
+      answerText: "test",
+      answerImageUrl: "http://test.snapshot.com"
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableImageQuestionAnswerMetadata;
+
+    expect(exportableAnswer).toBeDefined();
+
+    expect(exportableAnswer.remote_endpoint).toBe("");
+    expect(exportableAnswer.question_id).toBe("managed_interactive_123");
+    expect(exportableAnswer.question_type).toBe("image_question");
+    expect(exportableAnswer.id).toBeDefined();          // random uuid
+    expect(exportableAnswer.type).toBe("image_question_answer");
+    expect(exportableAnswer.answer_text).toBe("test");
+    expect(exportableAnswer.answer).toEqual({
+      text: "test",
+      image_url: "http://test.snapshot.com"
+    });
+    expect(exportableAnswer.submitted).toBeNull();
+    const expectedReport = JSON.stringify({
+      mode: "report",
+      authoredState: `{"version":1,"questionType":"image_question","prompt":"<p>Write something:</p>"}`,
+      interactiveState: `{"answerType":"image_question_answer","answerText":"test","answerImageUrl":"http://test.snapshot.com"}`,
       version: 1
     });
     expect(exportableAnswer.report_state).toBe(expectedReport);

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -1,6 +1,9 @@
 import { v4 as uuidv4 } from "uuid";
 import { IAuthoringMetadata, IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
-import { IExportableAnswerMetadata, IManagedInteractive, IReportState, IExportableMultipleChoiceAnswerMetadata, IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata } from "../types";
+import {
+  IExportableAnswerMetadata, IManagedInteractive, IReportState, IExportableMultipleChoiceAnswerMetadata,
+  IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata, IExportableImageQuestionAnswerMetadata
+} from "../types";
 
 export const getAnswerWithMetadata = (
     interactiveState: IRuntimeMetadata,
@@ -46,6 +49,14 @@ export const getAnswerWithMetadata = (
       ...exportableAnswerBase,
       answer: interactiveState.answerText
     } as IExportableOpenResponseAnswerMetadata;
+  } else if (interactiveState.answerType === "image_question_answer") {
+    exportableAnswer = {
+      ...exportableAnswerBase,
+      answer: {
+        text: interactiveState.answerText,
+        image_url: interactiveState.answerImageUrl
+      }
+    } as IExportableImageQuestionAnswerMetadata;
   } else {
     // note we don't current support has_report_url
     exportableAnswer = {


### PR DESCRIPTION
[#175165872]

1. Request interactive state before closing dialog. This prevents state loss when the user clicks dialog backdrop. Note that interactive API client delays sending state by ~2 seconds, so it was very likely to happen before.
2. Host features hash updated.
3. Dialog API: handle .notCloseable property.
4. Add close icon to lightbox.