### PR TITLE
Links in text boxes will not open in new tabs.

### DIFF
--- a/src/utilities/render-html.ts
+++ b/src/utilities/render-html.ts
@@ -15,5 +15,5 @@ interface DomElement {
 export type ParseHTMLReplacer = (domNode: DomElement) => JSX.Element | void | undefined | null | false;
 
 export function renderHTML(html: string, replace?: ParseHTMLReplacer) {
-  return parse(DOMPurify.sanitize(html || ""), { replace });
+  return parse(DOMPurify.sanitize(html || "", {ADD_ATTR: ["target"]}), { replace });
 }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177104163

[#177104163]

This change will prevent the `target` attribute from being removed from HTML. This is needed so that links in activities can open in new windows/tabs.