### PR TITLE
Request interactive states when user tries to change page

### DIFF
--- a/src/components/activity-header/nav-pages.test.tsx
+++ b/src/components/activity-header/nav-pages.test.tsx
@@ -68,4 +68,25 @@ describe("Nav Pages component", () => {
     expect(wrapper.find('[data-cy="nav-pages-button"]').at(9).text()).toContain("14"); // second to last page
     expect(wrapper.find('[data-cy="nav-pages-button"]').at(10).text()).toContain("15"); // last page
   });
+  it("blocks navigation after page change is requested", () => {
+    const onPageChange = jest.fn();
+    const wrapper = shallow(<NavPages
+      pages={activityPages}
+      currentPage={13}
+      onPageChange={onPageChange}
+    />);
+
+    // Lock nav buttons after one of them has been clicked.
+    expect(wrapper.find('[data-cy="nav-pages-button"]').at(0).hasClass("disabled")).toEqual(false);
+    wrapper.find('[data-cy="nav-pages-button"]').at(0).simulate("click");
+    wrapper.update();
+    expect(onPageChange).toHaveBeenCalled();
+    expect(wrapper.find('[data-cy="nav-pages-button"]').at(0).hasClass("disabled")).toEqual(true);
+
+    // Unlock when new page is set.
+    wrapper.setProps({
+      currentPage: 1
+    });
+    expect(wrapper.find('[data-cy="nav-pages-button"]').at(0).hasClass("disabled")).toEqual(false);
+  });
 });

--- a/src/components/activity-header/nav-pages.tsx
+++ b/src/components/activity-header/nav-pages.tsx
@@ -15,7 +15,25 @@ interface IProps {
   lockForwardNav?: boolean;
 }
 
