### PR TITLE
Use a default firebaseApp based on the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Inside of your `package.json` file:
 * portal-report:        sets the url of the student report
 
 #### User data loading:
-* firebase-app={id}: needed to load data from the correct firebase app
+* firebaseApp={id}: needed to load data from the correct firebase app
 * token={n}:         set by the portal when launching external activity, to authenticate with portal API
 * domain={n}:        set by the portal when launching external activity
 * report-source={id}: which source collection to save data to in firestore (defaults to own hostname)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Inside of your `package.json` file:
 * portal-report:        sets the url of the student report
 
 #### User data loading:
-* firebaseApp={id}: needed to load data from the correct firebase app
+* firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ without a path, defaults to `report-service-pro` every other url `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.
 * token={n}:         set by the portal when launching external activity, to authenticate with portal API
 * domain={n}:        set by the portal when launching external activity
 * report-source={id}: which source collection to save data to in firestore (defaults to own hostname)

--- a/cypress/integration/data-saving-anonymous.ts
+++ b/cypress/integration/data-saving-anonymous.ts
@@ -8,7 +8,7 @@ context("Saving and loading data as an anonymous user", () => {
 
   describe("Setting the run key", () => {
     it("will set the run key if we are not in preview mode", () => {
-      cy.visit("?activity=sample-activity-1&firebase-app=report-service-dev");
+      cy.visit("?activity=sample-activity-1");
       activityPage.getNavPage(2).click();
       cy.url().should("include", "runKey");
     });
@@ -21,7 +21,7 @@ context("Saving and loading data as an anonymous user", () => {
 
   describe("Saving and loading data", () => {
     const runKey = uuidv4();
-    const activityUrl = "?activity=sample-activity-1&firebase-app=report-service-dev&enableFirestorePersistence";
+    const activityUrl = "?activity=sample-activity-1&enableFirestorePersistence";
 
     it("we can use a runKey to retrieve data previously persisted", () => {
       const activityUrlWithRunKey = activityUrl + "&runKey=" + runKey;

--- a/cypress/integration/opening-reports.test.ts
+++ b/cypress/integration/opening-reports.test.ts
@@ -12,7 +12,6 @@ context("Test Opening Portal Reports from various places", () => {
     const activityStructureUrl = "https://example.com/activities/123";
     const activityPlayerUrl = "?" +
       "activity="+activityExportUrl+
-      "&firebase-app=report-service-dev" +
       "&report-source=authoring.staging.concord.org" +
       "&runKey="+runKey;
 

--- a/src/portal-api.test.ts
+++ b/src/portal-api.test.ts
@@ -41,7 +41,7 @@ describe("firebaseAppName", () => {
       expect(firebaseAppName()).toBe("report-service-dev");
     });
 
-    it("can be overriden to report-service-pro with a branch url", () => {
+    it("can be overridden to report-service-pro with a branch url", () => {
       url.href = "https://activity-player.concord.org/branch/foo?firebaseApp=report-service-pro";
       expect(firebaseAppName()).toBe("report-service-pro");
     });

--- a/src/portal-api.test.ts
+++ b/src/portal-api.test.ts
@@ -8,22 +8,22 @@ describe("firebaseAppName", () => {
 
   describe("with different urls", () => {
     const oldWindowLocation = window.location;
-    const url = document.createElement('a');
+    const url = document.createElement("a");
 
     beforeEach(() => {
       // Need to mock window location
       // The properties of `a` elements match the origin, hostname, pathname props of window.location
       // so that is a hacky way to mock the window location
 
-      // @ts-expect-error
+      // @ts-expect-error: mocking window location
       delete window.location;
-      // @ts-expect-error
+      // @ts-expect-error: mocking window location
       window.location = url;
     });
 
     afterEach(() => {
       // restore `window.location` to the `jsdom` `Location` object
-      window.location = oldWindowLocation
+      window.location = oldWindowLocation;
     });
 
     it("returns report-service-pro when the url is https://activity-player.concord.org", () => {
@@ -44,7 +44,7 @@ describe("firebaseAppName", () => {
     it("can be overriden to report-service-pro with a branch url", () => {
       url.href = "https://activity-player.concord.org/branch/foo?firebaseApp=report-service-pro";
       expect(firebaseAppName()).toBe("report-service-pro");
-    })
+    });
 
   });
 

--- a/src/portal-api.test.ts
+++ b/src/portal-api.test.ts
@@ -1,0 +1,51 @@
+import { firebaseAppName, clearFirebaseAppName } from "./portal-api";
+
+describe("firebaseAppName", () => {
+
+  beforeEach(() => {
+    clearFirebaseAppName();
+  });
+
+  describe("with different urls", () => {
+    const oldWindowLocation = window.location;
+    const url = document.createElement('a');
+
+    beforeEach(() => {
+      // Need to mock window location
+      // The properties of `a` elements match the origin, hostname, pathname props of window.location
+      // so that is a hacky way to mock the window location
+
+      // @ts-expect-error
+      delete window.location;
+      // @ts-expect-error
+      window.location = url;
+    });
+
+    afterEach(() => {
+      // restore `window.location` to the `jsdom` `Location` object
+      window.location = oldWindowLocation
+    });
+
+    it("returns report-service-pro when the url is https://activity-player.concord.org", () => {
+      url.href = "https://activity-player.concord.org";
+      expect(firebaseAppName()).toBe("report-service-pro");
+    });
+
+    it("returns report-service-dev on a branch url", () => {
+      url.href = "https://activity-player.concord.org/branch/foo";
+      expect(firebaseAppName()).toBe("report-service-dev");
+    });
+
+    it("returns report-service-dev on localhost url", () => {
+      url.href = "http://localhost:8080";
+      expect(firebaseAppName()).toBe("report-service-dev");
+    });
+
+    it("can be overriden to report-service-pro with a branch url", () => {
+      url.href = "https://activity-player.concord.org/branch/foo?firebaseApp=report-service-pro";
+      expect(firebaseAppName()).toBe("report-service-pro");
+    })
+
+  });
+
+});

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -235,7 +235,7 @@ export const firebaseAppName = ():FirebaseAppName => {
   } else {
     return "report-service-dev";
   }
-}
+};
 
 const getActivityPlayerFirebaseJWT = (basePortalUrl: string, rawPortalJWT: string, classHash?: string) => {
   const _classHash = classHash ? { class_hash: classHash } : undefined;

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -247,7 +247,7 @@ export const firebaseAppName = ():FirebaseAppName => {
 // this is used for testing purposes
 export const clearFirebaseAppName = () => {
   _firebaseAppName = null;
-}
+};
 
 const getActivityPlayerFirebaseJWT = (basePortalUrl: string, rawPortalJWT: string, classHash?: string) => {
   const _classHash = classHash ? { class_hash: classHash } : undefined;

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -244,6 +244,11 @@ export const firebaseAppName = ():FirebaseAppName => {
   return _firebaseAppName;
 };
 
+// this is used for testing purposes
+export const clearFirebaseAppName = () => {
+  _firebaseAppName = null;
+}
+
 const getActivityPlayerFirebaseJWT = (basePortalUrl: string, rawPortalJWT: string, classHash?: string) => {
   const _classHash = classHash ? { class_hash: classHash } : undefined;
   const queryParams = { firebase_app: firebaseAppName(), ..._classHash };

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -210,7 +210,7 @@ const getPortalJWTWithBearerToken = (basePortalUrl: string, rawToken: string) =>
 // only https://activity-player.concord.org defaults to report-service-pro
 // everything else defaults to report-service-dev
 //
-// The default can be overriden with a firebaseApp URL param
+// The default can be overridden with a firebaseApp URL param
 //
 // A memoized function is used here so we don't compute the app name until it is
 // actually needed. This will be useful if we start supporting OAuth where the

--- a/src/portal-utils.test.ts
+++ b/src/portal-utils.test.ts
@@ -1,7 +1,6 @@
 import { handleGetFirebaseJWT } from "./portal-utils";
 
-const firebaseApp = "firebase-app";
-const params = { firebase_app: firebaseApp };
+const params = { firebase_app: "firebase-app" };
 const rawFirebaseJWT = "rawFirebaseJWT";
 const rejectMessage = "Bad PortalJWT!";
 

--- a/src/utilities/report-utils.test.ts
+++ b/src/utilities/report-utils.test.ts
@@ -20,7 +20,7 @@ jest.mock("../firebase-db", () => (
 describe("getReportUrl", () => {
   beforeEach(() => {
     clearFirebaseAppName();
-  })
+  });
 
   it("returns a valid reportURL with basic AP params", () => {
     window.history.replaceState({}, "Test", "/?activity=https://lara.example.com/api/v1/activities/345.json");

--- a/src/utilities/report-utils.test.ts
+++ b/src/utilities/report-utils.test.ts
@@ -1,4 +1,5 @@
 import { getReportUrl } from "./report-utils";
+import { clearFirebaseAppName } from "../portal-api";
 
 jest.mock("../firebase-db", () => (
   {
@@ -17,7 +18,11 @@ jest.mock("../firebase-db", () => (
 ));
 
 describe("getReportUrl", () => {
-  it("does something", () => {
+  beforeEach(() => {
+    clearFirebaseAppName();
+  })
+
+  it("returns a valid reportURL with basic AP params", () => {
     window.history.replaceState({}, "Test", "/?activity=https://lara.example.com/api/v1/activities/345.json");
 
     const reportURL = getReportUrl();
@@ -26,6 +31,22 @@ describe("getReportUrl", () => {
       "https://portal-report.concord.org/branch/master/index.html?"
       + "class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
       + "&firebase-app=report-service-dev"
+      + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
+      + "&reportType=offering"
+      + "&studentId=abc345"
+      + "&sourceKey=lara.example.com"
+      + "&answersSourceKey=activity-player.unexisting.url.com"
+      + "&auth-domain=https://example.com");
+  });
+
+  it("returns a reportURL with the correct firebase-app if the firebaseApp param is used", () => {
+    window.history.replaceState({}, "Test", "/?firebaseApp=report-service-pro&activity=https://lara.example.com/api/v1/activities/345.json");
+    const reportURL = getReportUrl();
+
+    expect(reportURL).toEqual(
+      "https://portal-report.concord.org/branch/master/index.html?"
+      + "class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
+      + "&firebase-app=report-service-pro"
       + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
       + "&reportType=offering"
       + "&studentId=abc345"

--- a/src/utilities/report-utils.ts
+++ b/src/utilities/report-utils.ts
@@ -1,12 +1,9 @@
 import { queryValue } from "../utilities/url-query";
 import { getPortalData } from "../firebase-db";
-import { IPortalData } from "../portal-api";
+import { IPortalData, firebaseAppName } from "../portal-api";
 
 // TODO: switch default to production report version before production deploy
 export const DEFAULT_PORTAL_REPORT_URL = "https://portal-report.concord.org/branch/master/index.html";
-// export const DEFAULT_PORTAL_REPORT_URL = "https://localhost:8081/";
-// TODO: switch default to "report-service-pro" before production deploy
-export const DEFAULT_PORTAL_REPORT_FIREBASE_APP = "report-service-dev";
 
 const parseUrl = (url: string) => {
   const a = document.createElement("a");
@@ -21,7 +18,7 @@ const makeSourceKey = (url: string | null) => {
 export const getReportUrl = () => {
   // TODO: switch default to production report version before production deploy
   const reportLink = (queryValue("portal-report") as string) || DEFAULT_PORTAL_REPORT_URL;
-  const reportFirebaseApp = (queryValue("tool-id") as string) || DEFAULT_PORTAL_REPORT_FIREBASE_APP;
+  const reportFirebaseApp = firebaseAppName();
   const activity = queryValue("activity");
   const activityUrl = activity? ((activity.split(".json"))[0]).replace("api/v1/","") : "";
   const runKey= queryValue("runKey");


### PR DESCRIPTION
Only https://activity-player.concord.org uses `report-service-pro` by default.
Any additional path or different domain will use `report-service-dev` by default.
In either case the `firebaseApp` param can be used to override this. 

This still needs tests.