### PR TITLE
176275540 sequence header

### DIFF
--- a/cypress/integration/sequence-page.test.ts
+++ b/cypress/integration/sequence-page.test.ts
@@ -16,7 +16,7 @@ context("Test sequences", () => {
     it("should navigate to activity when activity thumbnail is selected", () => {
       activityPage.getHeader().should("contain", "Sequence");
       sequencePage.getThumbnails().eq(0).click();
-      activityPage.getHeader().should("contain", "Activity");
+      activityPage.getHeader().should("contain", "Sequence");
     });
   });
 });

--- a/src/assets/svg-icons/activity-icon.svg
+++ b/src/assets/svg-icons/activity-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path fill-rule="nonzero" d="M19 3c1.105 0 2 .895 2 2v14c0 1.105-.895 2-2 2H5c-1.105 0-2-.895-2-2V5c0-1.105.895-2 2-2h14zm-5.768 2.333h-2.488L5.892 18.367h2.855l.895-2.685h4.71l.903 2.685h2.856L13.232 5.333zm-1.244 3.295l1.638 4.878h-3.258l1.62-4.878z" transform="translate(-270 -108) translate(0 50) translate(40 40) translate(230 18)"/>
+</svg>

--- a/src/components/activity-header/activity-nav.scss
+++ b/src/components/activity-header/activity-nav.scss
@@ -6,7 +6,6 @@
   justify-content: space-between;
   height: 64px;
   width: $content-width;
-  border-radius: 2px;
   background-color: white;
   color: $cc-charcoal;
   font-size: 18px;

--- a/src/components/activity-header/activity-nav.test.tsx
+++ b/src/components/activity-header/activity-nav.test.tsx
@@ -3,7 +3,6 @@ import { ActivityNav } from "./activity-nav";
 import { shallow } from "enzyme";
 import { DefaultTestPage } from "../../test-utils/model-for-tests";
 import { NavPages } from "./nav-pages";
-import IconChevronLeft from "../../assets/svg-icons/icon-chevron-left.svg";
 
 const stubFunction = () => {
   // do nothing.
@@ -22,17 +21,5 @@ describe("Activity Nav Header component", () => {
       onPageChange={stubFunction}
       currentPage={0}
     />)).toEqual(true);
-  });
-  it("renders nav header content for sequence", () => {
-    const wrapper = shallow(<ActivityNav
-                              activityPages={activityPages}
-                              currentPage={0}
-                              onPageChange={stubFunction}
-                              singlePage={false}
-                              sequenceName={"test sequence"}
-                              onShowSequence={stubFunction}
-                              />);
-    expect(wrapper.find('[data-cy="activity-nav-sequence-name"]').text()).toContain("test sequence");
-    expect(wrapper.containsMatchingElement(<IconChevronLeft width={32} height={32}/>)).toEqual(true);
   });
 });

--- a/src/components/activity-header/activity-nav.tsx
+++ b/src/components/activity-header/activity-nav.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Page } from "../../types";
 import { NavPages } from "./nav-pages";
-import IconChevronLeft from "../../assets/svg-icons/icon-chevron-left.svg";
 
 import "./activity-nav.scss";
 
