### PR TITLE
Save answers even when there's no authored state

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -48,6 +48,8 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   const shouldWatchAnswer = isQuestion(props.embeddable);
   const [loading, setLoading] = useState(shouldWatchAnswer);
 
+  console.log(props.embeddable);
+
   const embeddableRefId = props.embeddable.ref_id;
   useEffect(() => {
     if (shouldWatchAnswer) {
@@ -186,12 +188,18 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
     }
   }));
 
+  // embeddable.url_fragment is an optional string (path, query params, hash) that can be defined by author.
+  // Some interactives are authored that way. Note that url_fragment is not merged with the dialog URL. 
+  // Each interactive will be first loaded inline with the url_fragment appended. So it can merge its custom dialog URL 
+  // with this fragment if necessary. ActivityPlayer doesn't have knowledge about URL format and provided url_fragment 
+  // to perform this merge automatically.
+  const iframeUrl = activeDialog?.url || (embeddable.url_fragment ? url + embeddable.url_fragment : url);
   const interactiveIframeRuntime =
     loading ?
       "Loading..." :
       <IframeRuntime
         ref={iframeRuntimeRef}
-        url={activeDialog?.url || url}
+        url={iframeUrl}
         id={interactiveId}
         authoredState={authoredState}
         initialInteractiveState={interactiveState.current}

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -48,8 +48,6 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   const shouldWatchAnswer = isQuestion(props.embeddable);
   const [loading, setLoading] = useState(shouldWatchAnswer);
 
-  console.log(props.embeddable);
-
   const embeddableRefId = props.embeddable.ref_id;
   useEffect(() => {
     if (shouldWatchAnswer) {

--- a/src/utilities/embeddable-utils.test.ts
+++ b/src/utilities/embeddable-utils.test.ts
@@ -175,4 +175,32 @@ describe("Embeddable utility functions", () => {
 
     expect(exportableAnswer.id).toBe("open_response_answer_123");
   });
+
+  it("can create an exportable answer when authored state is empty", () => {
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: "",
+      ref_id: "123-ManagedInteractive"
+    };
+
+    const interactiveState: IRuntimeMetadata = {
+      answerType: "open_response_answer",
+      answerText: "test"
+    };
+
+    const originalAnswer: IExportableAnswerMetadata = {
+      type: "open_response_answer",
+      remote_endpoint: "",
+      question_id: "managed_interactive_123",
+      question_type: "open_response",
+      id: "open_response_answer_123",
+      submitted: null,
+      report_state: "",
+      answer: ""
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable, originalAnswer) as IExportableOpenResponseAnswerMetadata;
+
+    expect(exportableAnswer.id).toBe("open_response_answer_123");
+  });
 });

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -15,25 +15,22 @@ export const getAnswerWithMetadata = (
     embeddable: IManagedInteractive,
     oldAnswerMeta?: IExportableAnswerMetadata): (IExportableAnswerMetadata | void) => {
 
-  if (!embeddable.authored_state) return;
   if (!interactiveState) return;
 
-  const authoredState = JSON.parse(embeddable.authored_state) as IAuthoringMetadata;
+  const authoredState = embeddable.authored_state && JSON.parse(embeddable.authored_state) as IAuthoringMetadata;
   const reportState: IReportState = {
     mode: "report",
-    authoredState: embeddable.authored_state,
-    interactiveState: JSON.stringify(interactiveState)
+    authoredState: embeddable.authored_state || "",
+    interactiveState: JSON.stringify(interactiveState),
+    version: 1
   };
-  if ((authoredState as any).version) {
-    reportState.version = (authoredState as any).version;
-  }
 
   const reportStateJSON = JSON.stringify(reportState);
 
   const exportableAnswerBase = {
     remote_endpoint: "",
     question_id: refIdToAnswersQuestionId(embeddable.ref_id),
-    question_type: authoredState.questionType,
+    question_type: authoredState ? authoredState.questionType : undefined,
     id: oldAnswerMeta ? oldAnswerMeta.id : uuidv4(),
     type: interactiveState.answerType,
     answer_text: interactiveState.answerText,


### PR DESCRIPTION
[#176576965]

Some interactives don't define any authored state.

Note that I changed how the "version" property is set in the report state. It's no longer taken from the authored state. I think it's a separate version / JSON format. Currently, it's a JSON with mode, authoredState, and interactiveState properties. It doesn't seem related to authored state format version that is interactive specific.