### PR TITLE
175844168 plugin load v2

### DIFF
--- a/src/components/activity-page/activity-page-content.test.tsx
+++ b/src/components/activity-page/activity-page-content.test.tsx
@@ -23,6 +23,7 @@ describe("Activity Page Content component", () => {
       pageNumber={5}
       totalPreviousQuestions={5}
       setNavigation={stubFunction}
+      pluginsLoaded={true}
     />);
     expect(getByTestId("page-content")).toBeDefined();
     expect(getByTestId("bottom-button-back")).toBeEnabled();

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -27,6 +27,7 @@ interface IProps {
   totalPreviousQuestions: number;
   setNavigation: (refId: string, options: INavigationOptions) => void;
   lockForwardNav?: boolean;
+  pluginsLoaded: boolean;
 }
 
 interface IState {
@@ -151,6 +152,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
                 linkedPluginEmbeddable={linkedPluginEmbeddable}
                 teacherEditionMode={this.props.teacherEditionMode}
                 setNavigation={this.props.setNavigation}
+                pluginsLoaded={this.props.pluginsLoaded}
               />
             );
           })

--- a/src/components/activity-page/embeddable.test.tsx
+++ b/src/components/activity-page/embeddable.test.tsx
@@ -18,7 +18,7 @@ describe("Embeddable component", () => {
       "section": "header_block"
     };
 
-    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment} pluginsLoaded={true} />);
     expect(wrapper.find(".textbox").hasClass("callout")).toBe(false);
     expect(wrapper.text()).toContain("This is a page");
   });
@@ -33,7 +33,7 @@ describe("Embeddable component", () => {
       "section": "header_block"
     };
 
-    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment} pluginsLoaded={true} />);
     expect(wrapper.find(".textbox").hasClass("callout")).toBe(true);
     expect(wrapper.text()).toContain("This is a callout text box");
   });
@@ -47,7 +47,7 @@ describe("Embeddable component", () => {
       "section": "interactive_box"
     };
 
-    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment} pluginsLoaded={true} />);
     expect(wrapper.text()).toContain("Content type not supported");
   });
 
@@ -67,7 +67,7 @@ describe("Embeddable component", () => {
     // Disable interactive state observing for this test.
     (embeddableWrapper.embeddable as IManagedInteractive).library_interactive!.data!.enable_learner_state = false;
 
-    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment}/>);
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} questionNumber={1} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.InfoAssessment} pluginsLoaded={true} />);
     expect(wrapper.find("ManagedInteractive").length).toBe(1);
     expect(wrapper.find("iframe").length).toBe(1);
     expect(wrapper.find('[data-cy="iframe-runtime"]').length).toBe(1);

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -21,12 +21,13 @@ interface IProps {
   questionNumber?: number;
   teacherEditionMode?: boolean;
   setNavigation?: (id: string, options: INavigationOptions) => void;
+  pluginsLoaded: boolean;
 }
 
 type ISendCustomMessage = (message: ICustomMessage) => void;
 
 export const Embeddable: React.FC<IProps> = (props) => {
-  const { activityLayout, embeddableWrapper, linkedPluginEmbeddable, pageLayout, pageSection, questionNumber, setNavigation, teacherEditionMode } = props;
+  const { activityLayout, embeddableWrapper, linkedPluginEmbeddable, pageLayout, pageSection, questionNumber, setNavigation, teacherEditionMode, pluginsLoaded } = props;
   const embeddable = embeddableWrapper.embeddable;
   const handleSetNavigation = useCallback((options: INavigationOptions) => {
     setNavigation?.(embeddable.ref_id, options);
@@ -50,10 +51,10 @@ export const Embeddable: React.FC<IProps> = (props) => {
       sendCustomMessage: sendCustomMessage.current
     };
     const validPluginContext = validateEmbeddablePluginContextForWrappedEmbeddable(pluginContext);
-    if (validPluginContext && teacherEditionMode) {
+    if (validPluginContext && teacherEditionMode && pluginsLoaded) {
       initializePlugin(validPluginContext);
     }
-  }, [LARA, linkedPluginEmbeddable, embeddable, teacherEditionMode]);
+  }, [LARA, linkedPluginEmbeddable, embeddable, teacherEditionMode, pluginsLoaded]);
 
   const handleSetSupportedFeatures = useCallback((container: HTMLElement, features: ISupportedFeatures) => {
     const event: IInteractiveSupportedFeaturesEvent = {
@@ -72,7 +73,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
                     setSendCustomMessage={setSendCustomMessage}
                     setNavigation={handleSetNavigation} />;
   } else if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.component_label === "windowShade") {
-    qComponent = teacherEditionMode ? <EmbeddablePlugin embeddable={embeddable} /> : undefined;
+    qComponent = teacherEditionMode ? <EmbeddablePlugin embeddable={embeddable} pluginsLoaded={pluginsLoaded} /> : undefined;
   } else if (embeddable.type === "Embeddable::Xhtml") {
     qComponent = <TextBox embeddable={embeddable} />;
   } else {

--- a/src/components/activity-page/plugins/embeddable-plugin.test.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.test.tsx
@@ -17,7 +17,7 @@ describe("Embeddable component", () => {
       "type": "Embeddable::EmbeddablePlugin",
       "ref_id": "2991-Embeddable::EmbeddablePlugin"
     };
-    const wrapper = shallow(<EmbeddablePlugin embeddable={embeddable}/>);
+    const wrapper = shallow(<EmbeddablePlugin embeddable={embeddable} pluginsLoaded={true} />);
     expect(wrapper.find('[data-cy="embeddable-plugin"]').length).toBe(1);
   });
 });

