### PR TITLE
Fix check for plugin content, ensure we check last page

### DIFF
--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -26,7 +26,7 @@ const addUsedPlugin = (plugin: Plugin) => {
 
 export const findUsedPlugins = (activity: Activity, teacherEditionMode: boolean) => {
   // search each page for teacher edition plugin use
-  for (let page = 0; page <= activity.pages.length - 1; page++) {
+  for (let page = 0; page < activity.pages.length; page++) {
     if (!activity.pages[page].is_hidden) {
       for (let embeddableNum = 0; embeddableNum < activity.pages[page].embeddables.length; embeddableNum++) {
         const embeddable = activity.pages[page].embeddables[embeddableNum].embeddable;

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -26,7 +26,7 @@ const addUsedPlugin = (plugin: Plugin) => {
 
 export const findUsedPlugins = (activity: Activity, teacherEditionMode: boolean) => {
   // search each page for teacher edition plugin use
-  for (let page = 0; page < activity.pages.length - 1; page++) {
+  for (let page = 0; page <= activity.pages.length - 1; page++) {
     if (!activity.pages[page].is_hidden) {
       for (let embeddableNum = 0; embeddableNum < activity.pages[page].embeddables.length; embeddableNum++) {
         const embeddable = activity.pages[page].embeddables[embeddableNum].embeddable;


### PR DESCRIPTION
Fix bug that caused us to skip the last activity page when checking for plugin content.  If the plugin content was on the last page ONLY, the plugin would fail to be loaded.