@@ -11,26 +10,14 @@ interface IProps {
   fullWidth?: boolean;
   onPageChange: (page: number) => void;
   singlePage: boolean;
-  sequenceName?: string;
-  onShowSequence?: () => void;
   lockForwardNav?: boolean;
 }
 
 export class ActivityNav extends React.PureComponent <IProps> {
   render() {
-    const { activityPages, currentPage, fullWidth, lockForwardNav, onPageChange, singlePage, sequenceName, onShowSequence} = this.props;
+    const { activityPages, currentPage, fullWidth, lockForwardNav, onPageChange, singlePage } = this.props;
     return (
       <div className={`activity-nav ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header">
-        { sequenceName &&
-          <div className="sequence-name" data-cy="activity-nav-sequence-name" onClick={onShowSequence}>
-            <IconChevronLeft
-              width={32}
-              height={32}
-              fill={"white"}
-            />
-            {sequenceName}
-          </div>
-        }
         { !singlePage &&
           <NavPages
             pages={activityPages}

--- a/src/components/activity-header/header.scss
+++ b/src/components/activity-header/header.scss
@@ -7,7 +7,7 @@
   font-size: 18px;
   font-weight: bold;
 
-  &.no-margin {
+  &.in-sequence {
     margin-bottom: 0;
   }
 

--- a/src/components/activity-header/header.scss
+++ b/src/components/activity-header/header.scss
@@ -7,6 +7,10 @@
   font-size: 18px;
   font-weight: bold;
 
+  &.no-margin {
+    margin-bottom: 0;
+  }
+
   .inner {
     display: flex;
     flex-direction: row;
@@ -45,14 +49,18 @@
       flex: 1;
       min-width: 0;
 
+      &.link {
+        cursor: pointer;
+      }
+
       .activity-title {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
       }
 
-      .sequence-logo {
-        height: 50px;
+      .sequence-icon {
+        fill: $cc-teal;
         margin-right: 5px;
       }
     }

--- a/src/components/activity-header/header.tsx
+++ b/src/components/activity-header/header.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { ProjectTypes } from "../../utilities/project-utils";
 import { AccountOwner } from "./account-owner";
 import { Logo } from "./logo";
+import SequenceIcon from "../../assets/svg-icons/assignment-icon.svg";
 
 import "./header.scss";
 
@@ -11,25 +12,25 @@ interface IProps {
   userName: string;
   contentName: string;
   showSequence?: boolean;
-  sequenceLogo?: string | null;
+  onShowSequence?: () => void;
 }
 
 export class Header extends React.PureComponent<IProps> {
   render() {
     const ccLogoLink = "https://concord.org/";
-    const { fullWidth, projectId, userName, sequenceLogo } = this.props;
+    const { fullWidth, projectId, userName, showSequence, onShowSequence } = this.props;
     const projectType = ProjectTypes.find(pt => pt.id === projectId);
     const logo = projectType?.headerLogo;
     const projectURL = projectType?.url || ccLogoLink;
     return (
-      <div className="activity-header" data-cy="activity-header">
+      <div className={`activity-header ${showSequence ? "no-margin" : ""}`} data-cy="activity-header">
         <div className={`inner ${fullWidth ? "full" : ""}`}>
           <div className="header-left">
             <Logo logo={logo} url={projectURL} />
             <div className="separator" />
           </div>
-          <div className="header-center">
-            {sequenceLogo && <img className="sequence-logo" src={sequenceLogo} alt="Sequence logo" />}
+          <div className={`header-center ${onShowSequence ? "link" : ""}`} onClick={onShowSequence}>
+            {showSequence && <SequenceIcon className="sequence-icon" />}
             {this.renderContentTitle()}
           </div>
           <div className="header-right">
@@ -44,7 +45,7 @@ export class Header extends React.PureComponent<IProps> {
     const { contentName, showSequence } = this.props;
     return (
       <div className="activity-title" data-cy ="activity-title">
-        {`${showSequence ? "Sequence: " : "Activity:"} ${contentName}`}
+        {`${showSequence ? "" : "Activity:"} ${contentName}`}
       </div>
     );
   }

--- a/src/components/activity-header/header.tsx
+++ b/src/components/activity-header/header.tsx
@@ -23,7 +23,7 @@ export class Header extends React.PureComponent<IProps> {
     const logo = projectType?.headerLogo;
     const projectURL = projectType?.url || ccLogoLink;
     return (
-      <div className={`activity-header ${showSequence ? "no-margin" : ""}`} data-cy="activity-header">
+      <div className={`activity-header ${showSequence ? "in-sequence" : ""}`} data-cy="activity-header">
         <div className={`inner ${fullWidth ? "full" : ""}`}>
           <div className="header-left">
             <Logo logo={logo} url={projectURL} />

--- a/src/components/activity-header/sequence-nav.scss
+++ b/src/components/activity-header/sequence-nav.scss
@@ -1,0 +1,24 @@
+@import "../vars.scss";
+
+.sequence-nav {
+  display: flex;
+  align-items: center;
+  height: 60px;
+  width: $content-width;
+  background-color: $cc-teal-light5;
+  color: $cc-charcoal;
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 3px;
+  padding: 0 20px;
+  box-sizing: border-box;
+
+  &.full {
+    width: 100%;
+  }
+
+  .select-label {
+    margin-right: 5px;
+  }
+
+}

--- a/src/components/activity-header/sequence-nav.test.tsx
+++ b/src/components/activity-header/sequence-nav.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { SequenceNav } from "./sequence-nav";
+import { shallow } from "enzyme";
+import { CustomSelect } from "../custom-select";
+
+const stubFunction = () => {
+  // do nothing.
+};
+const activities = [
+  "activity1",
+  "activity2",
+  "activity3"
+];
+
+describe("Sequence Nav Header component", () => {
+  it("renders sequence header content", () => {
+    const wrapper = shallow(<SequenceNav activities={activities} currentActivity={"activity1"} onActivityChange={stubFunction} />);
+    expect(wrapper.find('[data-cy="sequence-nav-header"]').length).toBe(1);
+    expect(wrapper.text()).toContain("Activity:");
+    expect(wrapper.find(CustomSelect)).toHaveLength(1);
+  });
+});

--- a/src/components/activity-header/sequence-nav.tsx
+++ b/src/components/activity-header/sequence-nav.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { CustomSelect } from "../custom-select";
+import ActivityIcon from "../../assets/svg-icons/activity-icon.svg";
+
+import "./sequence-nav.scss";
+
+interface IProps {
+  activities?: string[],
+  currentActivity?: string;
+  onActivityChange: (activityNum: number) => void;
+  fullWidth?: boolean;
+}
+
+export class SequenceNav extends React.PureComponent <IProps> {
+
+  render() {
+    const { activities, fullWidth, currentActivity } = this.props;
+    return (
+      <div className={`sequence-nav ${fullWidth ? "full" : ""}`} data-cy="sequence-nav-header">
+        <div className="select-label">Activity:</div>
+        { activities &&
+          <CustomSelect
+            items={activities}
+            value={currentActivity}
+            HeaderIcon={ActivityIcon}
+            onSelectItem={this.handleSelect}
+          />
+        }
+      </div>
+    );
+  }
+
+  private handleSelect = (item: string) => {
+    const activityIndex = this.props.activities?.findIndex((activity) => activity === item);
+    activityIndex && this.props.onActivityChange(activityIndex);
+  }
+
+}

--- a/src/components/custom-select.scss
+++ b/src/components/custom-select.scss
@@ -12,13 +12,13 @@
     box-sizing: border-box;
     border-radius: 4px;
     border: solid 1.5px $cc-charcoal-light1;
-    background-color: $activity-header-gray;
+    background-color: $cc-teal-light5;
     font-size: 16px;
     font-weight: bold;
     cursor: pointer;
 
     &:hover {
-      background-color: $cc-charcoal-light1;
+      background-color: $cc-teal-light4;
     }
 
     &.disabled {
@@ -28,8 +28,7 @@
     &.show-list, &:active {
       color: white;
       border-color: white;
-      background-color: $cc-charcoal-light2;
-
+      background-color: $cc-teal;
     }
 
     &:active .icon {
@@ -40,9 +39,9 @@
     }
 
     .icon {
-      height: 20px;
-      width: 20px;
-      margin: 0 5px 0 5px;
+      height: 24px;
+      width: 24px;
+      margin: 0 6px 0 3px;
       fill: var(--theme-primary-color);
 
       &.show-list {
@@ -110,11 +109,11 @@
       }
 
       &:hover {
-        background-color: $cc-charcoal-light2;
+        background-color: $cc-teal-light5;
       }
 
       &:active {
-        background-color: $cc-charcoal;
+        background-color: $cc-teal-light4;
       }
       &:active .check {
         fill: var(--theme-primary-color);
@@ -123,7 +122,7 @@
       .check {
         height: 24px;
         width: 24px;
-        margin: 0 5px 0 5px;
+        margin: 0 3px;
         fill: white;
 
         &.selected {

--- a/src/components/custom-select.tsx
+++ b/src/components/custom-select.tsx
@@ -7,13 +7,14 @@ import "./custom-select.scss";
 
 interface IProps {
   items: string[];
+  value?: string;
   onSelectItem?: (value: string) => void;
   HeaderIcon?: SvgIcon;
   isDisabled?: boolean;
 }
 
 interface IState {
-  current: string;
+  value: string;
   showList: boolean;
 }
 
@@ -22,18 +23,9 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   constructor(props: IProps) {
     super(props);
     this.state = {
-      current: props.items[0],
+      value: props.value || props.items[0],
       showList: false
     };
-  }
-
-  public componentDidUpdate(prevProps: IProps) {
-    if (prevProps.items !== this.props.items) {
-      this.setState({
-        current: this.props.items[0],
-        showList: false
-      });
-    }
   }
 
   public componentDidMount() {
@@ -54,8 +46,9 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   }
 
   private renderHeader = () => {
-    const { items, HeaderIcon, isDisabled } = this.props;
-    const currentItem = items.find(i => i === this.state.current);
+    const { items, HeaderIcon, isDisabled, value } = this.props;
+    const currentValue = value || this.state.value;
+    const currentItem = items.find(i => i === currentValue);
     const showListClass = this.state.showList ? "show-list" : "";
     const disabled = isDisabled ? "disabled" : "";
     return (
@@ -69,16 +62,17 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
   }
 
   private renderList = () => {
-    const { items } = this.props;
+    const { items, value } = this.props;
+    const currentValue = value || this.state.value;
     return (
       <div className={`list ${(this.state.showList ?"show" : "")}`} data-cy="custom-select-list">
         { items?.map((item: string, i: number) => {
-          const currentClass = this.state.current === item ? "selected" : "";
+          const currentClass = currentValue === item ? "selected" : "";
           return (
             <div
               key={`item ${i}`}
               className={`list-item ${currentClass}`}
-              onClick={this.handleListClick(item)}
+              onClick={this.handleChange(item)}
               data-cy={`list-item-${item.toLowerCase().replace(" ", "-")}`}
             >
               { <CheckIcon className={`check ${currentClass}`} /> }
@@ -102,10 +96,10 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
     this.setState(state => ({ showList: !state.showList }));
   }
 
-  private handleListClick = (current: string) => () => {
-    this.props.onSelectItem?.(current);
+  private handleChange = (value: string) => () => {
+    this.props.onSelectItem?.(value);
     this.setState({
-      current,
+      value,
       showList: false
     });
   }

--- a/src/components/sequence-introduction/sequence-introduction.tsx
+++ b/src/components/sequence-introduction/sequence-introduction.tsx
@@ -22,7 +22,6 @@ export const SequenceIntroduction: React.FC<IProps> = (props) => {
           userName={username}
           contentName={sequence.display_title || sequence.title || ""}
           showSequence={true}
-          sequenceLogo={sequence.logo}
         />
         <SequencePageContent
           sequence={sequence}


### PR DESCRIPTION
This PR updates the header portion of the application when displaying sequences.  Changes includes:
- remove sequence logo from header in sequence intro page
- add icon next to sequence name in header in sequence intro page
- when viewing an activity in a sequence, header, show the sequence name with sequence icon next to it (instead of activity name).  Clicking on sequence name returns user to sequence intro page.
- when viewing an activity in a sequence, a section appears below the header that contains a dropdown menu allowing users to navigate to any activity in the sequence.
- loading just an activity should result in no change in behavior

Can be demoed/tested here:
https://activity-player.concord.org/branch/sequence-header/?preview&sequence=sample-sequence

![image](https://user-images.githubusercontent.com/5126913/103832113-68192f80-5032-11eb-920f-ba4095c1f8cf.png)
