### PR TITLE
Use Firestore offline mode in AP preview mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-require-imports": "error",
       "@typescript-eslint/no-shadow": ["error", { builtinGlobals: false, hoist: "all", allow: [] }],
-      "@typescript-eslint/no-unused-vars": ["error", { args: "none", ignoreRestSiblings: true }],
+      "@typescript-eslint/no-unused-vars": ["warn", { args: "none", ignoreRestSiblings: true }],
       "@typescript-eslint/prefer-optional-chain": "warn",
       "@typescript-eslint/no-var-requires": "off",
       curly: ["error", "multi-line", "consistent"],

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -5,7 +5,7 @@ import iframePhone from "iframe-phone";
 import {
   ClientMessage, ICustomMessage, IGetFirebaseJwtRequest, IGetInteractiveSnapshotRequest,
   IGetInteractiveSnapshotResponse, IInitInteractive, ILinkedInteractive, IReportInitInteractive,
-  ISupportedFeatures, ServerMessage, IShowModal, ICloseModal, INavigationOptions
+  ISupportedFeatures, ServerMessage, IShowModal, ICloseModal, INavigationOptions, IGetInteractiveSnapshotOptions
 } from "@concord-consortium/lara-interactive-api";
 import Shutterbug from "shutterbug";
 import { Logger } from "../../../lib/logger";
@@ -36,7 +36,7 @@ interface IProps {
   ref?: React.Ref<IframeRuntimeImperativeAPI>;
 }
 
-export const IframeRuntime: React.FC<IProps> = forwardRef((props, ref) => {
+export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
   const { url, id, authoredState, initialInteractiveState, setInteractiveState, linkedInteractives, report,
     proposedHeight, containerWidth, setNewHint, getFirebaseJWT, showModal, closeModal, setSupportedFeatures,
     setSendCustomMessage, setNavigation } = props;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -85,8 +85,8 @@ export class App extends React.PureComponent<IProps, IState> {
 
       const showThemeButtons = queryValueBoolean("themeButtons");
       const teacherEditionMode = queryValue("mode")?.toLowerCase( )=== "teacher-edition";
-
-      const useAnonymousRunKey = !queryValue("token") && !queryValueBoolean("preview") && !teacherEditionMode;
+      // Teacher Edition mode is equal to preview mode. RunKey won't be used and the data won't be persisted.
+      const preview = queryValueBoolean("preview") || teacherEditionMode;
 
       const newState: Partial<IState> = {activity, currentPage, showThemeButtons, showSequence, sequence, teacherEditionMode};
       setDocumentTitle(activity, currentPage);
@@ -110,7 +110,7 @@ export class App extends React.PureComponent<IProps, IState> {
           if (portalData.runRemoteEndpoint) {
             runRemoteEndpoint = portalData.runRemoteEndpoint;
           }
-          await initializeDB(portalData.database.appName);
+          await initializeDB({ name: portalData.database.appName, preview: false });
           await signInWithToken(portalData.database.rawFirebaseJWT);
           this.setState({ portalData });
 
@@ -120,9 +120,9 @@ export class App extends React.PureComponent<IProps, IState> {
           this.setState({ authError: err });
           console.error("Authentication Error: " + err);
         }
-      } else if (useAnonymousRunKey) {
+      } else {
         try {
-          await initializeAnonymousDB();
+          await initializeAnonymousDB(preview);
           watchAnswers();
         } catch (err) {
           this.setState({ authError: err });

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -412,11 +412,17 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
 };
 
 // metadata for saving and loading work for anonymous users, not actually loaded from the portal
-export const anonymousPortalData = () => {
-  let runKey = queryValue("runKey");
-  if (!runKey) {
-    runKey = uuidv4();
-    setQueryValue("runKey", runKey);
+export const anonymousPortalData = (preview: boolean) => {
+  let runKey;
+  if (preview) {
+    // Set runKey to any value, it'll be saved only locally in offline Firestore.
+    runKey = "preview";
+  } else {
+    runKey = queryValue("runKey");
+    if (!runKey) {
+      runKey = uuidv4();
+      setQueryValue("runKey", runKey);
+    }
   }
 
   const hostname = window.location.hostname;


### PR DESCRIPTION
This a small PR to make watching interactive states easier.

Now, AP should always use Firestore, even in the preview mode. This lets me use db-related mechanisms for watching answers (this work is still in progress) => observing interactive state. I don't have to rely on some internal states of components in AP tree, I can just rely on Firestore values. In the future, this will let us use the same approach for observing interactive state from a different page (it should just come for free). And generally this change should generally make things make more consistent, as we can simply assume that Firestore is always used, but sometimes not use the network.