### PR TITLE
Restrict iframe reload to URL changes

### DIFF
--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -184,8 +184,9 @@ export const IframeRuntime: React.FC<IProps> = forwardRef((props, ref) => {
         phoneRef.current.disconnect();
       }
     };
-  }, [url, authoredState, report, initialInteractiveState, setNewHint, getFirebaseJWT, setSupportedFeatures,
-      setSendCustomMessage, showModal, closeModal, setNavigation]);
+    // Re-running the effect reloads the iframe.
+    // The _only_ time that's ever appropriate is when the url has changed.
+  }, [url]);  // eslint-disable-line react-hooks/exhaustive-deps
 
   useImperativeHandle(ref, () => ({
     requestInteractiveState: () => phoneRef.current?.post("getInteractiveState")


### PR DESCRIPTION
[[#175254598]](https://www.pivotaltracker.com/story/show/175254598)

Normally, I’m in favor of following the `exhaustive-deps` rule’s recommendations rather than disabling it, but in this case I think it makes sense to go the other way. With this effect in particular we’ve repeatedly gone through the cycle of adding new code to the effect, adding the recommended identifiers to the list of dependencies, and then figuring out what combination of `useCallback`, `useMemo`, and `useRef` will suffice to make sure that none of them trigger a reload of the `<iframe>`. Rather than perpetuating that cycle, with this PR I propose to say explicitly what we mean, namely that only a URL change should trigger an `<iframe>` reload and any reload triggered otherwise is a bug.
