### PR TITLE
Fix header content in single page layout

### DIFF
--- a/src/components/activity-header/header.test.tsx
+++ b/src/components/activity-header/header.test.tsx
@@ -11,27 +11,24 @@ describe("Header component", () => {
     const headerLogo1 = <Logo logo={mwLogo} url={"http://mw.concord.org/nextgen/"}/>;
     const headerLogo9 = <Logo logo={ccLogo} url={"https://concord.org/"}/>;
 
-    const wrapperIcon = shallow(<Header projectId={1} userName={"test student"} contentName={"test activity"} singlePage={false} />);
+    const wrapperIcon = shallow(<Header projectId={1} userName={"test student"} contentName={"test activity"} />);
     expect(wrapperIcon.containsMatchingElement(headerLogo1)).toEqual(true);
 
-    const wrapperNoIcon = shallow(<Header projectId={9} userName={"test student"} contentName={"test activity"} singlePage={false} />);
+    const wrapperNoIcon = shallow(<Header projectId={9} userName={"test student"} contentName={"test activity"} />);
     expect(wrapperNoIcon.containsMatchingElement(headerLogo9)).toEqual(true);
   });
   it("renders activity title dropdown when appropriate", () => {
     const activityDropdown = <div className="activity-title" data-cy ="activity-title">Activity:</div>;
 
-    const wrapperDropdown = shallow(<Header projectId={1} userName={"test student"} contentName={"test activity"} singlePage={false} />);
+    const wrapperDropdown = shallow(<Header projectId={1} userName={"test student"} contentName={"test activity"} />);
     expect(wrapperDropdown.containsMatchingElement(activityDropdown)).toEqual(true);
-
-    const wrapperNoDropdown = shallow(<Header projectId={1} userName={"test student"} contentName={"test activity"} singlePage={true} />);
-    expect(wrapperNoDropdown.containsMatchingElement(activityDropdown)).toEqual(false);
   });
   it("renders user name", () => {
       const user = "Student User";
       const accountOwner = <AccountOwner userName={user} />;
 
       const wrapperAccountOwner = shallow(accountOwner);
-      const wrapperHeader = shallow(<Header projectId={1} userName={user} contentName={"test activity"} singlePage={false} />);
+      const wrapperHeader = shallow(<Header projectId={1} userName={user} contentName={"test activity"} />);
       expect(wrapperHeader.containsMatchingElement(accountOwner)).toEqual(true);
       expect(wrapperAccountOwner.text()).toContain(user);
   });

--- a/src/components/activity-header/header.tsx
+++ b/src/components/activity-header/header.tsx
@@ -13,7 +13,6 @@ interface IProps {
   projectId: number | null;
   userName: string;
   contentName: string;
-  singlePage: boolean;
   showSequence?: boolean;
   sequenceLogo?: string | null;
 }