--- a/src/components/activity-page/plugins/embeddable-plugin.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.tsx
@@ -8,10 +8,11 @@ import "./embeddable-plugin.scss";
 
 interface IProps {
   embeddable: IEmbeddablePlugin;
+  pluginsLoaded: boolean;
 }
 
 export const EmbeddablePlugin: React.FC<IProps> = (props) => {
-    const { embeddable } = props;
+    const { embeddable, pluginsLoaded } = props;
     const divTarget = useRef<HTMLInputElement>(null);
     const LARA = useContext(LaraGlobalContext);
     useEffect(() => {
@@ -21,10 +22,10 @@ export const EmbeddablePlugin: React.FC<IProps> = (props) => {
         embeddableContainer: divTarget.current || undefined
       };
       const validPluginContext = validateEmbeddablePluginContextForPlugin(pluginContext);
-      if (validPluginContext) {
+      if (validPluginContext && pluginsLoaded) {
         initializePlugin(validPluginContext);
       }
-    }, [LARA, embeddable]);
+    }, [LARA, embeddable, pluginsLoaded]);
     return (
       <div className="plugin-container" ref={divTarget} data-cy="embeddable-plugin" key={embeddable.ref_id} />
     );

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -50,6 +50,7 @@ interface IState {
   showModal: boolean;
   modalLabel: string
   incompleteQuestions: IncompleteQuestion[];
+  pluginsLoaded: boolean;
 }
 interface IProps {}
 
@@ -68,6 +69,7 @@ export class App extends React.PureComponent<IProps, IState> {
       showModal: false,
       modalLabel: "",
       incompleteQuestions: [],
+      pluginsLoaded: false,
     };
   }
 
