### PR TITLE
Add custom tinymce classes defined in Lara [#176540074]

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -1,4 +1,5 @@
 @import "./vars.scss";
+@import "./tinymce.scss";
 
 #app {
   position: fixed;

--- a/src/components/tinymce.scss
+++ b/src/components/tinymce.scss
@@ -1,0 +1,11 @@
+// contents of https://github.com/concord-consortium/lara/blob/master/app/assets/stylesheets/partials/_tinymce-classes.scss
+
+.tinymce-img-float-left {
+  float: left;
+  margin-right: 15px;
+}
+
+.tinymce-img-float-right {
+  float: right;
+  margin-left: 15px;
+}


### PR DESCRIPTION
Adds tinymce-img-float-left and tinymce-img-float-right classes.  These are the only custom tinymce classes defined in Lara.