-export class NavPages extends React.PureComponent <IProps> {
+interface IState {
+  pageChangeInProgress: boolean;
+}
+
+export class NavPages extends React.Component <IProps, IState> {
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      pageChangeInProgress: false
+    };
+  }
+
+  componentDidUpdate(prevProps: IProps) {
+    if (prevProps.currentPage !== this.props.currentPage) {
+      // Unlock buttons after page has been changed.
+      this.setState({ pageChangeInProgress: false });
+    }
+  }
+
   render() {
     return (
       <div className="nav-pages" data-cy="nav-pages">
@@ -29,9 +47,10 @@ export class NavPages extends React.PureComponent <IProps> {
 
   private renderPreviousButton = () => {
     const { currentPage } = this.props;
+    const { pageChangeInProgress } = this.state;
     return (
       <button
-        className={`page-button ${currentPage === 0 ? "disabled" : ""}`}
+        className={`page-button ${pageChangeInProgress || currentPage === 0 ? "disabled" : ""}`}
         onClick={this.handleChangePage(currentPage - 1)}
         aria-label="Previous page"
       >
@@ -41,10 +60,11 @@ export class NavPages extends React.PureComponent <IProps> {
   }
   private renderNextButton = () => {
     const { currentPage, pages, lockForwardNav } = this.props;
+    const { pageChangeInProgress } = this.state;
     const totalPages = pages.length;
     return (
       <button
-        className={`page-button ${currentPage === totalPages || lockForwardNav ? "disabled" : ""}`}
+        className={`page-button ${pageChangeInProgress || currentPage === totalPages || lockForwardNav ? "disabled" : ""}`}
         onClick={this.handleChangePage(currentPage + 1)}
         aria-label="Next page"
       >
@@ -55,6 +75,7 @@ export class NavPages extends React.PureComponent <IProps> {
 
   private renderButtons = () => {
     const { currentPage, pages, lockForwardNav } = this.props;
+    const { pageChangeInProgress } = this.state;
     const totalPages = pages.length;
     const maxPagesLeftOfCurrent = currentPage - 1;
     const maxPagesRightOfCurrent = totalPages - currentPage;
@@ -76,7 +97,7 @@ export class NavPages extends React.PureComponent <IProps> {
     return (
       pageNums.map((page: number) =>
         <button
-          className={`page-button ${currentPage === page ? "current" : ""} ${(lockForwardNav && currentPage < page) ? "disabled" : ""}`}
+          className={`page-button ${currentPage === page ? "current" : ""} ${(pageChangeInProgress || lockForwardNav && currentPage < page) ? "disabled" : ""}`}
           onClick={this.handleChangePage(page)}
           key={`page ${page}`}
           data-cy="nav-pages-button"
@@ -90,8 +111,9 @@ export class NavPages extends React.PureComponent <IProps> {
 
   private renderHomePageButton = () => {
     const currentClass = this.props.currentPage === 0 ? "current" : "";
+    const { pageChangeInProgress } = this.state;
     return (
-      <button className={`page-button ${currentClass}`} onClick={this.handleChangePage(0)} aria-label="Home">
+      <button className={`page-button ${currentClass} ${(pageChangeInProgress) ? "disabled" : ""}`} onClick={this.handleChangePage(0)} aria-label="Home">
         <IconHome
           className={`icon ${this.props.currentPage === 0 ? "current" : ""}`}
           width={28}
@@ -102,6 +124,9 @@ export class NavPages extends React.PureComponent <IProps> {
   }
 
   private handleChangePage = (page: number) => () => {
-    this.props.onPageChange(page);
+    if (!this.state.pageChangeInProgress) {
+      this.props.onPageChange(page);
+      this.setState({ pageChangeInProgress: true });
+    }
   }
 }

--- a/src/components/activity-header/nav-pages.tsx
+++ b/src/components/activity-header/nav-pages.tsx
@@ -125,8 +125,9 @@ export class NavPages extends React.Component <IProps, IState> {
 
   private handleChangePage = (page: number) => () => {
     if (!this.state.pageChangeInProgress) {
-      this.props.onPageChange(page);
-      this.setState({ pageChangeInProgress: true });
+      this.setState({ pageChangeInProgress: true }, () => {
+        this.props.onPageChange(page);
+      });
     }
   }
 }

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useContext, useEffect, useRef }  from "react";
+import React, { forwardRef, useCallback, useContext, useEffect, useImperativeHandle, useRef }  from "react";
 import { TextBox } from "./text-box/text-box";
 import { LaraGlobalContext } from "../lara-global-context";
-import { ManagedInteractive } from "./managed-interactive/managed-interactive";
+import { ManagedInteractive, ManagedInteractiveImperativeAPI } from "./managed-interactive/managed-interactive";
 import { ActivityLayouts, PageLayouts, EmbeddableSections } from "../../utilities/activity-utils";
 import { EmbeddablePlugin } from "./plugins/embeddable-plugin";
 import { initializePlugin, IPartialEmbeddablePluginContext, validateEmbeddablePluginContextForWrappedEmbeddable
@@ -22,17 +22,22 @@ interface IProps {
   teacherEditionMode?: boolean;
   setNavigation?: (id: string, options: INavigationOptions) => void;
   pluginsLoaded: boolean;
+  ref?: React.Ref<EmbeddableImperativeAPI>;
+}
+
+export interface EmbeddableImperativeAPI {
+  requestInteractiveState: () => Promise<void>;
 }
 
 type ISendCustomMessage = (message: ICustomMessage) => void;
 
-export const Embeddable: React.FC<IProps> = (props) => {
+export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
   const { activityLayout, embeddableWrapper, linkedPluginEmbeddable, pageLayout, pageSection, questionNumber, setNavigation, teacherEditionMode, pluginsLoaded } = props;
   const embeddable = embeddableWrapper.embeddable;
   const handleSetNavigation = useCallback((options: INavigationOptions) => {
     setNavigation?.(embeddable.ref_id, options);
   }, [setNavigation, embeddable.ref_id]);
-
+  const managedInteractiveRef = useRef<ManagedInteractiveImperativeAPI>(null);
   const embeddableWrapperDivTarget = useRef<HTMLInputElement>(null);
   const embeddableDivTarget = useRef<HTMLInputElement>(null);
   const sendCustomMessage = useRef<ISendCustomMessage | undefined>(undefined);
@@ -57,6 +62,12 @@ export const Embeddable: React.FC<IProps> = (props) => {
     }
   }, [LARA, linkedPluginEmbeddable, embeddable, teacherEditionMode, pluginsLoaded]);
 
+  useImperativeHandle(ref, () => ({
+    requestInteractiveState: () => {
+      return managedInteractiveRef.current?.requestInteractiveState() || Promise.resolve();
+    }
+  }));
+
   const handleSetSupportedFeatures = useCallback((container: HTMLElement, features: ISupportedFeatures) => {
     const event: IInteractiveSupportedFeaturesEvent = {
       container,
@@ -68,6 +79,7 @@ export const Embeddable: React.FC<IProps> = (props) => {
   let qComponent;
   if (embeddable.type === "MwInteractive" || (embeddable.type === "ManagedInteractive" && embeddable.library_interactive)) {
     qComponent = <ManagedInteractive
+                    ref={managedInteractiveRef}
                     embeddable={embeddable}
                     questionNumber={questionNumber}
                     setSupportedFeatures={handleSetSupportedFeatures}
@@ -99,5 +111,5 @@ export const Embeddable: React.FC<IProps> = (props) => {
       </div>
     </div>
   );
-};
+});
 Embeddable.displayName = "Embeddable";

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -70,8 +70,6 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
   const setInteractiveStateRef = useRef<((state: any) => void)>(setInteractiveState);
   setInteractiveStateRef.current = setInteractiveState;
   const linkedInteractivesRef = useRef(linkedInteractives?.length ? { linkedInteractives } : { linkedInteractives: [] });
-  // const interactiveStateRequestPromise = useRef<Promise<void>>();
-  // const interactiveStateRequestPromiseResolve = useRef<() => void>();
   const interactiveStateRequest = {
     promise: useRef<Promise<void>>(),
     resolveAndCleanup: useRef<() => void>(),

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -60,6 +60,7 @@ interface IProps {}
 export class App extends React.PureComponent<IProps, IState> {
 
   private LARA: LaraGlobalType;
+  private activityPageContentRef = React.createRef<ActivityPageContent>();
 
   public constructor(props: IProps) {
     super(props);
@@ -227,6 +228,7 @@ export class App extends React.PureComponent<IProps, IState> {
             : activity.pages[currentPage - 1].is_completion
               ? this.renderCompletionContent(activity)
               : <ActivityPageContent
+                  ref={this.activityPageContentRef}
                   enableReportButton={currentPage === activity.pages.length && enableReportButton(activity)}
                   pageNumber={currentPage}
                   page={activity.pages.filter((page) => !page.is_hidden)[currentPage - 1]}
@@ -309,13 +311,24 @@ export class App extends React.PureComponent<IProps, IState> {
       const label = incompleteQuestions[0].navOptions?.message || kDefaultIncompleteMessage;
       this.setShowModal(true, label);
     } else if (page >= 0 && (activity && page <= activity.pages.length)) {
-      this.setState({currentPage: page, incompleteQuestions: []});
-      setDocumentTitle(activity, page);
-      Logger.updateActivityPage(page);
-      Logger.log({
-        event: LogEventName.change_activity_page,
-        parameters: { new_page: page }
-      });
+      const navigateAway = () => {
+        this.setState({ currentPage: page, incompleteQuestions: [] });
+        setDocumentTitle(activity, page);
+        Logger.updateActivityPage(page);
+        Logger.log({
+          event: LogEventName.change_activity_page,
+          parameters: { new_page: page }
+        });
+      };
+      // Make sure that interactive state is saved before user can navigate away.
+      const promises = this.activityPageContentRef.current?.requestInteractiveStates() || [Promise.resolve()];
+      Promise.all(promises)
+        .then(navigateAway)
+        .catch(error => {
+          // Notify user about error, but change page anyway.
+          window.alert(error);
+          navigateAway();
+        });
     }
   }
 
@@ -365,5 +378,4 @@ export class App extends React.PureComponent<IProps, IState> {
   private handleLoadPlugins = () => {
     this.setState({ pluginsLoaded: true });
   }
-
 }

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -16,6 +16,7 @@ export const getAnswerWithMetadata = (
     oldAnswerMeta?: IExportableAnswerMetadata): (IExportableAnswerMetadata | void) => {
 
   if (!embeddable.authored_state) return;
+  if (!interactiveState) return;
 
   const authoredState = JSON.parse(embeddable.authored_state) as IAuthoringMetadata;
   const reportState: IReportState = {


### PR DESCRIPTION
[#176178847]

The `App` component uses refs and imperative APIs to request all the interactive states just before the current page number is updated. The final call is executed by iframe-runtime. The page number is updated only after all the interactives respond or after 2 seconds when a promise gets rejected. The user will see an error message in this case. Usually, this shouldn't happen, and hopefully will be caught by authors. The easiest way to trigger it is to check "save state" on the interactive that actually doesn't save state. Otherwise, Interactive API Client handles that automatically for interactives, so all the new ones should be safe. Generally, this feature should work the same as LARA + timeout support + error message.