@@ -132,7 +134,7 @@ export class App extends React.PureComponent<IProps, IState> {
 
       this.LARA = initializeLara();
       if (teacherEditionMode) {
-        loadPluginScripts(this.LARA, activity);
+        loadPluginScripts(this.LARA, activity, this.handleLoadPlugins);
       }
 
       Modal.setAppElement("#app");
@@ -167,7 +169,7 @@ export class App extends React.PureComponent<IProps, IState> {
   }
 
   private renderActivity = () => {
-    const { activity, authError, currentPage, username } = this.state;
+    const { activity, authError, currentPage, username, pluginsLoaded } = this.state;
     if (!activity) return (<div>Loading</div>);
     const totalPreviousQuestions = numQuestionsOnPreviousPages(currentPage, activity);
     const fullWidth = (currentPage !== 0) && (activity.pages[currentPage - 1].layout === PageLayouts.Responsive);
@@ -189,7 +191,7 @@ export class App extends React.PureComponent<IProps, IState> {
             projectId={activity.project_id}
           />
         }
-        { (activity.layout !== ActivityLayouts.SinglePage && currentPage !== 0 && !activity.pages[currentPage - 1].is_completion) &&
+        { pluginsLoaded && (activity.layout === ActivityLayouts.SinglePage || (currentPage !== 0 && !activity.pages[currentPage - 1].is_completion)) &&
           <ExpandableContainer
             activity={activity}
             pageNumber={currentPage}
@@ -234,6 +236,7 @@ export class App extends React.PureComponent<IProps, IState> {
                   setNavigation={this.handleSetNavigation}
                   key={`page-${currentPage}`}
                   lockForwardNav={this.state.incompleteQuestions.length > 0}
+                  pluginsLoaded={this.state.pluginsLoaded}
                 />
         }
       </>
@@ -245,6 +248,7 @@ export class App extends React.PureComponent<IProps, IState> {
       <SinglePageContent
         activity={activity}
         teacherEditionMode={this.state.teacherEditionMode}
+        pluginsLoaded={this.state.pluginsLoaded}
       />
     );
   }
@@ -324,6 +328,10 @@ export class App extends React.PureComponent<IProps, IState> {
       updatedIncompleteQuestions.push(newIncompleteQuestion);
       this.setState({ incompleteQuestions: updatedIncompleteQuestions });
     }
+  }
+
+  private handleLoadPlugins = () => {
+    this.setState({ pluginsLoaded: true });
   }
 
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -169,7 +169,7 @@ export class App extends React.PureComponent<IProps, IState> {
   }
 
   private renderActivity = () => {
-    const { activity, authError, currentPage, username, pluginsLoaded } = this.state;
+    const { activity, authError, currentPage, username, pluginsLoaded, teacherEditionMode } = this.state;
     if (!activity) return (<div>Loading</div>);
     const totalPreviousQuestions = numQuestionsOnPreviousPages(currentPage, activity);
     const fullWidth = (currentPage !== 0) && (activity.pages[currentPage - 1].layout === PageLayouts.Responsive);
@@ -191,12 +191,13 @@ export class App extends React.PureComponent<IProps, IState> {
             projectId={activity.project_id}
           />
         }
-        { pluginsLoaded && (activity.layout === ActivityLayouts.SinglePage || (currentPage !== 0 && !activity.pages[currentPage - 1].is_completion)) &&
+        { (activity.layout === ActivityLayouts.SinglePage || (currentPage !== 0 && !activity.pages[currentPage - 1].is_completion)) &&
           <ExpandableContainer
             activity={activity}
             pageNumber={currentPage}
             page={activity.pages.filter((page) => !page.is_hidden)[currentPage - 1]}
-            teacherEditionMode={this.state.teacherEditionMode}
+            teacherEditionMode={teacherEditionMode}
+            pluginsLoaded={pluginsLoaded}
           />
         }
       </React.Fragment>

--- a/src/components/expandable-content/expandable-container.test.tsx
+++ b/src/components/expandable-content/expandable-container.test.tsx
@@ -14,7 +14,7 @@ describe("Expandable container component", () => {
     expect(wrapper.find('[data-cy="expandable-container"]').length).toBe(1);
   });
   it("renders component content", () => {
-    const wrapper = shallow(<ExpandableContainer activity={activityPlugins} page={activityPlugins.pages[2]} pageNumber={3} teacherEditionMode={true} />);
+    const wrapper = shallow(<ExpandableContainer activity={activityPlugins} page={activityPlugins.pages[2]} pageNumber={3} teacherEditionMode={true} pluginsLoaded={true} />);
     expect(wrapper.find('[data-cy="expandable-container"]').length).toBe(1);
     expect(wrapper.find('[data-cy="expandable-container"]').length).toBe(1);
     expect(wrapper.find('[data-cy="expandable-container"]').length).toBe(1);

--- a/src/components/expandable-content/expandable-container.tsx
+++ b/src/components/expandable-content/expandable-container.tsx
@@ -19,7 +19,7 @@ interface IProps {
 
 export const ExpandableContainer: React.FC<IProps> = (props) => {
   const { activity, page, pageNumber, teacherEditionMode } = props;
-  const sideTips = getPageSideTipEmbeddables(page);
+  const sideTips = getPageSideTipEmbeddables(activity, page);
   const verticalOffset = kExpandableContentTop + sideTips.length * (kExpandableItemHeight + kExpandableContentMargin);
   const sidebars = getPageSideBars(activity, page);
   return (

--- a/src/components/expandable-content/expandable-container.tsx
+++ b/src/components/expandable-content/expandable-container.tsx
@@ -15,11 +15,12 @@ interface IProps {
   page: Page;
   pageNumber: number;
   teacherEditionMode?: boolean;
+  pluginsLoaded?: boolean;
 }
 
 export const ExpandableContainer: React.FC<IProps> = (props) => {
-  const { activity, page, pageNumber, teacherEditionMode } = props;
-  const sideTips = getPageSideTipEmbeddables(activity, page);
+  const { activity, page, pageNumber, teacherEditionMode, pluginsLoaded } = props;
+  const sideTips = pluginsLoaded ? getPageSideTipEmbeddables(activity, page) : [];
   const verticalOffset = kExpandableContentTop + sideTips.length * (kExpandableItemHeight + kExpandableContentMargin);
   const sidebars = getPageSideBars(activity, page);
   return (

--- a/src/components/single-page/single-page-content.test.tsx
+++ b/src/components/single-page/single-page-content.test.tsx
@@ -10,11 +10,11 @@ const activitySinglePage = _activitySinglePage as Activity;
 
 describe("Single Page Content component", () => {
   it("renders component", () => {
-    const wrapper = shallow(<SinglePageContent activity={DefaultTestActivity} />);
+    const wrapper = shallow(<SinglePageContent activity={DefaultTestActivity} pluginsLoaded={true} />);
     expect(wrapper.find('[data-cy="single-page-content"]').length).toBe(1);
   });
   it("renders component content", () => {
-    const wrapper = shallow(<SinglePageContent activity={activitySinglePage} />);
+    const wrapper = shallow(<SinglePageContent activity={activitySinglePage} pluginsLoaded={true} />);
     expect(wrapper.find('[data-cy="single-page-content"]').length).toBe(1);
     // should render 10 embeddables, there are 11 total, 1 is hidden
     expect(wrapper.find(Embeddable).length).toBe(10);

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ActivityLayouts, PageLayouts, isQuestion, VisibleEmbeddables, getVisibleEmbeddablesOnPage,
-         EmbeddableSections } from "../../utilities/activity-utils";
+         EmbeddableSections, getLinkedPluginEmbeddable } from "../../utilities/activity-utils";
 import { Embeddable } from "../activity-page/embeddable";
 import { RelatedContent } from "./related-content";
 import { SubmitButton } from "./submit-button";
@@ -11,10 +11,11 @@ import { Activity, Page } from "../../types";
 interface IProps {
   activity: Activity;
   teacherEditionMode?: boolean;
+  pluginsLoaded: boolean;
 }
 
 export const SinglePageContent: React.FC<IProps> = (props) => {
-  const { activity, teacherEditionMode } = props;
+  const { activity, teacherEditionMode, pluginsLoaded } = props;
   let questionNumber = 0;
   let embeddableNumber = 0;
 
@@ -28,6 +29,7 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
               questionNumber++;
             }
             embeddableNumber++;
+            const linkedPluginEmbeddable = getLinkedPluginEmbeddable(page, embeddableWrapper.embeddable.ref_id);
             return (
               <Embeddable
                 activityLayout={ActivityLayouts.SinglePage}
@@ -36,7 +38,9 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
                 pageLayout={PageLayouts.FullWidth}
                 pageSection={EmbeddableSections.InfoAssessment}
                 questionNumber={isQuestion(embeddableWrapper) ? questionNumber : undefined}
+                linkedPluginEmbeddable={linkedPluginEmbeddable}
                 teacherEditionMode={teacherEditionMode}
+                pluginsLoaded={pluginsLoaded}
               />
             );
           })

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -7,6 +7,7 @@ import sampleActivityHas from "../data/sample-activity-HAS.json";
 import sampleActivityHiddenContent from "../data/sample-activity-hidden-content.json";
 import sampleActivityMultipleLayoutTypes from "../data/sample-activity-multiple-layout-types.json";
 import sampleActivityPlugins from "../data/sample-activity-plugins.json";
+import sampleActivityPluginsSinglePage from "../data/sample-activity-plugins-single-page.json";
 import sampleActivityResponsive from "../data/sample-activity-responsive-layout.json";
 import sampleActivitySinglePageLayout from "../data/sample-activity-single-page-layout.json";
 import sampleActivityFullWidthOff from "../data/LARA-page-elements-full-width-off.json";
@@ -24,6 +25,7 @@ const sampleActivities: {[name: string]: Activity} = {
   "sample-activity-hidden-content": sampleActivityHiddenContent as Activity,
   "sample-activity-multiple-layout-types": sampleActivityMultipleLayoutTypes as Activity,
   "sample-activity-plugins": sampleActivityPlugins as Activity,
+  "sample-activity-plugins-single-page": sampleActivityPluginsSinglePage as Activity,
   "sample-activity-responsive-layout": sampleActivityResponsive as Activity,
   "sample-activity-single-page-layout": sampleActivitySinglePageLayout as Activity,
   "LARA-page-elements-full-width-off": sampleActivityFullWidthOff as Activity,

--- a/src/data/sample-activity-plugins-single-page.json
+++ b/src/data/sample-activity-plugins-single-page.json
@@ -1,0 +1,559 @@
+{
+  "description": "",
+  "editor_mode": 0,
+  "layout": 1,
+  "name": "Plugin Test",
+  "notes": "",
+  "project_id": null,
+  "related": "",
+  "show_submit_button": true,
+  "student_report_enabled": true,
+  "thumbnail_url": "",
+  "time_to_complete": null,
+  "version": 1,
+  "theme_name": "HAS National Geographic: Water",
+  "pages": [
+    {
+      "additional_sections": {},
+      "embeddable_display_mode": "stacked",
+      "is_completion": false,
+      "is_hidden": false,
+      "layout": "l-full-width",
+      "name": null,
+      "position": 1,
+      "show_header": true,
+      "show_info_assessment": true,
+      "show_interactive": false,
+      "show_sidebar": false,
+      "sidebar": null,
+      "sidebar_title": "Did you know?",
+      "toggle_info_assessment": true,
+      "embeddables": [
+        {
+          "embeddable": {
+            "content": "<p>This page contains:</p>\r\n<ul>\r\n<li>3 questions with TE wrappers showing each wrapper location</li>\r\n<li>mc question with hint</li>\r\n<li>window shade</li>\r\n<li>side tip</li>\r\n</ul>",
+            "is_callout": false,
+            "is_full_width": true,
+            "is_hidden": false,
+            "name": "",
+            "type": "Embeddable::Xhtml",
+            "ref_id": "272135-Embeddable::Xhtml"
+          },
+          "section": "header_block"
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"questionWrapper\",\"questionWrapper\":{\"correctExplanation\":\"correct\",\"distractorsExplanation\":\"distractor\",\"exemplar\":\"this is an exemplar\",\"teacherTip\":\"this is a teacher tip with top location\",\"teacherTipImageOverlay\":\"\",\"location\":\"top\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "questionWrapper"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3002-Embeddable::EmbeddablePlugin",
+            "embeddable_ref_id": "413-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"questionWrapper\",\"questionWrapper\":{\"correctExplanation\":\"correct\",\"distractorsExplanation\":\"distractor\",\"exemplar\":\"this is an exemplar\",\"teacherTip\":\"this is a teacher tip with sticky location\",\"teacherTipImageOverlay\":\"\",\"location\":\"stickyNote\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "questionWrapper"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3003-Embeddable::EmbeddablePlugin",
+            "embeddable_ref_id": "414-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"questionWrapper\",\"questionWrapper\":{\"correctExplanation\":\"correct\",\"distractorsExplanation\":\"distractor\",\"exemplar\":\"this is an exemplar\",\"teacherTip\":\"this is a teacher tip with bottom location\",\"teacherTipImageOverlay\":\"\",\"location\":\"bottom\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "questionWrapper"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3004-Embeddable::EmbeddablePlugin",
+            "embeddable_ref_id": "415-ManagedInteractive"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}]}",
+            "is_hidden": false,
+            "is_full_width": false,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": "DEFAULT",
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "af5d1860b2d4a037ae01e3d86931a30886fcb42d",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/multiple-choice/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "A basic multiple choice interactive. This is pointing to the master branch and is in development so it shouldn't be used by real activities. \r\n",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Multiple Choice (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": true,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "413-ManagedInteractive",
+            "linked_interactives": []
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}]}",
+            "is_hidden": false,
+            "is_full_width": false,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": "DEFAULT",
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "af5d1860b2d4a037ae01e3d86931a30886fcb42d",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/multiple-choice/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "A basic multiple choice interactive. This is pointing to the master branch and is in development so it shouldn't be used by real activities. \r\n",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Multiple Choice (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": true,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "414-ManagedInteractive",
+            "linked_interactives": []
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}]}",
+            "is_hidden": false,
+            "is_full_width": false,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": "DEFAULT",
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "af5d1860b2d4a037ae01e3d86931a30886fcb42d",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/multiple-choice/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "A basic multiple choice interactive. This is pointing to the master branch and is in development so it shouldn't be used by real activities. \r\n",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Multiple Choice (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": true,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "415-ManagedInteractive",
+            "linked_interactives": []
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"multiple_choice\",\"multipleAnswers\":false,\"layout\":\"vertical\",\"choices\":[{\"id\":\"1\",\"content\":\"Choice A\",\"correct\":false},{\"id\":\"2\",\"content\":\"Choice B\",\"correct\":false},{\"id\":\"3\",\"content\":\"Choice C\",\"correct\":false}],\"prompt\":\"<p>this MC has a hint</p>\",\"hint\":\"<p>I&#x27;m a hint</p>\"}",
+            "is_hidden": false,
+            "is_full_width": true,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": "DEFAULT",
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "af5d1860b2d4a037ae01e3d86931a30886fcb42d",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/multiple-choice/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "A basic multiple choice interactive. This is pointing to the master branch and is in development so it shouldn't be used by real activities. \r\n",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Multiple Choice (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": true,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "406-ManagedInteractive",
+            "linked_interactives": []
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"theoryAndBackground\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"this is a windowshade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "windowShade"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "2991-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"this is a sidetip\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "sideTip"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "2992-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        }
+      ]
+    },
+    {
+      "additional_sections": {},
+      "embeddable_display_mode": "stacked",
+      "is_completion": false,
+      "is_hidden": false,
+      "layout": "l-full-width",
+      "name": null,
+      "position": 2,
+      "show_header": true,
+      "show_info_assessment": true,
+      "show_interactive": false,
+      "show_sidebar": false,
+      "sidebar": null,
+      "sidebar_title": "Did you know?",
+      "toggle_info_assessment": false,
+      "embeddables": [
+        {
+          "embeddable": {
+            "content": "<p>This page contains 4 window shade plugins</p>",
+            "is_callout": false,
+            "is_full_width": true,
+            "is_hidden": false,
+            "name": "",
+            "type": "Embeddable::Xhtml",
+            "ref_id": "272138-Embeddable::Xhtml"
+          },
+          "section": "header_block"
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"teacherTip\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"This is a teacher tip window shade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "windowShade"
+            },
+            "is_hidden": false,
+            "is_full_width": true,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "2993-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"theoryAndBackground\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"This is a theory and background window shade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "windowShade"
+            },
+            "is_hidden": false,
+            "is_full_width": true,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "2994-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"discussionPoints\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"This is a discussion points window shade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "windowShade"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "2995-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"diggingDeeper\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"This is a digging deeper window shade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "windowShade"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "2996-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        }
+      ]
+    },
+    {
+      "additional_sections": {},
+      "embeddable_display_mode": "stacked",
+      "is_completion": false,
+      "is_hidden": false,
+      "layout": "l-6040",
+      "name": null,
+      "position": 3,
+      "show_header": true,
+      "show_info_assessment": true,
+      "show_interactive": true,
+      "show_sidebar": true,
+      "sidebar": "<p>This is a page sidebar.</p>",
+      "sidebar_title": "Did you know?",
+      "toggle_info_assessment": false,
+      "embeddables": [
+        {
+          "embeddable": {
+            "content": "<p>This page contains 2 sidetip plugins and a page sidebar.</p>",
+            "is_callout": true,
+            "is_full_width": true,
+            "is_hidden": false,
+            "name": "",
+            "type": "Embeddable::Xhtml",
+            "ref_id": "272271-Embeddable::Xhtml"
+          },
+          "section": "header_block"
+        },
+        {
+          "embeddable": {
+            "name": "",
+            "url_fragment": null,
+            "authored_state": "{\"version\":1,\"questionType\":\"open_response\"}",
+            "is_hidden": false,
+            "is_full_width": true,
+            "show_in_featured_question_report": true,
+            "inherit_aspect_ratio_method": true,
+            "custom_aspect_ratio_method": null,
+            "inherit_native_width": true,
+            "custom_native_width": 576,
+            "inherit_native_height": true,
+            "custom_native_height": 435,
+            "inherit_click_to_play": true,
+            "custom_click_to_play": false,
+            "inherit_full_window": true,
+            "custom_full_window": false,
+            "inherit_click_to_play_prompt": true,
+            "custom_click_to_play_prompt": null,
+            "inherit_image_url": true,
+            "custom_image_url": null,
+            "library_interactive": {
+              "hash": "da655ced823a0246a5f8c5c46c90345f28f53efe",
+              "data": {
+                "aspect_ratio_method": "DEFAULT",
+                "authoring_guidance": "",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/open-response/",
+                "click_to_play": false,
+                "click_to_play_prompt": null,
+                "description": "This shouldn't be used by any real activities it is still under development.",
+                "enable_learner_state": true,
+                "full_window": false,
+                "has_report_url": false,
+                "image_url": null,
+                "name": "Open Response (master)",
+                "native_height": 435,
+                "native_width": 576,
+                "no_snapshots": false,
+                "show_delete_data_button": false,
+                "thumbnail_url": "",
+                "customizable": false,
+                "authorable": true
+              }
+            },
+            "type": "ManagedInteractive",
+            "ref_id": "574-ManagedInteractive",
+            "linked_interactives": []
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"This is a teacher edition side tip.\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "sideTip"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3258-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "plugin": {
+              "description": null,
+              "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"This is a teacher edition side tip with markdown.\\n\\n# Capillos iugo Palaemona sacros moenia desunt ducit\\n\\n## Sanguine decidit Iovemque natalibus venturi haberet nos\\n\\nLorem markdownum acernae pendere tegitur trepidantem facias dixit. Ignava est\\ncarbasa, et pugnae ibimus nostri si astra statuit dapes. Nec aevo forti arces\\nnon barbaque postera.\\n\\n> Veri movere. Quae Coei quo oculis illa et iram ante inpositus litora agmina\\n> ignaram Lyncides praeside est acta medullas tosti utque dicta. Caecisque ad\\n> deum frondes, est *ferrum frustra multaque* in venerit cupidine, et non piasti\\n> quoque! Tenent urget, tangunt animos nil papavera terra attonitas odorato dat\\n> [unde coagula](http://et.com/erebi-cum.php).\\n\\nSaxo vestigia esset, ad sinuataque unica, de iugulatus mille per tuum **vero**!\\nQuem decurrere viroque furit? Rapidas amens, per isque lignum volucris ut talia\\nadmoverat; aquarum Acheronte in. Fuit noctis in laudisque guttis lemnius ille\\ntetigit populi tenuissima fecere ripis stratum undas. Quoquam visa solidissima\\ntibi quaerunt: renascitur curru recens, versant ut pro.\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
+              "approved_script_label": "teacherEditionTips",
+              "component_label": "sideTip"
+            },
+            "is_hidden": false,
+            "is_full_width": false,
+            "type": "Embeddable::EmbeddablePlugin",
+            "ref_id": "3259-Embeddable::EmbeddablePlugin"
+          },
+          "section": null
+        },
+        {
+          "embeddable": {
+            "aspect_ratio_method": "DEFAULT",
+            "authored_state": "",
+            "click_to_play": false,
+            "click_to_play_prompt": null,
+            "enable_learner_state": false,
+            "full_window": false,
+            "has_report_url": false,
+            "image_url": null,
+            "is_full_width": true,
+            "is_hidden": false,
+            "model_library_url": null,
+            "name": "cbio",
+            "native_height": 435,
+            "native_width": 576,
+            "no_snapshots": false,
+            "show_delete_data_button": true,
+            "show_in_featured_question_report": true,
+            "url": "https://connected-bio-spaces.concord.org/",
+            "type": "MwInteractive",
+            "ref_id": "210729-MwInteractive",
+            "linked_interactives": []
+          },
+          "section": "interactive_box"
+        }
+      ]
+    }
+  ],
+  "plugins": [],
+  "type": "LightweightActivity",
+  "export_site": "Lightweight Activities Runtime and Authoring"
+}

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -63,8 +63,21 @@ export const isEmbeddableSideTip = (e: EmbeddableWrapper) => {
   return (e.embeddable.type === "Embeddable::EmbeddablePlugin" && e.embeddable.plugin?.component_label === "sideTip");
 };
 
-export const getPageSideTipEmbeddables = (page: Page) => {
-  return page.embeddables.filter((e: any) => isEmbeddableSideTip(e));
+export const getPageSideTipEmbeddables = (activity: Activity, currentPage: Page) => {
+  if (activity.layout === ActivityLayouts.SinglePage) {
+    const sidetips: EmbeddableWrapper[] = [];
+    for (let page = 0; page < activity.pages.length - 1; page++) {
+      for (let embeddableNum = 0; embeddableNum < activity.pages[page].embeddables.length; embeddableNum++) {
+        const embeddableWrapper = activity.pages[page].embeddables[embeddableNum];
+        if (isEmbeddableSideTip(embeddableWrapper)) {
+          sidetips.push(embeddableWrapper);
+        }
+      }
+    }
+    return sidetips;
+  } else {
+    return currentPage.embeddables.filter((e: any) => isEmbeddableSideTip(e));
+  }
 };
 
 export const getPageSideBars = (activity: Activity, currentPage: Page) => {

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -10,6 +10,7 @@ export interface PluginInfo {
   type: PluginType,
   name: string;
   id: number;
+  loaded: boolean;
 }
 
 // TODO: this information should come from the activity JSON
@@ -18,11 +19,12 @@ export const Plugins: PluginInfo[] = [
     url: "https://teacher-edition-tips-plugin.concord.org/version/v3.5.6/plugin.js",
     type: "TeacherEdition",
     name: "Teacher Edition",
-    id: 0
+    id: 0,
+    loaded: false
   },
 ];
 
-export const loadPluginScripts = (LARA: LaraGlobalType, activity: Activity) => {
+export const loadPluginScripts = (LARA: LaraGlobalType, activity: Activity, handleLoadPlugins: () => void) => {
   // load any plugin scripts, each should call registerPlugin if correctly loaded
   const usedPlugins: PluginInfo[] = [];
   for (let page = 0; page < activity.pages.length - 1; page++) {
@@ -47,10 +49,13 @@ export const loadPluginScripts = (LARA: LaraGlobalType, activity: Activity) => {
     const script = document.createElement("script");
     script.type = "text/javascript";
     script.src = plugin.url;
-    document.body.appendChild(script);
+    //document.body.appendChild(script);
+    setTimeout(() => { document.body.appendChild(script); }, 4000);
     script.onload = function() {
-      // TODO: might need additional handling here
-      // console.log("plugin script loaded");
+      plugin.loaded = true;
+      if (usedPlugins.filter((p) => !p.loaded).length === 0) {
+        handleLoadPlugins();
+      }
     };
   });
 };

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -49,8 +49,7 @@ export const loadPluginScripts = (LARA: LaraGlobalType, activity: Activity, hand
     const script = document.createElement("script");
     script.type = "text/javascript";
     script.src = plugin.url;
-    //document.body.appendChild(script);
-    setTimeout(() => { document.body.appendChild(script); }, 4000);
+    document.body.appendChild(script);
     script.onload = function() {
       plugin.loaded = true;
       if (usedPlugins.filter((p) => !p.loaded).length === 0) {


### PR DESCRIPTION
This PR is an alternate approach to the async/await plugin loading seen here:
https://github.com/concord-consortium/activity-player/pull/88

This PR adds a `pluginsLoaded` state variable and `handleLoadPlugins` callback to the `App` component.  The `pluginsLoaded` flag is used to signal to child components that plugin script loading is complete and plugin content can be initialized.  `handleLoadPlugins` is passed to `loadPluginScripts` and called when plugin script loading is complete.  `handleLoadPlugins` toggles the `pluginsLoaded` flag.  

A few other small improvements include:
- display sidetip plugins on single page activity
- display wrapper plugins on single page activity

I created a branch off of this that includes an artificial 4 second delay when loading the plugin scripts.  This allows us to see the question interactives load while waiting for the plugin scripts without any slowdown or blocking:
https://activity-player.concord.org/branch/load-delay/?mode=teacher-edition&preview&activity=sample-activity-plugins&page=1
https://activity-player.concord.org/branch/load-delay/?mode=teacher-edition&preview&activity=sample-activity-plugins-single-page
