### PR TITLE
Fix header embeddable sizing bugs

### DIFF
--- a/src/components/activity-page/activity-page-content.scss
+++ b/src/components/activity-page/activity-page-content.scss
@@ -18,6 +18,10 @@
     color: var(--theme-secondary-color);
   }
 
+  .introduction {
+    max-width: 900px;
+  }
+
   .embeddables {
     display: flex;
     flex-direction: row;

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -135,7 +135,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
     let questionNumber = totalPreviousQuestions;
     return (
       <React.Fragment>
-        { embeddables.map((embeddableWrapper, i: number) => {
+        { embeddables.map((embeddableWrapper) => {
             if (isQuestion(embeddableWrapper)) {
               questionNumber++;
             }
@@ -145,6 +145,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
                 key={`embeddable-${embeddableWrapper.embeddable.ref_id}`}
                 embeddableWrapper={embeddableWrapper}
                 pageLayout={this.props.page.layout}
+                pageSection={section}
                 questionNumber={isQuestion(embeddableWrapper) ? questionNumber : undefined}
                 linkedPluginEmbeddable={linkedPluginEmbeddable}
                 teacherEditionMode={this.props.teacherEditionMode}
@@ -160,7 +161,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
   private renderIntroEmbeddables = (embeddables: EmbeddableWrapper[], totalPreviousQuestions: number) => {
     return (
       <div className="embeddables">
-        <div className="group fill-remaining">
+        <div className="group fill-remaining responsive">
           {this.renderEmbeddables(embeddables, EmbeddableSections.Introduction, totalPreviousQuestions)}
         </div>
       </div>

--- a/src/components/activity-page/embeddable.test.tsx
+++ b/src/components/activity-page/embeddable.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { waitFor } from "@testing-library/dom";
 import iframePhone from "iframe-phone";
 import { Embeddable } from "./embeddable";
-import { PageLayouts } from "../../utilities/activity-utils";
+import { PageLayouts, EmbeddableSections } from "../../utilities/activity-utils";
 import { mount, ReactWrapper } from "enzyme";
 import { EmbeddableWrapper } from "../../types";
 import { act } from "react-dom/test-utils";
@@ -22,7 +22,7 @@ describe("Embeddable component", () => {
 
     let wrapper: ReactWrapper;
     await act(async () => {
-      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
+      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
       expect(wrapper.containsMatchingElement(<div>Loading...</div>)).toEqual(true);
     });
 
@@ -45,7 +45,7 @@ describe("Embeddable component", () => {
 
     let wrapper: ReactWrapper;
     await act(async () => {
-      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
+      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
       expect(wrapper.containsMatchingElement(<div>Loading...</div>)).toEqual(true);
     });
 
@@ -68,7 +68,7 @@ describe("Embeddable component", () => {
 
     let wrapper: ReactWrapper;
     await act(async () => {
-      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
+      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
     });
 
     await waitFor(() => {
@@ -92,7 +92,7 @@ describe("Embeddable component", () => {
 
     let wrapper: ReactWrapper;
     await act(async () => {
-      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive}/>);
+      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
     });
 
     await waitFor(() => {

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useContext, useEffect, useRef, useState }  from "re
 import { TextBox } from "./text-box/text-box";
 import { LaraGlobalContext } from "../lara-global-context";
 import { ManagedInteractive } from "./managed-interactive/managed-interactive";
-import { ActivityLayouts, PageLayouts } from "../../utilities/activity-utils";
+import { ActivityLayouts, PageLayouts, EmbeddableSections } from "../../utilities/activity-utils";
 import { EmbeddablePlugin } from "./plugins/embeddable-plugin";
 import { initializePlugin, IPartialEmbeddablePluginContext, validateEmbeddablePluginContextForWrappedEmbeddable
         } from "../../utilities/plugin-utils";
@@ -18,6 +18,7 @@ interface IProps {
   embeddableWrapper: EmbeddableWrapper;
   linkedPluginEmbeddable?: IEmbeddablePlugin;
   pageLayout: string;
+  pageSection: string;
   questionNumber?: number;
   teacherEditionMode?: boolean;
   setNavigation?: (id: string, options: INavigationOptions) => void;
@@ -26,7 +27,7 @@ interface IProps {
 type ISendCustomMessage = (message: ICustomMessage) => void;
 
 export const Embeddable: React.FC<IProps> = (props) => {
-  const { activityLayout, embeddableWrapper, linkedPluginEmbeddable, pageLayout, questionNumber, setNavigation, teacherEditionMode } = props;
+  const { activityLayout, embeddableWrapper, linkedPluginEmbeddable, pageLayout, pageSection, questionNumber, setNavigation, teacherEditionMode } = props;
   const embeddable = embeddableWrapper.embeddable;
 
   interface InitialInteractiveState {
@@ -117,12 +118,15 @@ export const Embeddable: React.FC<IProps> = (props) => {
     qComponent = <div>Content type not supported</div>;
   }
 
-  const staticWidth = pageLayout === PageLayouts.FortySixty || pageLayout === PageLayouts.SixtyForty || pageLayout === PageLayouts.Responsive;
+  const fillContainerWidth = pageSection !== EmbeddableSections.Introduction &&
+                             (pageLayout === PageLayouts.FortySixty ||
+                              pageLayout === PageLayouts.SixtyForty ||
+                              pageLayout === PageLayouts.Responsive);
   const singlePageLayout = activityLayout === ActivityLayouts.SinglePage;
 
   return (
     <div
-      className={`embeddable ${embeddableWrapper.embeddable.is_full_width || staticWidth || singlePageLayout ? "full-width" : "reduced-width"}`}
+      className={`embeddable ${embeddableWrapper.embeddable.is_full_width || fillContainerWidth || singlePageLayout ? "full-width" : "reduced-width"}`}
       data-cy="embeddable"
       key={embeddableWrapper.embeddable.ref_id}
     >

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { ActivityLayouts, PageLayouts, isQuestion, VisibleEmbeddables, getVisibleEmbeddablesOnPage } from "../../utilities/activity-utils";
+import { ActivityLayouts, PageLayouts, isQuestion, VisibleEmbeddables, getVisibleEmbeddablesOnPage,
+         EmbeddableSections } from "../../utilities/activity-utils";
 import { Embeddable } from "../activity-page/embeddable";
 import { RelatedContent } from "./related-content";
 import { SubmitButton } from "./submit-button";
@@ -33,6 +34,7 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
                 key={`embeddable ${embeddableNumber}`}
                 embeddableWrapper={embeddableWrapper}
                 pageLayout={PageLayouts.FullWidth}
+                pageSection={EmbeddableSections.InfoAssessment}
                 questionNumber={isQuestion(embeddableWrapper) ? questionNumber : undefined}
                 teacherEditionMode={teacherEditionMode}
               />


### PR DESCRIPTION
This PR adds more fixes to the header content sizing.  Changes include:
- the page header/intro max-width is brought back (was removed in previous PR).  LARA does in fact enforce a max-width of content in the header/intro which is needed when displaying the header/intro on a page with responsive layout.  This was erroneously removed in the last PR.
- the embeddable container in the page header/intro now includes the `responsive` class which allows non-full-width embeddables to wrap and display side-by-side in the page header/intro section.
- refinement of the code in the `Embeddable` component that determines if the embeddable is full or half width.  Half-width embeddables in the page header/intro section should include the `reduced-width` CSS class so that they are sized properly.