### PR TITLE
Fix / refactor Firestore helpers and interactive state handling

### DIFF
--- a/src/components/activity-page/embeddable.test.tsx
+++ b/src/components/activity-page/embeddable.test.tsx
@@ -1,15 +1,13 @@
 import React from "react";
-import { waitFor } from "@testing-library/dom";
 import iframePhone from "iframe-phone";
 import { Embeddable } from "./embeddable";
 import { PageLayouts, EmbeddableSections } from "../../utilities/activity-utils";
-import { mount, ReactWrapper } from "enzyme";
-import { EmbeddableWrapper } from "../../types";
-import { act } from "react-dom/test-utils";
+import { mount } from "enzyme";
+import { EmbeddableWrapper, IManagedInteractive } from "../../types";
 import { DefaultManagedInteractive, DefaultXhtmlComponent } from "../../test-utils/model-for-tests";
 
 describe("Embeddable component", () => {
-  it("renders a non-callout text component", async () => {
+  it("renders a non-callout text component", () => {
     const embeddableWrapper: EmbeddableWrapper = {
       "embeddable": {
         ...DefaultXhtmlComponent,
@@ -20,20 +18,12 @@ describe("Embeddable component", () => {
       "section": "header_block"
     };
 
-    let wrapper: ReactWrapper;
-    await act(async () => {
-      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
-      expect(wrapper.containsMatchingElement(<div>Loading...</div>)).toEqual(true);
-    });
-
-    await waitFor(() => {
-      wrapper.update();
-      expect(wrapper.find(".textbox").hasClass("callout")).toBe(false);
-      expect(wrapper.text()).toContain("This is a page");
-    });
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
+    expect(wrapper.find(".textbox").hasClass("callout")).toBe(false);
+    expect(wrapper.text()).toContain("This is a page");
   });
 
-  it("renders a callout text component", async () => {
+  it("renders a callout text component", () => {
     const embeddableWrapper: EmbeddableWrapper = {
       "embeddable": {
         ...DefaultXhtmlComponent,
@@ -43,21 +33,12 @@ describe("Embeddable component", () => {
       "section": "header_block"
     };
 
-    let wrapper: ReactWrapper;
-    await act(async () => {
-      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
-      expect(wrapper.containsMatchingElement(<div>Loading...</div>)).toEqual(true);
-    });
-
-    await waitFor(() => {
-      wrapper.update();
-      expect(wrapper.find(".textbox").hasClass("callout")).toBe(true);
-      expect(wrapper.text()).toContain("This is a callout text box");
-    });
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
+    expect(wrapper.find(".textbox").hasClass("callout")).toBe(true);
+    expect(wrapper.text()).toContain("This is a callout text box");
   });
 
-  it("renders an empty managed interactive", async () => {
-
+  it("renders an empty managed interactive", () => {
     const embeddableWrapper: EmbeddableWrapper = {
       "embeddable": {
         ...DefaultManagedInteractive,
@@ -66,17 +47,11 @@ describe("Embeddable component", () => {
       "section": "interactive_box"
     };
 
-    let wrapper: ReactWrapper;
-    await act(async () => {
-      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
-    });
-
-    await waitFor(() => {
-      expect(wrapper.text()).toContain("Content type not supported");
-    });
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
+    expect(wrapper.text()).toContain("Content type not supported");
   });
 
-  it("renders a managed interactive", async () => {
+  it("renders a managed interactive", () => {
     iframePhone.ParentEndpoint = jest.fn().mockImplementation(() => ({
       disconnect: jest.fn()
     }));
@@ -89,19 +64,13 @@ describe("Embeddable component", () => {
       },
       "section": "interactive_box"
     };
+    // Disable interactive state observing for this test.
+    (embeddableWrapper.embeddable as IManagedInteractive).library_interactive!.data!.enable_learner_state = false;
 
-    let wrapper: ReactWrapper;
-    await act(async () => {
-      wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
-    });
-
-    await waitFor(() => {
-      // for some reason, can't get any version of
-      //   expect(wrapper.find("ManagedInteractive").length).toBe(1);
-      //   expect(wrapper.find("iframe").length).toBe(1);
-      //   expect(wrapper.find('[data-cy="iframe-runtime"]').length).toBe(1);
-      // to work
-      expect(wrapper.html()).toContain("iframe-runtime");
-    });
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
+    expect(wrapper.find("ManagedInteractive").length).toBe(1);
+    expect(wrapper.find("iframe").length).toBe(1);
+    expect(wrapper.find('[data-cy="iframe-runtime"]').length).toBe(1);
+    expect(wrapper.html()).toContain("iframe-runtime");
   });
 });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -5,7 +5,7 @@ import iframePhone from "iframe-phone";
 import {
   ClientMessage, ICustomMessage, IGetFirebaseJwtRequest, IGetInteractiveSnapshotRequest,
   IGetInteractiveSnapshotResponse, IInitInteractive, ILinkedInteractive, IReportInitInteractive,
-  ISupportedFeatures, ServerMessage, IShowModal, ICloseModal, INavigationOptions, IGetInteractiveSnapshotOptions
+  ISupportedFeatures, ServerMessage, IShowModal, ICloseModal, INavigationOptions
 } from "@concord-consortium/lara-interactive-api";
 import Shutterbug from "shutterbug";
 import { Logger } from "../../../lib/logger";

--- a/src/components/activity-page/managed-interactive/managed-interactive.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.test.tsx
@@ -54,7 +54,6 @@ describe("ManagedInteractive component", () => {
     };
     const wrapper = shallow(<ManagedInteractive
                               embeddable={sampleEmbeddable}
-                              initialInteractiveState={null}
                               questionNumber={1}
                               setSupportedFeatures={() => { /* nop */ }}
                               setSendCustomMessage={() => { /* nop */ }}

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -76,7 +76,7 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
     }
     const url = embeddableData?.base_url || embeddableData?.url || "";
     const authoredState = useMemo(() => safeJsonParseIfString(authored_state) || {}, [authored_state]);
-    const linkedInteractives = useRef((embeddable.type === "ManagedInteractive") && embeddable.linked_interactives?.length
+    const linkedInteractives = useRef(embeddable.linked_interactives?.length
                                   ? embeddable.linked_interactives.map(link => ({ id: link.ref_id, label: link.label }))
                                   : undefined);
     // interactiveId value should always match IDs generated above in the `linkedInteractives` array.

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useContext, useMemo, useRef } from "react";
+import React, { useState, useCallback, useContext, useMemo, useRef, useEffect } from "react";
 import Modal from "react-modal";
 import { IframeRuntime, IframeRuntimeImperativeAPI } from "./iframe-runtime";
 import useResizeObserver from "@react-hook/resize-observer";
@@ -8,9 +8,9 @@ import {
 } from "@concord-consortium/lara-interactive-api";
 import { PortalDataContext } from "../../portal-data-context";
 import { IManagedInteractive, IMwInteractive, LibraryInteractiveData, IExportableAnswerMetadata } from "../../../types";
-import { createOrUpdateAnswer } from "../../../firebase-db";
+import { createOrUpdateAnswer, watchAnswer } from "../../../firebase-db";
 import { handleGetFirebaseJWT } from "../../../portal-utils";
-import { getAnswerWithMetadata } from "../../../utilities/embeddable-utils";
+import { getAnswerWithMetadata, isQuestion } from "../../../utilities/embeddable-utils";
 import IconQuestion from "../../../assets/svg-icons/icon-question.svg";
 import IconArrowUp from "../../../assets/svg-icons/icon-arrow-up.svg";
 import { accessibilityClick } from "../../../utilities/accessibility-helper";
@@ -23,8 +23,6 @@ import "./managed-interactive.scss";
 interface IProps {
   embeddable: IManagedInteractive | IMwInteractive;
   questionNumber?: number;
-  initialInteractiveState: any;     // user state that existed in DB when embeddable was first loaded
-  initialAnswerMeta?: IExportableAnswerMetadata;   // saved metadata for that initial user state
   setSupportedFeatures: (container: HTMLElement, features: ISupportedFeatures) => void;
   setSendCustomMessage: (sender: (message: ICustomMessage) => void) => void;
   setNavigation?: (options: INavigationOptions) => void;
@@ -39,12 +37,27 @@ const getModalContainer = (): HTMLElement => {
 export const ManagedInteractive: React.FC<IProps> = (props) => {
   const iframeRuntimeRef = useRef<IframeRuntimeImperativeAPI>(null);
   const onSetInteractiveStateCallback = useRef<() => void>();
+  const interactiveState = useRef<any>();
+  const answerMeta = useRef<IExportableAnswerMetadata>();
+  const shouldWatchAnswer = isQuestion(props.embeddable);
+  const [loading, setLoading] = useState(shouldWatchAnswer);
+
+  const embeddableRefId = props.embeddable.ref_id;
+  useEffect(() => {
+    if (shouldWatchAnswer) {
+      return watchAnswer(embeddableRefId, (wrappedAnswer) => {
+        answerMeta.current = wrappedAnswer?.meta;
+        interactiveState.current = wrappedAnswer?.interactiveState;
+        setLoading(false);
+      });
+    }
+  }, [embeddableRefId, shouldWatchAnswer]);
 
     const handleNewInteractiveState = (state: IRuntimeMetadata) => {
       // Keep interactive state in sync if iFrame is opened in modal popup
-      iframeInteractiveState.current = state;
+      interactiveState.current = state;
 
-      const exportableAnswer = getAnswerWithMetadata(state, props.embeddable as IManagedInteractive, props.initialAnswerMeta);
+      const exportableAnswer = getAnswerWithMetadata(state, props.embeddable as IManagedInteractive, answerMeta.current);
       if (exportableAnswer) {
         createOrUpdateAnswer(exportableAnswer);
       }
@@ -59,12 +72,10 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
       return handleGetFirebaseJWT({ firebase_app: firebaseApp, ...others }, portalData);
     }, [portalData]);
 
-    const { embeddable, questionNumber, initialInteractiveState, setSupportedFeatures, setSendCustomMessage, setNavigation } = props;
+    const { embeddable, questionNumber, setSupportedFeatures, setSendCustomMessage, setNavigation } = props;
     const { authored_state } = embeddable;
     const [ activeDialog, setActiveDialog ] = useState<IShowDialog | null>(null);
     const [ activeLightbox, setActiveLightbox ] = useState<IShowLightbox | null>(null);
-    // both Modal and inline versions of interactive should reflect the same state
-    const iframeInteractiveState = useRef(initialInteractiveState);
     const questionName = embeddable.name ? `: ${embeddable.name}` : "";
     // in older iframe interactive embeddables, we get url, native_width, native_height, etc. directly off
     // of the embeddable object. On newer managed/library interactives, this data is in library_interactive.data.
@@ -159,12 +170,14 @@ export const ManagedInteractive: React.FC<IProps> = (props) => {
   };
 
   const interactiveIframeRuntime =
+    loading ?
+      "Loading..." :
       <IframeRuntime
         ref={iframeRuntimeRef}
         url={activeDialog?.url || url}
         id={interactiveId}
         authoredState={authoredState}
-        initialInteractiveState={iframeInteractiveState.current}
+        initialInteractiveState={interactiveState.current}
         setInteractiveState={handleNewInteractiveState}
         setSupportedFeatures={setSupportedFeatures}
         linkedInteractives={linkedInteractives.current}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -13,7 +13,7 @@ import { WarningBanner } from "./warning-banner";
 import { CompletionPageContent } from "./activity-completion/completion-page-content";
 import { queryValue, queryValueBoolean } from "../utilities/url-query";
 import { fetchPortalData, IPortalData } from "../portal-api";
-import { signInWithToken, watchAnswers, initializeDB, setPortalData, initializeAnonymousDB } from "../firebase-db";
+import { signInWithToken, initializeDB, setPortalData, initializeAnonymousDB } from "../firebase-db";
 import { Activity, Sequence } from "../types";
 import { initializeLara, LaraGlobalType } from "../lara-plugin/index";
 import { LaraGlobalContext } from "./lara-global-context";
@@ -115,7 +115,6 @@ export class App extends React.PureComponent<IProps, IState> {
           this.setState({ portalData });
 
           setPortalData(portalData);
-          watchAnswers();
         } catch (err) {
           this.setState({ authError: err });
           console.error("Authentication Error: " + err);
@@ -123,7 +122,6 @@ export class App extends React.PureComponent<IProps, IState> {
       } else {
         try {
           await initializeAnonymousDB(preview);
-          watchAnswers();
         } catch (err) {
           this.setState({ authError: err });
           console.error("Authentication Error: " + err);

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -14,7 +14,6 @@ import { IPortalData, IAnonymousPortalData, anonymousPortalData } from "./portal
 import { refIdToAnswersQuestionId } from "./utilities/embeddable-utils";
 import { IExportableAnswerMetadata, LTIRuntimeAnswerMetadata, AnonymousRuntimeAnswerMetadata } from "./types";
 import { queryValueBoolean } from "./utilities/url-query";
-import DocumentData = firebase.firestore.DocumentData;
 
 export type FirebaseAppName = "report-service-dev" | "report-service-pro";
 
@@ -228,5 +227,5 @@ export function createOrUpdateAnswer(answer: IExportableAnswerMetadata) {
 
   return firebase.firestore()
       .doc(answersPath(answer.id))
-      .set(postAnswer as Partial<DocumentData>, {merge: true});
+      .set(postAnswer as Partial<firebase.firestore.DocumentData>, {merge: true});
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface IMwInteractive extends EmbeddableBase {
   native_height?: number;
   native_width?: number;
   enable_learner_state?: boolean;
+  linked_interactives?: { ref_id: string, label: string }[];
 }
 
 export interface IEmbeddableXhtml extends EmbeddableBase {

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -1,5 +1,6 @@
 import { Page, Activity, EmbeddableWrapper } from "../types";
 import { SidebarConfiguration } from "../components/page-sidebar/sidebar-wrapper";
+import { isQuestion as isEmbeddableQuestion } from "./embeddable-utils";
 
 export enum ActivityLayouts {
   MultiplePages = 0,
@@ -25,10 +26,7 @@ export interface VisibleEmbeddables {
   infoAssessment: EmbeddableWrapper[],
 }
 
-export const isQuestion = (embeddableWrapper: EmbeddableWrapper) => {
-  return ((embeddableWrapper.embeddable.type === "ManagedInteractive" && embeddableWrapper.embeddable.library_interactive?.data?.enable_learner_state)
-          || (embeddableWrapper.embeddable.type === "MwInteractive" && embeddableWrapper.embeddable.enable_learner_state));
-};
+export const isQuestion = (embeddableWrapper: EmbeddableWrapper) => isEmbeddableQuestion(embeddableWrapper.embeddable);
 
 export interface PageSectionQuestionCount {
   Header: number;

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -2,8 +2,13 @@ import { v4 as uuidv4 } from "uuid";
 import { IAuthoringMetadata, IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
 import {
   IExportableAnswerMetadata, IManagedInteractive, IReportState, IExportableMultipleChoiceAnswerMetadata,
-  IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata, IExportableImageQuestionAnswerMetadata
+  IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata, IExportableImageQuestionAnswerMetadata,
+  Embeddable
 } from "../types";
+
+export const isQuestion = (embeddable: Embeddable) =>
+  (embeddable.type === "ManagedInteractive" && embeddable.library_interactive?.data?.enable_learner_state) ||
+  (embeddable.type === "MwInteractive" && embeddable.enable_learner_state);
 
 export const getAnswerWithMetadata = (
     interactiveState: IRuntimeMetadata,


### PR DESCRIPTION
The main problem was that interactives were sometimes sending multiple docs to Firestore, as answerMeta was never updated, and they're generating new UUID each time. This PR fixes that by more general refactoring of firestore helpers and interactive state handling.

- Firestore helpers are simplified and reorganized a bit. There are no separate listeners and local DB copy, as it seemed a bit redundant. Firestore already provides API to observe docs. 
- Interactive state handling is removed from `embeddable.ts` and limited to `managed-interactive.ts`. 
- linked_interactives are passed to MwInteractives too (not only ManagedInteractives).

