### PR TITLE
Enforce session timeout

### DIFF
--- a/cypress/integration/idle-warning.test.ts
+++ b/cypress/integration/idle-warning.test.ts
@@ -1,0 +1,48 @@
+context("Idle warning", () => {
+  beforeEach(() => {
+    cy.clock();  
+  });
+
+  context("when user is anonymous", () => {
+    it("shows after 20 minutes of inactivity and lets user continue his work", () => {
+      cy.visit("?activity=sample-activity-1");
+      cy.tick(1000); // necessary to "download" sample activity. AP uses setTimeout(, 250) for fake network request.
+      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+      cy.tick(21 * 60 * 1000); // 21 minutes
+      cy.get("[data-cy=idle-warning]").should("contain", "You've been idle for too long.");
+
+      cy.get("[data-cy=continue]").click();
+      // Activity should be visible again.
+      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+    });
+  });
+
+  context("when user is logged in", () => {
+    // __cypressLoggedIn is used to trigger logged in code path for Cypress tests.
+    // Eventually it should be replaced with better patterns for testing logged in users (probably via using 
+    // `token` param and stubbing network requests).
+
+    it("shows after 20 minutes of inactivity and lets user continue his work", () => {
+      cy.visit("?activity=sample-activity-1&__cypressLoggedIn=true");
+      cy.tick(1000); // necessary to "download" sample activity. AP uses setTimeout(, 250) for fake network request.
+      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+      cy.tick(21 * 60 * 1000); // 21 minutes
+      cy.get("[data-cy=idle-warning]").should("contain", "your session is about to expire");
+
+      cy.get("[data-cy=continue]").click();
+      // Activity should be visible again.
+      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+    });
+    
+    it("shows after 20 minutes of inactivity and lets user go back to Portal", () => {
+      cy.visit("?activity=sample-activity-1&__cypressLoggedIn=true");
+      cy.tick(1000); // necessary to "download" sample activity. AP uses setTimeout(, 250) for fake network request.
+      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+      cy.tick(21 * 60 * 1000); // 21 minutes
+      cy.get("[data-cy=idle-warning]").should("contain", "your session is about to expire");
+
+      cy.get("[data-cy=exit]").click();
+      cy.url().should("eq", "https://learn.concord.org/");
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10476,9 +10476,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.2.1.tgz",
-      "integrity": "sha512-OYkSgzA4J4Q7eMjZvNf5qWpBLR4RXrkqjL3UZ1UzGGLAskO0nFTi/RomNTG6TKvL3Zp4tw4zFY1gp5MtmkCZrA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.3.0.tgz",
+      "integrity": "sha512-Ec6TAFOxdSB2HPINNJ1f7z75pENXcfCaQkz+A9j0eGSvusFJ2NNErq650DexCbNJAnCQkPqXB4XPH9kXnSQnUA==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -10556,15 +10556,15 @@
           }
         },
         "fs-extra": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
           }
         },
         "get-stream": {
@@ -10590,14 +10590,6 @@
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
-          },
-          "dependencies": {
-            "universalify": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-              "dev": true
-            }
           }
         },
         "npm-run-path": {
@@ -10649,9 +10641,9 @@
           }
         },
         "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "babel-jest": "^26.3.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^4.3.0",
