### PR TITLE
Various fixes for offline authoring and usage

### DIFF
--- a/src/launch-list-api.ts
+++ b/src/launch-list-api.ts
@@ -44,7 +44,7 @@ export const cacheLaunchList = (options: cacheLaunchListOptions) => {
   const {launchList, onCachingStarted, onUrlCached, onUrlCacheFailed, onAllUrlsCached, onAllUrlsCacheFailed} = options;
   const urls = launchList.activities.map(a => a.url).concat(launchList.cacheList);
   const loadingPromises = urls.map(url => {
-    return fetch(url)
+    return fetch(url, {mode: "no-cors"})
       .then(() => onUrlCached(url))
       .catch(err => onUrlCacheFailed(url, err));
   });


### PR DESCRIPTION
- Change cache loader to use no-cors mode since we don't need the actual response
- Enable offline mode when in authoring so the service worker starts
- Change to only load launch list saved in localstorage when in offline mode
- Skip the current offline mode rendering when in authoring mode