### PR TITLE
175606584 page numbers

### DIFF
--- a/cypress/integration/workspace.test.ts
+++ b/cypress/integration/workspace.test.ts
@@ -17,7 +17,7 @@ context("Test the overall app", () => {
   describe("ActivityNavHeader",()=>{
     it("verify ActivityNavHeader loads",()=>{
         cy.get("[data-cy=activity-nav-header]").should("be.visible");
-        cy.get(".page-button").should("have.length", 11);
+        cy.get(".page-button").should("have.length", 22); // top and bottom nav headers exist
     });
   });
   describe("ProfileNavHeader",()=>{

--- a/src/components/activity-completion/completion-page-content.scss
+++ b/src/components/activity-completion/completion-page-content.scss
@@ -5,7 +5,7 @@
   box-sizing: border-box;
   background-color: rgba(255,255,255,0.95);
   padding: 20px;
-  margin-bottom: 40px;
+  margin-bottom: 10px;
 
   .completion-text {
     color: $cc-teal-dark1;

--- a/src/components/activity-header/activity-nav.scss
+++ b/src/components/activity-header/activity-nav.scss
@@ -1,6 +1,6 @@
 @import "../vars.scss";
 
-.activity-nav-header {
+.activity-nav {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/components/activity-header/activity-nav.test.tsx
+++ b/src/components/activity-header/activity-nav.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ActivityNavHeader } from "./activity-nav-header";
+import { ActivityNav } from "./activity-nav";
 import { shallow } from "enzyme";
 import { DefaultTestPage } from "../../test-utils/model-for-tests";
 import { NavPages } from "./nav-pages";
@@ -16,7 +16,7 @@ const activityPages = [
 
 describe("Activity Nav Header component", () => {
   it("renders nav header content for activity", () => {
-    const wrapper = shallow(<ActivityNavHeader activityPages={activityPages} currentPage={0} onPageChange={stubFunction} singlePage={false} />);
+    const wrapper = shallow(<ActivityNav activityPages={activityPages} currentPage={0} onPageChange={stubFunction} singlePage={false} />);
     expect(wrapper.containsMatchingElement(<NavPages
       pages={activityPages}
       onPageChange={stubFunction}
@@ -24,7 +24,7 @@ describe("Activity Nav Header component", () => {
     />)).toEqual(true);
   });
   it("renders nav header content for sequence", () => {
-    const wrapper = shallow(<ActivityNavHeader
+    const wrapper = shallow(<ActivityNav
                               activityPages={activityPages}
                               currentPage={0}
                               onPageChange={stubFunction}
@@ -32,7 +32,7 @@ describe("Activity Nav Header component", () => {
                               sequenceName={"test sequence"}
                               onShowSequence={stubFunction}
                               />);
-    expect(wrapper.find('[data-cy="activity-nav-header-sequence-name"]').text()).toContain("test sequence");
+    expect(wrapper.find('[data-cy="activity-nav-sequence-name"]').text()).toContain("test sequence");
     expect(wrapper.containsMatchingElement(<IconChevronLeft width={32} height={32}/>)).toEqual(true);
   });
 });

--- a/src/components/activity-header/activity-nav.tsx
+++ b/src/components/activity-header/activity-nav.tsx
@@ -3,7 +3,7 @@ import { Page } from "../../types";
 import { NavPages } from "./nav-pages";
 import IconChevronLeft from "../../assets/svg-icons/icon-chevron-left.svg";
 
-import "./activity-nav-header.scss";
+import "./activity-nav.scss";
 
 interface IProps {
   activityPages: Page[];
@@ -16,13 +16,13 @@ interface IProps {
   lockForwardNav?: boolean;
 }
 
-export class ActivityNavHeader extends React.PureComponent <IProps> {
+export class ActivityNav extends React.PureComponent <IProps> {
   render() {
     const { activityPages, currentPage, fullWidth, lockForwardNav, onPageChange, singlePage, sequenceName, onShowSequence} = this.props;
     return (
-      <div className={`activity-nav-header ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header">
+      <div className={`activity-nav ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header">
         { sequenceName &&
-          <div className="sequence-name" data-cy="activity-nav-header-sequence-name" onClick={onShowSequence}>
+          <div className="sequence-name" data-cy="activity-nav-sequence-name" onClick={onShowSequence}>
             <IconChevronLeft
               width={32}
               height={32}

--- a/src/components/activity-page/activity-page-content.scss
+++ b/src/components/activity-page/activity-page-content.scss
@@ -5,7 +5,7 @@
   box-sizing: border-box;
   background-color: rgba(255,255,255,0.95);
   padding: 20px;
-  margin-bottom: 40px;
+  margin-bottom: 10px;
 
   &.full {
     width: 100%;

--- a/src/components/activity-page/activity-page-content.test.tsx
+++ b/src/components/activity-page/activity-page-content.test.tsx
@@ -19,8 +19,6 @@ describe("Activity Page Content component", () => {
       pluginsLoaded={true}
     />);
     expect(getByTestId("page-content")).toBeDefined();
-    expect(getByTestId("bottom-button-back")).toBeEnabled();
-    expect(getByTestId("bottom-button-next")).toBeEnabled();
     expect(getByText("Hide")).toBeEnabled();
     fireEvent.click(getByText("Hide"));
     expect(getByText("Show")).toBeEnabled();

--- a/src/components/activity-page/activity-page-content.test.tsx
+++ b/src/components/activity-page/activity-page-content.test.tsx
@@ -8,17 +8,10 @@ describe("Activity Page Content component", () => {
     const stubFunction = () => {
       // do nothing.
     };
-    let callCount = 0;
-    const handlePageChange = () => {
-      ++callCount;
-    };
     const page = { ...DefaultTestPage, layout: "l-responsive" };
     configure({ testIdAttribute: "data-cy" });
     const { getByTestId, getByText } = render(<ActivityPageContent
       enableReportButton={false}
-      isFirstActivityPage={false}
-      isLastActivityPage={false}
-      onPageChange={handlePageChange}
       page={page}
       pageNumber={5}
       totalPreviousQuestions={5}
@@ -31,10 +24,5 @@ describe("Activity Page Content component", () => {
     expect(getByText("Hide")).toBeEnabled();
     fireEvent.click(getByText("Hide"));
     expect(getByText("Show")).toBeEnabled();
-    expect(callCount).toBe(0);
-    fireEvent.click(getByTestId("bottom-button-back"));
-    expect(callCount).toBe(1);
-    fireEvent.click(getByTestId("bottom-button-next"));
-    expect(callCount).toBe(2);
   });
 });

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -18,15 +18,11 @@ const kPinMargin = 20;
 
 interface IProps {
   enableReportButton: boolean;
-  isFirstActivityPage: boolean;
-  isLastActivityPage: boolean;
-  onPageChange: (page: number) => void;
   page: Page;
   pageNumber: number;
   teacherEditionMode?: boolean;
   totalPreviousQuestions: number;
   setNavigation: (refId: string, options: INavigationOptions) => void;
-  lockForwardNav?: boolean;
   pluginsLoaded: boolean;
 }
 
@@ -47,7 +43,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
   }
 
   render() {
-    const { enableReportButton, isFirstActivityPage, isLastActivityPage, page, pageNumber, totalPreviousQuestions, lockForwardNav } = this.props;
+    const { enableReportButton, page, pageNumber, totalPreviousQuestions } = this.props;
     const { scrollOffset } = this.state;
     const primaryFirst = page.layout === PageLayouts.FullWidth || page.layout === PageLayouts.FortySixty;
     const pageSectionQuestionCount = getPageSectionQuestionCount(page);
@@ -81,12 +77,11 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
           { first }
           { second }
         </div>
-        <BottomButtons
-          onBack={!isFirstActivityPage ? this.handleBack : undefined}
-          onNext={!isLastActivityPage ? this.handleNext : undefined}
-          lockForwardNav={lockForwardNav}
-          onGenerateReport={enableReportButton ? this.handleReport : undefined}
-        />
+        { enableReportButton &&
+          <BottomButtons
+            onGenerateReport={this.handleReport}
+          />
+        }
       </div>
     );
   }
@@ -120,12 +115,6 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
     }
   }
 
-  private handleBack = () => {
-    this.props.onPageChange(this.props.pageNumber - 1);
-  }
-  private handleNext = () => {
-    this.props.onPageChange(this.props.pageNumber + 1);
-  }
   private handleReport = () => {
     showReport();
     Logger.log({

--- a/src/components/activity-page/bottom-buttons.scss
+++ b/src/components/activity-page/bottom-buttons.scss
@@ -3,7 +3,7 @@
 .bottom-buttons {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: center;
 
   &.center {
     justify-content: center;

--- a/src/components/activity-page/bottom-buttons.test.tsx
+++ b/src/components/activity-page/bottom-buttons.test.tsx
@@ -7,20 +7,7 @@ describe("Bottom Buttons component", () => {
     const stubFunction = () => {
       // do nothing.
     };
-    const wrapperBackNext = shallow(<BottomButtons onBack={stubFunction} onNext={stubFunction} onGenerateReport={stubFunction} />);
-    expect(wrapperBackNext.find('[data-cy="bottom-button-back"]').length).toBe(1);
-    expect(wrapperBackNext.find('[data-cy="bottom-button-next"]').length).toBe(1);
+    const wrapperBackNext = shallow(<BottomButtons onGenerateReport={stubFunction} />);
     expect(wrapperBackNext.find('[data-cy="bottom-button-report"]').length).toBe(1);
-
-    const wrapperBack = shallow(<BottomButtons onBack={stubFunction} />);
-    expect(wrapperBack.find('[data-cy="bottom-button-back"]').length).toBe(1);
-    expect(wrapperBack.find('[data-cy="bottom-button-next"]').length).toBe(1);
-
-    const wrapperNext = shallow(<BottomButtons onNext={stubFunction} />);
-    expect(wrapperNext.find('[data-cy="bottom-button-back"]').length).toBe(1);
-    expect(wrapperNext.find('[data-cy="bottom-button-next"]').length).toBe(1);
-
-    const wrapperLocked = shallow(<BottomButtons onNext={stubFunction} lockForwardNav={true} />);
-    expect(wrapperLocked.find('[data-cy="bottom-button-next"]').hasClass("disabled")).toBe(true);
   });
 });

--- a/src/components/activity-page/bottom-buttons.tsx
+++ b/src/components/activity-page/bottom-buttons.tsx
@@ -2,45 +2,19 @@ import React from "react";
 
 import "./bottom-buttons.scss";
 
-interface BottomButtonProps {
-  onBack?: () => void;
-  onNext?: () => void;
-  onGenerateReport?: () => void;
-  lockForwardNav?: boolean;
+interface IProps {
+  onGenerateReport: () => void;
 }
 
-export const BottomButtons: React.FC<BottomButtonProps> = (props) => {
+export const BottomButtons: React.FC<IProps> = (props) => {
   return (
     <div className="bottom-buttons">
-      <div>
-        { <button className="button"
-                  disabled={!props.onBack}
-                  onClick={props.onBack}
-                  data-cy="bottom-button-back"
-                  tabIndex={1}>
-            {"< Back"}
-          </button> }
-      </div>
-      <div>
-        { props.onGenerateReport &&
-          <button className="button"
-                  onClick={props.onGenerateReport}
-                  data-cy="bottom-button-report"
-                  tabIndex={1}>
-            {"Generate Report"}
-          </button>
-        }
-      </div>
-      <div>
-        { <button className={`button ${props.lockForwardNav ? "disabled" : ""}`}
-                  disabled={!props.onNext && !props.lockForwardNav}
-                  onClick={props.onNext}
-                  data-cy="bottom-button-next"
-                  tabIndex={1}>
-            {"Next >"}
-          </button>
-        }
-      </div>
+      <button className="button"
+              onClick={props.onGenerateReport}
+              data-cy="bottom-button-report"
+              tabIndex={1}>
+        {"Generate Report"}
+      </button>
     </div>
   );
 };

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -20,7 +20,7 @@
   align-items: center;
   width: 100%;
   height: fit-content;
-  padding: 0 20px;
+  padding: 0 20px 20px 20px;
   line-height: 1.35;
   color: #444;
 
@@ -48,6 +48,6 @@
     &:focus {
       outline: 3px solid var(--theme-primary-hover-color);
     }
-  } 
+  }
 
 }

--- a/src/components/app.test.tsx
+++ b/src/components/app.test.tsx
@@ -20,7 +20,7 @@ describe("App component", () => {
     const wrapper = shallow(<App />);
     expect(wrapper.find('[data-cy="app"]').length).toBe(1);
     wrapper.setState({ activity });
-    expect(wrapper.find(ActivityNavHeader).length).toBe(1);
+    expect(wrapper.find(ActivityNavHeader).length).toBe(2);
     expect(wrapper.find(Header).length).toBe(1);
     expect(wrapper.find(Footer).length).toBe(1);
   });

--- a/src/components/app.test.tsx
+++ b/src/components/app.test.tsx
@@ -6,7 +6,7 @@ import "jquery-ui";
 import { App } from "./app";
 import { shallow } from "enzyme";
 import { Activity } from "../types";
-import { ActivityNavHeader } from "../components/activity-header/activity-nav-header";
+import { ActivityNav } from "./activity-header/activity-nav";
 import { Header } from "./activity-header/header";
 import { Footer } from "./activity-introduction/footer";
 import _activitySinglePage from "../data/sample-activity-single-page-layout.json";
@@ -20,14 +20,14 @@ describe("App component", () => {
     const wrapper = shallow(<App />);
     expect(wrapper.find('[data-cy="app"]').length).toBe(1);
     wrapper.setState({ activity });
-    expect(wrapper.find(ActivityNavHeader).length).toBe(2);
+    expect(wrapper.find(ActivityNav).length).toBe(2);
     expect(wrapper.find(Header).length).toBe(1);
     expect(wrapper.find(Footer).length).toBe(1);
   });
   it("renders single page activity", () => {
     const wrapper = shallow(<App />);
     wrapper.setState({ activity: activitySinglePage });
-    expect(wrapper.find(ActivityNavHeader).length).toBe(0);
+    expect(wrapper.find(ActivityNav).length).toBe(0);
     expect(wrapper.find(Header).length).toBe(1);
     expect(wrapper.find(Footer).length).toBe(1);
   });

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -213,16 +213,7 @@ export class App extends React.PureComponent<IProps, IState> {
     return (
       <>
         { (activity.layout !== ActivityLayouts.SinglePage || this.state.sequence) &&
-          <ActivityNavHeader
-            activityPages={activity.pages}
-            currentPage={currentPage}
-            fullWidth={fullWidth}
-            onPageChange={this.handleChangePage}
-            singlePage={activity.layout === ActivityLayouts.SinglePage}
-            sequenceName={this.state.sequence?.display_title || (this.state.sequence && "Sequence")}
-            onShowSequence={this.handleShowSequence}
-            lockForwardNav={this.state.incompleteQuestions.length > 0}
-          />
+          this.renderNavHeader(activity, currentPage, fullWidth)
         }
         { activity.layout === ActivityLayouts.SinglePage
           ? this.renderSinglePageContent(activity)
@@ -232,20 +223,34 @@ export class App extends React.PureComponent<IProps, IState> {
               ? this.renderCompletionContent(activity)
               : <ActivityPageContent
                   enableReportButton={currentPage === activity.pages.length && enableReportButton(activity)}
-                  isFirstActivityPage={currentPage === 1}
-                  isLastActivityPage={currentPage === activity.pages.filter((page) => !page.is_hidden).length}
                   pageNumber={currentPage}
-                  onPageChange={this.handleChangePage}
                   page={activity.pages.filter((page) => !page.is_hidden)[currentPage - 1]}
                   totalPreviousQuestions={totalPreviousQuestions}
                   teacherEditionMode={this.state.teacherEditionMode}
                   setNavigation={this.handleSetNavigation}
                   key={`page-${currentPage}`}
-                  lockForwardNav={this.state.incompleteQuestions.length > 0}
                   pluginsLoaded={this.state.pluginsLoaded}
                 />
         }
+        { (activity.layout !== ActivityLayouts.SinglePage || this.state.sequence) &&
+          this.renderNavHeader(activity, currentPage, fullWidth)
+        }
       </>
+    );
+  }
+
+  private renderNavHeader = (activity: Activity, currentPage: number, fullWidth: boolean) => {
+    return (
+      <ActivityNavHeader
+        activityPages={activity.pages}
+        currentPage={currentPage}
+        fullWidth={fullWidth}
+        onPageChange={this.handleChangePage}
+        singlePage={activity.layout === ActivityLayouts.SinglePage}
+        sequenceName={this.state.sequence?.display_title || (this.state.sequence && "Sequence")}
+        onShowSequence={this.handleShowSequence}
+        lockForwardNav={this.state.incompleteQuestions.length > 0}
+      />
     );
   }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { PortalDataContext } from "./portal-data-context";
 import { Header } from "./activity-header/header";
-import { ActivityNavHeader } from "./activity-header/activity-nav-header";
+import { ActivityNav } from "./activity-header/activity-nav";
 import { ActivityPageContent } from "./activity-page/activity-page-content";
 import { IntroductionPageContent } from "./activity-introduction/introduction-page-content";
 import { Footer } from "./activity-introduction/footer";
@@ -213,7 +213,7 @@ export class App extends React.PureComponent<IProps, IState> {
     return (
       <>
         { (activity.layout !== ActivityLayouts.SinglePage || this.state.sequence) &&
-          this.renderNavHeader(activity, currentPage, fullWidth)
+          this.renderNav(activity, currentPage, fullWidth)
         }
         { activity.layout === ActivityLayouts.SinglePage
           ? this.renderSinglePageContent(activity)
@@ -233,15 +233,15 @@ export class App extends React.PureComponent<IProps, IState> {
                 />
         }
         { (activity.layout !== ActivityLayouts.SinglePage || this.state.sequence) &&
-          this.renderNavHeader(activity, currentPage, fullWidth)
+          this.renderNav(activity, currentPage, fullWidth)
         }
       </>
     );
   }
 
-  private renderNavHeader = (activity: Activity, currentPage: number, fullWidth: boolean) => {
+  private renderNav = (activity: Activity, currentPage: number, fullWidth: boolean) => {
     return (
-      <ActivityNavHeader
+      <ActivityNav
         activityPages={activity.pages}
         currentPage={currentPage}
         fullWidth={fullWidth}

--- a/src/components/single-page/single-page-content.scss
+++ b/src/components/single-page/single-page-content.scss
@@ -5,5 +5,5 @@
   box-sizing: border-box;
   background-color: rgba(255,255,255,0.95);
   padding: 20px;
-  margin-bottom: 40px;
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
This PR adds the navigation buttons to the bottom of each activity page.  Note that this styling will most likely be updated once Michael takes a UI pass at the AP, but for now this should get the job done.

Typical activity page:
![image](https://user-images.githubusercontent.com/5126913/100799412-da667680-33d9-11eb-8f9a-65d59c93e42c.png)

Page with report button:
![image](https://user-images.githubusercontent.com/5126913/100801062-51047380-33dc-11eb-8999-6b33ce4d22ea.png)

Single page activity (report button shows, no navigation is shown):
![image](https://user-images.githubusercontent.com/5126913/100801094-5eb9f900-33dc-11eb-9df0-e228d278ba09.png)

