### PR TITLE
Add async load of plugin scripts before loading page content

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -91,6 +91,11 @@ export class App extends React.PureComponent<IProps, IState> {
       const newState: Partial<IState> = {activity, currentPage, showThemeButtons, showSequence, sequence, teacherEditionMode};
       setDocumentTitle(activity, currentPage);
 
+      this.LARA = initializeLara();
+      if (teacherEditionMode) {
+        await loadPluginScripts(this.LARA, activity);
+      }
+
       let classHash = "";
       let role = "unknown";
       let runRemoteEndpoint = "";
@@ -129,11 +134,6 @@ export class App extends React.PureComponent<IProps, IState> {
       }
 
       this.setState(newState as IState);
-
-      this.LARA = initializeLara();
-      if (teacherEditionMode) {
-        loadPluginScripts(this.LARA, activity);
-      }
 
       Modal.setAppElement("#app");
 

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -22,7 +22,7 @@ export const Plugins: PluginInfo[] = [
   },
 ];
 
-export const loadPluginScripts = (LARA: LaraGlobalType, activity: Activity) => {
+export const loadPluginScripts = async (LARA: LaraGlobalType, activity: Activity) => {
   // load any plugin scripts, each should call registerPlugin if correctly loaded
   const usedPlugins: PluginInfo[] = [];
   for (let page = 0; page < activity.pages.length - 1; page++) {
@@ -39,20 +39,27 @@ export const loadPluginScripts = (LARA: LaraGlobalType, activity: Activity) => {
     }
   }
 
-  usedPlugins.forEach((plugin) => {
-    // set plugin label
+  // load the plugin scripts
+  for (const plugin of usedPlugins) {
     const pluginLabel = "plugin" + plugin.id;
     LARA.Plugins.setNextPluginLabel(pluginLabel);
-    // load the script
-    const script = document.createElement("script");
-    script.type = "text/javascript";
-    script.src = plugin.url;
-    document.body.appendChild(script);
+    await loadScript(plugin.url);
+  }
+};
+
+const loadScript = async (url: string) => {
+  const script = document.createElement("script");
+  script.type = "text/javascript";
+  script.src = url;
+  document.body.appendChild(script);
+
+  const promise = new Promise((resolve, reject) => {
     script.onload = function() {
-      // TODO: might need additional handling here
-      // console.log("plugin script loaded");
+      resolve(true);
     };
   });
+  const result = await promise;
+  return result;
 };
 
 export interface IEmbeddablePluginContext {


### PR DESCRIPTION
Use async/await to load the plugin scripts before loading the rest of the page content.  Previously, plugins only worked if the user went to the intro page first (where the plugin scripts would be loaded) and then navigated to the activity internal pages (at this point, the plugin scripts had been loaded on the intro page and could be used by the internal page embeddables).  However, if a user navigated directly to a page or to a single page activity, the embeddable page content would be loaded before the plugins, would attempt to access the not-yet-loaded plugin scripts. and the plugin content would fail to be displayed.

I tested some examples of using both the TE and glossary plugins on a page, and I do not see any noticeable slow down caused by waiting for the plugin scripts to load.

For comparison, here is how direct page load with plugins looks on master (note that content fails to load):
https://activity-player.concord.org/branch/master/?mode=teacher-edition&preview&activity=sample-activity-plugins&page=2

And here is how it looks on the PR branch:
https://activity-player.concord.org/branch/plugin-load/?mode=teacher-edition&preview&activity=sample-activity-plugins&page=2