### PR TITLE
Fix interactive sizing in header section

### DIFF
--- a/src/components/activity-page/activity-page-content.scss
+++ b/src/components/activity-page/activity-page-content.scss
@@ -18,10 +18,6 @@
     color: var(--theme-secondary-color);
   }
 
-  .introduction {
-    max-width: 900px;
-  }
-
   .embeddables {
     display: flex;
     flex-direction: row;

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -160,7 +160,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
   private renderIntroEmbeddables = (embeddables: EmbeddableWrapper[], totalPreviousQuestions: number) => {
     return (
       <div className="embeddables">
-        <div className="group responsive">
+        <div className="group fill-remaining">
           {this.renderEmbeddables(embeddables, EmbeddableSections.Introduction, totalPreviousQuestions)}
         </div>
       </div>


### PR DESCRIPTION
This PR fixes a bug found by @emcelroy while working on the carousels.  Full-width embeddables in the header section were not being sized correctly to fill the horizontal space.  This was partly due to incorrect CSS being applied to the header container itself and incorrect CSS being applied to each individual header embeddable (a remnant of early work from before the header could contain any embeddable content - we never went back and fixed some of this CSS when we changed the header capabilities).

![image](https://user-images.githubusercontent.com/5126913/97651242-c31e1d00-1a18-11eb-8dbb-66117a44e710.png)