@@ -21,20 +20,19 @@ interface IProps {
 export class Header extends React.PureComponent<IProps> {
   render() {
     const ccLogoLink = "https://concord.org/";
-    const { fullWidth, projectId, userName, singlePage, sequenceLogo } = this.props;
+    const { fullWidth, projectId, userName, sequenceLogo } = this.props;
     const projectType = ProjectTypes.find(pt => pt.id === projectId);
     const logo = projectType?.headerLogo || ccLogo;
     const projectURL = projectType?.url || ( logo === ccLogo ? ccLogoLink : undefined );
-
     return (
       <div className="activity-header" data-cy="activity-header">
         <div className={`inner ${fullWidth ? "full" : ""}`}>
           <div className="header-left">
-            <Logo logo={logo} url={projectURL}/>
+            <Logo logo={logo} url={projectURL} />
           </div>
           <div className="header-center">
             {sequenceLogo && <img src={sequenceLogo} />}
-            {!singlePage && this.renderActivityMenu()}
+            {this.renderActivityMenu()}
           </div>
           <div className="header-right">
             <AccountOwner userName={userName} />

--- a/src/components/app.test.tsx
+++ b/src/components/app.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { App } from "./app";
+import { shallow } from "enzyme";
+import { Activity } from "../types";
+import { ActivityNavHeader } from "../components/activity-header/activity-nav-header";
+import { Header } from "./activity-header/header";
+import { Footer } from "./activity-introduction/footer";
+import _activitySinglePage from "../data/sample-activity-single-page-layout.json";
+import _activity from "../data/sample-activity-multiple-layout-types.json";
+
+const activity = _activity as Activity;
+const activitySinglePage = _activitySinglePage as Activity;
+
+describe("App component", () => {
+  it("renders component", () => {
+    const wrapper = shallow(<App />);
+    expect(wrapper.find('[data-cy="app"]').length).toBe(1);
+    wrapper.setState({ activity });
+    expect(wrapper.find(ActivityNavHeader).length).toBe(1);
+    expect(wrapper.find(Header).length).toBe(1);
+    expect(wrapper.find(Footer).length).toBe(1);
+  });
+  it("renders single page activity", () => {
+    const wrapper = shallow(<App />);
+    wrapper.setState({ activity: activitySinglePage });
+    expect(wrapper.find(ActivityNavHeader).length).toBe(0);
+    expect(wrapper.find(Header).length).toBe(1);
+    expect(wrapper.find(Footer).length).toBe(1);
+  });
+});

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -178,7 +178,6 @@ export class App extends React.PureComponent<IProps, IState> {
           projectId={activity.project_id}
           userName={username}
           contentName={activity.name}
-          singlePage={activity.layout === ActivityLayouts.SinglePage}
         />
         { authError
           ? <AuthError />
@@ -205,16 +204,18 @@ export class App extends React.PureComponent<IProps, IState> {
   private renderActivityContent = (activity: Activity, currentPage: number, totalPreviousQuestions: number, fullWidth: boolean) => {
     return (
       <>
-        <ActivityNavHeader
-          activityPages={activity.pages}
-          currentPage={currentPage}
-          fullWidth={fullWidth}
-          onPageChange={this.handleChangePage}
-          singlePage={activity.layout === ActivityLayouts.SinglePage}
-          sequenceName={this.state.sequence?.display_title || (this.state.sequence && "Sequence")}
-          onShowSequence={this.handleShowSequence}
-          lockForwardNav={this.state.incompleteQuestions.length > 0}
-        />
+        { (activity.layout !== ActivityLayouts.SinglePage || this.state.sequence) &&
+          <ActivityNavHeader
+            activityPages={activity.pages}
+            currentPage={currentPage}
+            fullWidth={fullWidth}
+            onPageChange={this.handleChangePage}
+            singlePage={activity.layout === ActivityLayouts.SinglePage}
+            sequenceName={this.state.sequence?.display_title || (this.state.sequence && "Sequence")}
+            onShowSequence={this.handleShowSequence}
+            lockForwardNav={this.state.incompleteQuestions.length > 0}
+          />
+        }
         { activity.layout === ActivityLayouts.SinglePage
           ? this.renderSinglePageContent(activity)
           : currentPage === 0
@@ -242,18 +243,18 @@ export class App extends React.PureComponent<IProps, IState> {
   private renderSinglePageContent = (activity: Activity) => {
     return (
       <SinglePageContent
-          activity={activity}
-          teacherEditionMode={this.state.teacherEditionMode}
-        />
+        activity={activity}
+        teacherEditionMode={this.state.teacherEditionMode}
+      />
     );
   }
 
   private renderIntroductionContent = (activity: Activity) => {
     return (
       <IntroductionPageContent
-          activity={activity}
-          onPageChange={this.handleChangePage}
-        />
+        activity={activity}
+        onPageChange={this.handleChangePage}
+      />
     );
   }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -148,7 +148,7 @@ export class App extends React.PureComponent<IProps, IState> {
     return (
       <LaraGlobalContext.Provider value={this.LARA}>
         <PortalDataContext.Provider value={this.state.portalData}>
-          <div className="app">
+          <div className="app" data-cy="app">
             <WarningBanner/>
             { this.state.teacherEditionMode && <TeacherEditionBanner/>}
             { this.state.showSequence

--- a/src/components/sequence-introduction/sequence-introduction.tsx
+++ b/src/components/sequence-introduction/sequence-introduction.tsx
@@ -21,7 +21,6 @@ export const SequenceIntroduction: React.FC<IProps> = (props) => {
           projectId={sequence.project_id}
           userName={username}
           contentName={sequence.display_title || sequence.title || ""}
-          singlePage={false}
           showSequence={true}
           sequenceLogo={sequence.logo}
         />


### PR DESCRIPTION
This PR fixes the header content in the single page layout activity.  Previously no activity title was shown and an empty nav bar was shown (a big empty rectangle).  I believe we should show the activity title in the header and only show the nav bar if needed (the only case is if we are in a sequence and need to show a link back to the main sequence page).

Previous version:
![image](https://user-images.githubusercontent.com/5126913/100050849-35dba780-2dcf-11eb-89e8-8808a8127eee.png)

Updated version:
![image](https://user-images.githubusercontent.com/5126913/100050863-3e33e280-2dcf-11eb-8b16-d543fe93ba05.png)
