### PR TITLE
176503551 fix page links

### DIFF
--- a/src/components/activity-introduction/activity-page-links.scss
+++ b/src/components/activity-introduction/activity-page-links.scss
@@ -40,6 +40,9 @@
 
     .page-link {
       margin-left: 3px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 

--- a/src/components/activity-introduction/activity-page-links.test.tsx
+++ b/src/components/activity-introduction/activity-page-links.test.tsx
@@ -9,9 +9,9 @@ describe("Activity Page Links component", () => {
       // do nothing.
     };
     const activityPages = [
-      {...DefaultTestPage, name: "1"},
-      {...DefaultTestPage, name: "2"},
-      {...DefaultTestPage, name: "3"},
+      {...DefaultTestPage, name: "Page 1"},
+      {...DefaultTestPage, name: "Page 2"},
+      {...DefaultTestPage, name: "Page 3"},
     ];
 
     const wrapper = shallow(<ActivityPageLinks activityPages={activityPages} onPageChange={stubFunction} />);

--- a/src/components/activity-introduction/activity-page-links.tsx
+++ b/src/components/activity-introduction/activity-page-links.tsx
@@ -23,7 +23,7 @@ export class ActivityPageLinks extends React.PureComponent <IProps> {
             tabIndex={0}
           >
             <span>{`${index + 1}:`}</span>
-            <span className="page-link">{`Page ${index + 1}`}</span>
+            <span className="page-link">{`${page.name ? page.name : "Page " + (index + 1)}`}</span>
           </div>
           ))
         }

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -68,7 +68,7 @@ export class ActivityPageContent extends React.PureComponent <IProps, IState> {
 
     return (
       <div className={`page-content ${page.layout === PageLayouts.Responsive ? "full" : ""}`} data-cy="page-content">
-        <div className="name">{`Page ` + pageNumber + `: ` + pageTitle}</div>
+        <div className="name">{`Page ${pageNumber} ${pageTitle ? ":" : ""} ${pageTitle}`}</div>
         <div className="introduction">
           { page.text && renderHTML(page.text) }
           { visibleEmbeddables.headerBlock.length > 0 && this.renderIntroEmbeddables(visibleEmbeddables.headerBlock, totalPreviousQuestions) }


### PR DESCRIPTION
This PR updates the pages names in the page links in the activity home page to show the actual page name (if it exists) instead of showing "Page N" (and includes handling of long page names).  

This also includes a small tweak to remove the ":" in the internal page when there is no page name so we show, for example, "Page 3" instead of "Page 3:".

![image](https://user-images.githubusercontent.com/5126913/104641470-a62fd800-565e-11eb-95d5-271fcb4f3b48.png)
