### PR TITLE
Remove border around image and video interactives

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.scss
+++ b/src/components/activity-page/managed-interactive/managed-interactive.scss
@@ -1,7 +1,10 @@
 @import "../../vars.scss";
 
 .managed-interactive {
-  border: 1px solid $cc-charcoal-light1;
+
+  &.has-question-number {
+    border: 1px solid $cc-charcoal-light1;
+  }
 }
 
 .question-container {

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -192,6 +192,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   // with this fragment if necessary. ActivityPlayer doesn't have knowledge about URL format and provided url_fragment 
   // to perform this merge automatically.
   const iframeUrl = activeDialog?.url || (embeddable.url_fragment ? url + embeddable.url_fragment : url);
+  const miContainerClass = questionNumber ? "managed-interactive has-question-number" : "managed-interactive";
   const interactiveIframeRuntime =
     loading ?
       "Loading..." :
@@ -218,7 +219,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
       />;
 
     return (
-      <div ref={divTarget} className="managed-interactive" data-cy="managed-interactive">
+      <div ref={divTarget} className={miContainerClass} data-cy="managed-interactive">
         { questionNumber &&
           <div className="header">
             Question #{questionNumber}{questionName}


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/176855442

[#176855442]

With these changes, only interactives that save state (and therefore get a question number) will have a border. So in addition to images and videos that don't save state, Model My Watershed models and Lab interactives will also be borderless.