-    "cypress": "^6.0.0",
+    "cypress": "^6.3.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.4",
     "eslint": "^7.9.0",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -178,7 +178,7 @@ export class App extends React.PureComponent<IProps, IState> {
 
       Logger.initializeLogger(this.LARA, newState.username || this.state.username, role, classHash, teacherEditionMode, sequencePath, 0, sequencePath ? undefined : activityPath, currentPage, runRemoteEndpoint);
 
-      const idleDetector = new IdleDetector({ idle: kMaxIdleTime, onIdle: this.handleIdleness });
+      const idleDetector = new IdleDetector({ idle: Number(kMaxIdleTime), onIdle: this.handleIdleness });
       idleDetector.start();
     } catch (e) {
       console.warn(e);
@@ -209,7 +209,7 @@ export class App extends React.PureComponent<IProps, IState> {
   }
 
   private renderActivity = () => {
-    const { activity, idle, errorType, currentPage, username, pluginsLoaded, teacherEditionMode, sequence } = this.state;
+    const { activity, idle, errorType, currentPage, username, pluginsLoaded, teacherEditionMode, sequence, portalData } = this.state;
     if (!activity) return (<div>Loading</div>);
     const totalPreviousQuestions = numQuestionsOnPreviousPages(currentPage, activity);
     const fullWidth = (currentPage !== 0) && (activity.pages[currentPage - 1].layout === PageLayouts.Responsive);
@@ -228,7 +228,10 @@ export class App extends React.PureComponent<IProps, IState> {
         {
           idle && !errorType && 
           <IdleWarning 
-            timeout={kTimeout} username={username}
+            // __cypressLoggedIn is used to trigger logged in code path for Cypress tests.
+            // Eventually it should be replaced with better patterns for testing logged in users (probably via using 
+            // `token` param and stubbing network requests).
+            timeout={kTimeout} username={username} anonymous={!portalData && queryValue("__cypressLoggedIn") !== "true"}
             onTimeout={this.handleTimeout} onContinue={this.handleContinueSession} onExit={this.goToPortal}
           />
         }

--- a/src/components/error/error.scss
+++ b/src/components/error/error.scss
@@ -19,6 +19,10 @@
 
   .login-again {
     margin-top: 35px;
+    .link {
+      text-decoration: underline;
+      cursor: pointer;
+    }
   }
 
   button {

--- a/src/components/error/error.scss
+++ b/src/components/error/error.scss
@@ -20,4 +20,8 @@
   .login-again {
     margin-top: 35px;
   }
+
+  button {
+    margin-right: 30px;
+  }
 }

--- a/src/components/error/error.test.tsx
+++ b/src/components/error/error.test.tsx
@@ -4,17 +4,17 @@ import { shallow } from "enzyme";
 
 describe("Error component", () => {
   it("renders authentication error message", () => {
-    const wrapper = shallow(<Error type="auth" />);
+    const wrapper = shallow(<Error type="auth" portalUrl={"https://learn.concord.org"} />);
     expect(wrapper.find('[data-cy="error"]').length).toBe(1);
     expect(wrapper.text()).toContain(errorMsg.auth);
   });
   it("renders network error message", () => {
-    const wrapper = shallow(<Error type="network" />);
+    const wrapper = shallow(<Error type="network" portalUrl={"https://learn.concord.org"} />);
     expect(wrapper.find('[data-cy="error"]').length).toBe(1);
     expect(wrapper.text()).toContain(errorMsg.network);
   });
   it("renders session timeout error message", () => {
-    const wrapper = shallow(<Error type="timeout" />);
+    const wrapper = shallow(<Error type="timeout" portalUrl={"https://learn.concord.org"} />);
     expect(wrapper.find('[data-cy="error"]').length).toBe(1);
     expect(wrapper.text()).toContain(errorMsg.timeout);
   });

--- a/src/components/error/error.test.tsx
+++ b/src/components/error/error.test.tsx
@@ -4,18 +4,28 @@ import { shallow } from "enzyme";
 
 describe("Error component", () => {
   it("renders authentication error message", () => {
-    const wrapper = shallow(<Error type="auth" portalUrl={"https://learn.concord.org"} />);
+    const wrapper = shallow(<Error type="auth" onExit={jest.fn()}/>);
     expect(wrapper.find('[data-cy="error"]').length).toBe(1);
     expect(wrapper.text()).toContain(errorMsg.auth);
   });
+  
   it("renders network error message", () => {
-    const wrapper = shallow(<Error type="network" portalUrl={"https://learn.concord.org"} />);
+    const wrapper = shallow(<Error type="network" onExit={jest.fn()}/>);
     expect(wrapper.find('[data-cy="error"]').length).toBe(1);
     expect(wrapper.text()).toContain(errorMsg.network);
   });
+  
   it("renders session timeout error message", () => {
-    const wrapper = shallow(<Error type="timeout" portalUrl={"https://learn.concord.org"} />);
+    const wrapper = shallow(<Error type="timeout" onExit={jest.fn()}/>);
     expect(wrapper.find('[data-cy="error"]').length).toBe(1);
     expect(wrapper.text()).toContain(errorMsg.timeout);
+  });
+
+  it("calls onExit when user clicks the exit link", () => {
+    const onExit = jest.fn();
+    const wrapper = shallow(<Error type="timeout" onExit={onExit} />);
+    expect(wrapper.find('[data-cy="error"]').length).toBe(1);
+    wrapper.find('[data-cy="login-again"]').simulate("click");
+    expect(onExit).toHaveBeenCalled();
   });
 });

--- a/src/components/error/error.tsx
+++ b/src/components/error/error.tsx
@@ -3,7 +3,8 @@ import { ErrorType } from "../app";
 import "./error.scss";
 
 interface IProps {
-  type: ErrorType
+  type: ErrorType;
+  portalUrl: string;
 }
 
 export const errorMsg: Record<ErrorType, string> = {
@@ -12,7 +13,8 @@ export const errorMsg: Record<ErrorType, string> = {
   timeout: "Your session has expired."
 };
 
-export const Error: React.FC<IProps> = ({ type }) => {
+
+export const Error: React.FC<IProps> = ({ type, portalUrl }) => {
   return (
     <div className="error" data-cy="error">
       <h1>Hmm... we&apos;re having trouble connecting.</h1>
@@ -22,7 +24,7 @@ export const Error: React.FC<IProps> = ({ type }) => {
         <li>Checking your internet connection status.</li>
         <li>Closing this window or tab and logging back in to relaunch this activity.</li>
       </ul>
-      <p className="login-again"><a href="https://learn.concord.org">Click here</a> to log in again.</p>
+      <p className="login-again"><a href={portalUrl}>Click here</a> to log in again.</p>
     </div>
   );
 };

--- a/src/components/error/error.tsx
+++ b/src/components/error/error.tsx
@@ -4,7 +4,7 @@ import "./error.scss";
 
 interface IProps {
   type: ErrorType;
-  portalUrl: string;
+  onExit: () => void;
 }
 
 export const errorMsg: Record<ErrorType, string> = {
@@ -14,7 +14,7 @@ export const errorMsg: Record<ErrorType, string> = {
 };
 
 
-export const Error: React.FC<IProps> = ({ type, portalUrl }) => {
+export const Error: React.FC<IProps> = ({ type, onExit }) => {
   return (
     <div className="error" data-cy="error">
       <h1>Hmm... we&apos;re having trouble connecting.</h1>
@@ -24,7 +24,7 @@ export const Error: React.FC<IProps> = ({ type, portalUrl }) => {
         <li>Checking your internet connection status.</li>
         <li>Closing this window or tab and logging back in to relaunch this activity.</li>
       </ul>
-      <p className="login-again"><a href={portalUrl}>Click here</a> to log in again.</p>
+      <p className="login-again"><span className="link" onClick={onExit} data-cy="login-again">Click here</span> to log in again.</p>
     </div>
   );
 };

--- a/src/components/error/idle-warning.test.tsx
+++ b/src/components/error/idle-warning.test.tsx
@@ -4,53 +4,82 @@ import { shallow, mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 
 describe("IdleWarning component", () => {
-  const getProps = () => ({
-    username: "test user",
-    onTimeout: jest.fn(),
-    onContinue: jest.fn(),
-    onExit: jest.fn(),
-    timeout: 2 * 60 * 1000
-  });
-
-  it("renders user name and remaining time", () => {
-    const props = getProps();
-    const wrapper = shallow(<IdleWarning {...props} />);
-    expect(wrapper.find('[data-cy="idle-warning"]').length).toBe(1);
-    expect(wrapper.text()).toContain(props.username);
-    expect(wrapper.text()).toContain("2 minutes");
-    expect(wrapper.text()).toContain("and 0 seconds");
-  });
-
-  it("calls onTimeout after `timeout` time", () => {
-    jest.useFakeTimers(); // mock timers  
-    const props = getProps();
-    props.timeout = 1;
-    mount(<IdleWarning {...props} />);
-
-    act(() => {
-      jest.runOnlyPendingTimers();
-      jest.runOnlyPendingTimers();
-      jest.runOnlyPendingTimers();
+  describe("when user is logged in", () => {  
+    const getProps = () => ({
+      username: "test user",
+      onTimeout: jest.fn(),
+      onContinue: jest.fn(),
+      onExit: jest.fn(),
+      timeout: 2 * 60 * 1000,
+      anonymous: false
     });
 
-    expect(props.onTimeout).toHaveBeenCalled();
+    it("renders user name and remaining time", () => {
+      const props = getProps();
+      const wrapper = shallow(<IdleWarning {...props} />);
+      expect(wrapper.find('[data-cy="idle-warning"]').length).toBe(1);
+      expect(wrapper.text()).toContain(props.username);
+      expect(wrapper.text()).toContain("2 minutes");
+      expect(wrapper.text()).toContain("and 0 seconds");
+    });
 
-    jest.useRealTimers();
+    it("calls onTimeout after `timeout` time", () => {
+      jest.useFakeTimers(); // mock timers  
+      const props = getProps();
+      props.timeout = 1;
+      mount(<IdleWarning {...props} />);
+
+      act(() => {
+        jest.runOnlyPendingTimers();
+        jest.runOnlyPendingTimers();
+        jest.runOnlyPendingTimers();
+      });
+
+      expect(props.onTimeout).toHaveBeenCalled();
+
+      jest.useRealTimers();
+    });
+
+    it("calls onContinue when user clicks the continue button", () => {
+      const props = getProps();
+      const wrapper = shallow(<IdleWarning {...props} />);
+      expect(wrapper.find('[data-cy="continue"]').length).toBe(1);
+      wrapper.find('[data-cy="continue"]').simulate("click");
+      expect(props.onContinue).toHaveBeenCalled();
+    });
+
+    it("redirects user to Portal when user clicks the exit button", () => {
+      const props = getProps();
+      const wrapper = shallow(<IdleWarning {...props} />);
+      expect(wrapper.find('[data-cy="exit"]').length).toBe(1);
+      wrapper.find('[data-cy="exit"]').simulate("click");
+      expect(props.onExit).toHaveBeenCalled();
+    });
   });
 
-  it("calls onContinue when user clicks the continue button", () => {
-    const props = getProps();
-    const wrapper = shallow(<IdleWarning {...props} />);
-    expect(wrapper.find('[data-cy="continue"]').length).toBe(1);
-    wrapper.find('[data-cy="continue"]').simulate("click");
-    expect(props.onContinue).toHaveBeenCalled();
-  });
+  describe("when user is anonymous", () => {
+    const getProps = () => ({
+      username: "Anonymous",
+      onTimeout: jest.fn(),
+      onContinue: jest.fn(),
+      onExit: jest.fn(),
+      timeout: 2 * 60 * 1000,
+      anonymous: true
+    });
 
-  it("redirects user to Portal when user clicks the exit button", () => {
-    const props = getProps();
-    const wrapper = shallow(<IdleWarning {...props} />);
-    expect(wrapper.find('[data-cy="exit"]').length).toBe(1);
-    wrapper.find('[data-cy="exit"]').simulate("click");
-    expect(props.onExit).toHaveBeenCalled();
+    it("renders basic warning", () => {
+      const props = getProps();
+      const wrapper = shallow(<IdleWarning {...props} />);
+      expect(wrapper.find('[data-cy="idle-warning"]').length).toBe(1);
+      expect(wrapper.text()).toContain("You've been idle for too long.");
+    });
+
+    it("calls onContinue when user clicks the continue button", () => {
+      const props = getProps();
+      const wrapper = shallow(<IdleWarning {...props} />);
+      expect(wrapper.find('[data-cy="continue"]').length).toBe(1);
+      wrapper.find('[data-cy="continue"]').simulate("click");
+      expect(props.onContinue).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/error/idle-warning.test.tsx
+++ b/src/components/error/idle-warning.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { IdleWarning } from "./idle-warning";
+import { shallow, mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+
+describe("IdleWarning component", () => {
+  const getProps = () => ({
+    username: "test user",
+    onTimeout: jest.fn(),
+    onContinue: jest.fn(),
+    onExit: jest.fn(),
+    timeout: 2 * 60 * 1000
+  });
+
+  it("renders user name and remaining time", () => {
+    const props = getProps();
+    const wrapper = shallow(<IdleWarning {...props} />);
+    expect(wrapper.find('[data-cy="idle-warning"]').length).toBe(1);
+    expect(wrapper.text()).toContain(props.username);
+    expect(wrapper.text()).toContain("2 minutes");
+    expect(wrapper.text()).toContain("and 0 seconds");
+  });
+
+  it("calls onTimeout after `timeout` time", () => {
+    jest.useFakeTimers(); // mock timers  
+    const props = getProps();
+    props.timeout = 1;
+    mount(<IdleWarning {...props} />);
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+      jest.runOnlyPendingTimers();
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(props.onTimeout).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
+  it("calls onContinue when user clicks the continue button", () => {
+    const props = getProps();
+    const wrapper = shallow(<IdleWarning {...props} />);
+    expect(wrapper.find('[data-cy="continue"]').length).toBe(1);
+    wrapper.find('[data-cy="continue"]').simulate("click");
+    expect(props.onContinue).toHaveBeenCalled();
+  });
+
+  it("redirects user to Portal when user clicks the exit button", () => {
+    const props = getProps();
+    const wrapper = shallow(<IdleWarning {...props} />);
+    expect(wrapper.find('[data-cy="exit"]').length).toBe(1);
+    wrapper.find('[data-cy="exit"]').simulate("click");
+    expect(props.onExit).toHaveBeenCalled();
+  });
+});

--- a/src/components/error/idle-warning.tsx
+++ b/src/components/error/idle-warning.tsx
@@ -3,18 +3,23 @@ import "./error.scss";
 
 interface IProps {
   username: string;
+  anonymous: boolean;
+  timeout: number;
   onTimeout: () => void;
   onContinue: () => void;
   onExit: () => void;
-  timeout: number;
 }
 
 const kMaxTimeInterval = 500; // ms
 
-export const IdleWarning: React.FC<IProps> = ({ username, timeout, onTimeout, onContinue, onExit }) => {
+export const IdleWarning: React.FC<IProps> = ({ username, anonymous, timeout, onTimeout, onContinue, onExit }) => {
   const [ time, setTime ] = useState(0);
 
   useEffect(() => {
+    if (anonymous) {
+      // Don't start the counter in anonymous mode.
+      return;
+    }
     const startTime = Date.now();
     const intervalId = setInterval(() => {
       const currentTime = Date.now();
@@ -25,7 +30,7 @@ export const IdleWarning: React.FC<IProps> = ({ username, timeout, onTimeout, on
       }
     }, Math.min(timeout / 2, kMaxTimeInterval));
     return () => window.clearInterval(intervalId);
-  }, [timeout]);
+  }, [timeout, anonymous]);
 
   useEffect(() => {
     if (time >= timeout) {
@@ -39,13 +44,24 @@ export const IdleWarning: React.FC<IProps> = ({ username, timeout, onTimeout, on
 
   return (
     <div className="error" data-cy="idle-warning">
-      <h1>{username }, your session is about to expire.</h1>
-      <p>You will be logged out automatically in 
-        <b>{min > 1 && ` ${min} minutes and`}{min === 1 && ` ${min} minute and`}{` ${sec} seconds` }</b>.
-      </p>
-      <p>Please choose to continue your session or to log in as a different user.</p>
-      <button className="button" onClick={onExit} data-cy="exit">Log in as a different user</button> 
-      <button className="button" onClick={onContinue} data-cy="continue"> Continue your session </button> 
+      { 
+        anonymous ? 
+        <div>
+          <h1>You&apos;ve been idle for too long.</h1>
+          <p>Click continue below to keep working.</p>
+          <button className="button" onClick={onContinue} data-cy="continue"> Continue your session </button> 
+        </div>
+        :
+        <div>
+          <h1>{username }, your session is about to expire.</h1>
+          <p>You will be logged out automatically in 
+            <b>{min > 1 && ` ${min} minutes and`}{min === 1 && ` ${min} minute and`}{` ${sec} seconds` }</b>.
+          </p>
+          <p>Please choose to continue your session or to log in as a different user.</p>
+          <button className="button" onClick={onExit} data-cy="exit">Log in as a different user</button> 
+          <button className="button" onClick={onContinue} data-cy="continue"> Continue your session </button> 
+        </div>
+      }
     </div>
   );
 };

--- a/src/components/error/idle-warning.tsx
+++ b/src/components/error/idle-warning.tsx
@@ -9,6 +9,8 @@ interface IProps {
   timeout: number;
 }
 
+const kMaxTimeInterval = 500; // ms
+
 export const IdleWarning: React.FC<IProps> = ({ username, timeout, onTimeout, onContinue, onExit }) => {
   const [ time, setTime ] = useState(0);
 
@@ -21,7 +23,7 @@ export const IdleWarning: React.FC<IProps> = ({ username, timeout, onTimeout, on
       if (timeDiff >= timeout) {
         window.clearInterval(intervalId);
       }
-    }, Math.min(timeout / 2, 500));
+    }, Math.min(timeout / 2, kMaxTimeInterval));
     return () => window.clearInterval(intervalId);
   }, [timeout]);
 

--- a/src/components/error/idle-warning.tsx
+++ b/src/components/error/idle-warning.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from "react";
+import "./error.scss";
+
+interface IProps {
+  username: string;
+  onTimeout: () => void;
+  onContinue: () => void;
+  onExit: () => void;
+  timeout: number;
+}
+
+export const IdleWarning: React.FC<IProps> = ({ username, timeout, onTimeout, onContinue, onExit }) => {
+  const [ time, setTime ] = useState(0);
+
+  useEffect(() => {
+    const startTime = Date.now();
+    const intervalId = setInterval(() => {
+      const currentTime = Date.now();
+      const timeDiff = currentTime - startTime;
+      setTime(timeDiff);
+      if (timeDiff >= timeout) {
+        window.clearInterval(intervalId);
+      }
+    }, Math.min(timeout / 2, 500));
+    return () => window.clearInterval(intervalId);
+  }, [timeout]);
+
+  useEffect(() => {
+    if (time >= timeout) {
+      onTimeout();
+    }
+  }, [onTimeout, time, timeout]);
+  
+  const timeLeft = timeout - time;
+  const sec = Math.round((timeLeft / 1000) % 60);
+  const min = Math.floor((timeLeft / 1000) / 60);
+
+  return (
+    <div className="error" data-cy="idle-warning">
+      <h1>{username }, your session is about to expire.</h1>
+      <p>Session has been idle over its time limit.</p>
+      <p>You will be logged out automatically in 
+        <b>{min > 1 && ` ${min} minutes and`}{min === 1 && ` ${min} minute and`}{` ${sec} seconds` }</b>.
+      </p>
+      <p>Please choose to continue your session or to log in as a different user.</p>
+      <button className="button" onClick={onExit} data-cy="exit">Log in as a different user</button> 
+      <button className="button" onClick={onContinue} data-cy="continue"> Continue your session </button> 
+    </div>
+  );
+};

--- a/src/components/error/idle-warning.tsx
+++ b/src/components/error/idle-warning.tsx
@@ -40,7 +40,6 @@ export const IdleWarning: React.FC<IProps> = ({ username, timeout, onTimeout, on
   return (
     <div className="error" data-cy="idle-warning">
       <h1>{username }, your session is about to expire.</h1>
-      <p>Session has been idle over its time limit.</p>
       <p>You will be logged out automatically in 
         <b>{min > 1 && ` ${min} minutes and`}{min === 1 && ` ${min} minute and`}{` ${sec} seconds` }</b>.
       </p>

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -42,6 +42,10 @@ export enum LogEventName {
   toggle_collapsible_column,
   create_report,
   toggle_hint,
+  show_idle_warning,
+  go_back_to_portal,
+  continue_session,
+  session_timeout
 }
 
 export class Logger {

--- a/src/utilities/idle-detector.test.ts
+++ b/src/utilities/idle-detector.test.ts
@@ -1,6 +1,6 @@
 import { IdleDetector } from "./idle-detector";
 
-const idleTime = 3;
+const idleTime = 20;
 
 describe("IdleDetector", () => {
   it("detects idle user and calls onIdle", (done) => {
@@ -12,7 +12,7 @@ describe("IdleDetector", () => {
     setTimeout(() => {
       expect(onIdle).toHaveBeenCalled();
       done();
-    }, idleTime + 1);
+    }, idleTime + 5);
   });
 
   it("detects user actions user and doesn't call onIdle", (done) => {
@@ -23,12 +23,12 @@ describe("IdleDetector", () => {
 
     setTimeout(() => {
       window.dispatchEvent(new Event("mousemove"));
-    }, idleTime - 1);
+    }, idleTime - 5);
 
     setTimeout(() => {
       expect(onIdle).not.toHaveBeenCalled();
       done();
-    }, idleTime + 1);
+    }, idleTime + 5);
   });
 
   it("calls onActive after user has been idle and active again", (done) => {
@@ -42,11 +42,11 @@ describe("IdleDetector", () => {
       expect(onActive).not.toHaveBeenCalled();
       
       window.dispatchEvent(new Event("mousemove"));
-    }, idleTime + 1);
+    }, idleTime + 5);
 
     setTimeout(() => {
       expect(onActive).toHaveBeenCalled();
       done();
-    }, idleTime + 2);
+    }, idleTime + 10);
   });
 });

--- a/src/utilities/idle-detector.test.ts
+++ b/src/utilities/idle-detector.test.ts
@@ -1,0 +1,52 @@
+import { IdleDetector } from "./idle-detector";
+
+const idleTime = 3;
+
+describe("IdleDetector", () => {
+  it("detects idle user and calls onIdle", (done) => {
+    const onIdle = jest.fn();
+    const onActive = jest.fn();
+    const id = new IdleDetector({ idle: idleTime, onIdle, onActive });
+    id.start();
+
+    setTimeout(() => {
+      expect(onIdle).toHaveBeenCalled();
+      done();
+    }, idleTime + 1);
+  });
+
+  it("detects user actions user and doesn't call onIdle", (done) => {
+    const onIdle = jest.fn();
+    const onActive = jest.fn();
+    const id = new IdleDetector({ idle: idleTime, onIdle, onActive });
+    id.start();
+
+    setTimeout(() => {
+      window.dispatchEvent(new Event("mousemove"));
+    }, idleTime - 1);
+
+    setTimeout(() => {
+      expect(onIdle).not.toHaveBeenCalled();
+      done();
+    }, idleTime + 1);
+  });
+
+  it("calls onActive after user has been idle and active again", (done) => {
+    const onIdle = jest.fn();
+    const onActive = jest.fn();
+    const id = new IdleDetector({ idle: idleTime, onIdle, onActive });
+    id.start();
+
+    setTimeout(() => {
+      expect(onIdle).toHaveBeenCalled();
+      expect(onActive).not.toHaveBeenCalled();
+      
+      window.dispatchEvent(new Event("mousemove"));
+    }, idleTime + 1);
+
+    setTimeout(() => {
+      expect(onActive).toHaveBeenCalled();
+      done();
+    }, idleTime + 2);
+  });
+});

--- a/src/utilities/idle-detector.ts
+++ b/src/utilities/idle-detector.ts
@@ -1,0 +1,138 @@
+// This helper is based on: https://www.npmjs.com/package/idle-js
+// All the functionality and options should be supported.
+// However, it's been cleaned up and rewritten in TypeScript.
+// PJ 01/25/2020: It happened as I thought it'd be possible to add iframe support, but I was wrong. Still, the library 
+// is small enough and it's not actively developed, so I think it makes sense to have an own TS copy anyway.
+type EventHandler = () => void;
+
+interface IOptions {
+  idle?: number; // idle time in ms
+  events?: string[]; // events that will trigger the idle resetter
+  onIdle?: EventHandler; // callback function to be executed after idle time
+  onActive?: EventHandler; // callback function to be executed after back form idleness
+  onHide?: EventHandler; // callback function to be executed when window become hidden
+  onShow?: EventHandler; // callback function to be executed when window become visible
+  keepTracking?: boolean; // set it to false of you want to track only once
+  startAtIdle?: boolean; // set it to true if you want to start in the idle state
+  recurIdleCall?: boolean;
+}
+
+const bulkAddEventListener = (object: any, events: string[], callback: EventHandler) => {
+  events.forEach(function (event) {
+    object.addEventListener(event, callback, true);
+  });
+};
+
+const bulkRemoveEventListener = (object: any, events: string[], callback: EventHandler) => {
+  events.forEach(function (event) {
+    object.removeEventListener(event, callback, true);
+  });
+};
+
+const visibilityEvents = ["visibilitychange", "webkitvisibilitychange", "mozvisibilitychange", "msvisibilitychange"];
+
+const defaultOptions: IOptions = {
+  idle: 10000, // idle time in ms
+  events: ["mousemove", "keydown", "mousedown", "touchstart", "scroll"], // events that will trigger the idle resetter
+  onIdle: undefined, // callback function to be executed after idle time
+  onActive: undefined, // callback function to be executed after back form idleness
+  onHide: undefined, // callback function to be executed when window become hidden
+  onShow: undefined, // callback function to be executed when window become visible
+  keepTracking: true, // set it to false of you want to track only once
+  startAtIdle: false, // set it to true if you want to start in the idle state
+  recurIdleCall: false
+};
+
+export class IdleDetector {
+  public settings: IOptions;
+  public visible: boolean;
+  public idle: boolean;
+  public clearTimeout: (() => void) | null = null;
+
+  constructor(options: IOptions) {
+    this.settings = { ...defaultOptions, ...options };
+    this.reset();
+  }
+
+  private idlenessEventsHandler = () => {
+    if (this.idle) {
+      this.idle = false;
+      this.settings.onActive?.();
+    }
+    this.resetTimeout();
+  }
+
+  private visibilityEventsHandler = () => {
+    if (document.hidden || (document as any).webkitHidden || (document as any).mozHidden || (document as any).msHidden) {
+      if (this.visible) {
+        this.visible = false;
+        this.settings.onHide?.();
+      }
+    } else {
+      if (!this.visible) {
+        this.visible = true;
+        this.settings.onShow?.();
+      }
+    }
+  }
+
+  private resetTimeout(keepTracking = this.settings.keepTracking) {
+    if (this.clearTimeout) {
+      this.clearTimeout();
+      this.clearTimeout = null;
+    }
+    if (keepTracking) {
+      this.timeout();
+    }
+  }
+
+  private timeout() {
+    const timer = (this.settings.recurIdleCall) ? {
+      set: setInterval.bind(window),
+      clear: clearInterval.bind(window),
+    } : {
+        set: setTimeout.bind(window),
+        clear: clearTimeout.bind(window),
+      };
+
+    const id = timer.set(() => {
+      this.idle = true;
+      this.settings.onIdle?.();
+    }, this.settings.idle);
+
+    this.clearTimeout = () => timer.clear(id);
+  }
+
+  public start() {
+    this.timeout();
+
+    bulkAddEventListener(window, this.settings.events || [], this.idlenessEventsHandler);
+
+    if (this.settings.onShow || this.settings.onHide) {
+      bulkAddEventListener(document, visibilityEvents, this.visibilityEventsHandler);
+    }
+
+    return this;
+  }
+
+  public stop() {
+    bulkRemoveEventListener(window, this.settings.events || [], this.idlenessEventsHandler);
+    this.resetTimeout(false);
+
+    if (this.settings.onShow || this.settings.onHide) {
+      bulkRemoveEventListener(document, visibilityEvents, this.visibilityEventsHandler);
+    }
+
+    return this;
+  }
+
+  public registerAction() {
+    this.idlenessEventsHandler();
+  }
+
+  public reset() {
+    this.idle = !!this.settings.startAtIdle;
+    this.visible = !this.settings.startAtIdle;
+    return this;
+  }
+}


### PR DESCRIPTION
[#173359395]

I've added a new utility called IdleDetector. It's based on the existing library, although it was a bit dead (updated 2-3 years ago) and written in JS. I quickly rewrote it to TS as I was hoping I could support iframes. Finally, it turned out I can't really do it. I've left this copy here, as it's in TS now and I've added some tests that the original version didn't have.

If the user interacts only with iframes, we might trigger the warning about being idle. I can't really see a solution for that. But we don't log out user automatically. He'll still have 5 minutes to get back to the activity. Given that the initial timeout is 20 minutes, I think it's very unlikely to happen. And even if it does, there's still an easy way to continue work.

<img width="1481" alt="Screenshot 2021-01-25 at 13 41 10" src="https://user-images.githubusercontent.com/767857/105719755-f4788d00-5f22-11eb-8d95-e7bac605191e.png">

@scytacki, we discussed that a bit, you might be interested in the final error UI.

If you have some suggestions re wording, I'm happy to update it. It hasn't been designed by Kiley or Michael, I just based it on Michael's generic error UI.
