### PR TITLE
Fix lightbox sizing

### DIFF
--- a/src/components/activity-page/managed-interactive/lightbox.tsx
+++ b/src/components/activity-page/managed-interactive/lightbox.tsx
@@ -32,6 +32,7 @@ const getSizeOptions = ({ size, allowUpscale }: { size?: { width: number, height
   const sizeOpts: { width: number, height: number } = { width: 0, height: 0 };
   if (size) {
     const aspectRatio = size.width / size.height;
+    const availableAspectRatio = availableWidth / availableHeight;
 
     if (allowUpscale) {
       // If upscaling is enabled, simply try to use all available width first. It's either fine or height is too big.
@@ -40,18 +41,18 @@ const getSizeOptions = ({ size, allowUpscale }: { size?: { width: number, height
       size.height = availableWidth / aspectRatio;
     }
 
-    if (size.height > availableHeight) {
+    if (aspectRatio >= availableAspectRatio && size.width > availableWidth) {
+      // width is constraining dimension
+      sizeOpts.width = availableWidth;
+      sizeOpts.height = availableWidth / aspectRatio;
+    } else if (aspectRatio < availableAspectRatio && size.height > availableHeight) {
       // height is constraining dimension
       sizeOpts.width = availableHeight * aspectRatio;
       sizeOpts.height = availableHeight;
     } else {
+      // image fits in the available space, no adjustments necessary
       sizeOpts.width = size.width;
       sizeOpts.height = size.height;
-    }
-    if (size.width > availableWidth) {
-      // width is constraining dimension
-      sizeOpts.width = availableWidth;
-      sizeOpts.height = availableWidth / aspectRatio;
     }
     return sizeOpts;
   }


### PR DESCRIPTION
[#176540138]

The previous logic was slightly broken.

Example case that was failing before:
- image 2000px x 2000px
- window 1000px x 500px
- allowUpscale = false (so, "original dimension" option in the Image Interactive)


First `if` was setting height to 500px and width to 500px.
That would be fine, but there was another `if` that was checking width independently.
So, it'd set the final width to 1000px and height to 1000px following image aspect ratio.
So, the image would be taller than the window and the close "X" icon won't be visible.

New logic just calculates aspect ratios first and uses pretty clear logic to check for constraining dimension.