### PR TITLE
Pass the sourceKey and firebase-app to the portal-report from show work button

### DIFF
--- a/cypress/integration/opening-reports.test.ts
+++ b/cypress/integration/opening-reports.test.ts
@@ -37,6 +37,7 @@ context("Test Opening Portal Reports from various places", () => {
         cy.window().its("open").should("be.calledWith",
           portalReportUrl + "?runKey=" + runKey +
             "&activity=" + activityStructureUrl +
+            "&firebase-app=report-service-dev&sourceKey=example.com" +
             "&answersSourceKey=authoring.staging.concord.org");
       });
     });

--- a/src/utilities/report-utils.test.ts
+++ b/src/utilities/report-utils.test.ts
@@ -18,40 +18,93 @@ jest.mock("../firebase-db", () => (
 ));
 
 describe("getReportUrl", () => {
+  const basicParams = "/?activity=https://lara.example.com/api/v1/activities/345.json";
+
   beforeEach(() => {
     clearFirebaseAppName();
   });
+  describe("with a run key", () => {
+    const runKey = "b948ae4f-83e4-4448-a500-b6564bda3a08";
+    const paramsWithRunKey = basicParams + "&runKey=" + runKey;
+    it("returns valid report URL", () => {
+      window.history.replaceState({}, "Test", paramsWithRunKey);
 
-  it("returns a valid reportURL with basic AP params", () => {
-    window.history.replaceState({}, "Test", "/?activity=https://lara.example.com/api/v1/activities/345.json");
+      const reportURL = getReportUrl();
 
-    const reportURL = getReportUrl();
+      expect(reportURL).toEqual(
+        "https://portal-report.concord.org/branch/master/index.html?"
+        + "runKey=" + runKey
+        + "&activity=https://lara.example.com/activities/345"
+        + "&firebase-app=report-service-dev"
+        + "&sourceKey=lara.example.com"
+        + "&answersSourceKey=activity-player.unexisting.url.com"
+      );
+    });
 
-    expect(reportURL).toEqual(
-      "https://portal-report.concord.org/branch/master/index.html?"
-      + "class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
-      + "&firebase-app=report-service-dev"
-      + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
-      + "&reportType=offering"
-      + "&studentId=abc345"
-      + "&sourceKey=lara.example.com"
-      + "&answersSourceKey=activity-player.unexisting.url.com"
-      + "&auth-domain=https://example.com");
+    it("returns valid report URL", () => {
+      window.history.replaceState({}, "Test", paramsWithRunKey);
+
+      const reportURL = getReportUrl();
+
+      expect(reportURL).toEqual(
+        "https://portal-report.concord.org/branch/master/index.html?"
+        + "runKey=" + runKey
+        + "&activity=https://lara.example.com/activities/345"
+        + "&firebase-app=report-service-dev"
+        + "&sourceKey=lara.example.com"
+        + "&answersSourceKey=activity-player.unexisting.url.com"
+      );
+    });
+
+    it("includes the correct firebase-app if it is specified", () => {
+      window.history.replaceState({}, "Test", paramsWithRunKey + "&firebaseApp=report-service-pro");
+
+      const reportURL = getReportUrl();
+
+      expect(reportURL).toEqual(
+        "https://portal-report.concord.org/branch/master/index.html?"
+        + "runKey=" + runKey
+        + "&activity=https://lara.example.com/activities/345"
+        + "&firebase-app=report-service-pro"
+        + "&sourceKey=lara.example.com"
+        + "&answersSourceKey=activity-player.unexisting.url.com"
+      );
+    });
   });
 
-  it("returns a reportURL with the correct firebase-app if the firebaseApp param is used", () => {
-    window.history.replaceState({}, "Test", "/?firebaseApp=report-service-pro&activity=https://lara.example.com/api/v1/activities/345.json");
-    const reportURL = getReportUrl();
+  describe("without a run key" , () => {
 
-    expect(reportURL).toEqual(
-      "https://portal-report.concord.org/branch/master/index.html?"
-      + "class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
-      + "&firebase-app=report-service-pro"
-      + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
-      + "&reportType=offering"
-      + "&studentId=abc345"
-      + "&sourceKey=lara.example.com"
-      + "&answersSourceKey=activity-player.unexisting.url.com"
-      + "&auth-domain=https://example.com");
+    it("returns a valid reportURL", () => {
+      window.history.replaceState({}, "Test", basicParams);
+
+      const reportURL = getReportUrl();
+
+      expect(reportURL).toEqual(
+        "https://portal-report.concord.org/branch/master/index.html?"
+        + "class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
+        + "&firebase-app=report-service-dev"
+        + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
+        + "&reportType=offering"
+        + "&studentId=abc345"
+        + "&sourceKey=lara.example.com"
+        + "&answersSourceKey=activity-player.unexisting.url.com"
+        + "&auth-domain=https://example.com");
+    });
+
+    it("includes correct firebase-app if the firebaseApp param is used", () => {
+      window.history.replaceState({}, "Test", basicParams + "&firebaseApp=report-service-pro");
+      const reportURL = getReportUrl();
+
+      expect(reportURL).toEqual(
+        "https://portal-report.concord.org/branch/master/index.html?"
+        + "class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
+        + "&firebase-app=report-service-pro"
+        + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
+        + "&reportType=offering"
+        + "&studentId=abc345"
+        + "&sourceKey=lara.example.com"
+        + "&answersSourceKey=activity-player.unexisting.url.com"
+        + "&auth-domain=https://example.com");
+    });
   });
 });

--- a/src/utilities/report-utils.ts
+++ b/src/utilities/report-utils.ts
@@ -24,15 +24,21 @@ export const getReportUrl = () => {
   const runKey= queryValue("runKey");
   // Sometimes the location of the answers is overridden with a report-source param
   const answerSource = queryValue("report-source") || window.location.hostname;
+  const sourceKey = activityUrl ? makeSourceKey(activityUrl) : window.location.hostname;
 
   if (runKey) {
-    return reportLink + "?runKey=" + runKey + "&activity=" + activityUrl + "&answersSourceKey="+answerSource;
+    return reportLink
+            + "?"
+            + "runKey=" + runKey
+            + "&activity=" + activityUrl
+            + "&firebase-app="+reportFirebaseApp
+            + "&sourceKey="+sourceKey
+            + "&answersSourceKey="+answerSource;
   }
   else {
     // We know this is a IPortalData because there is no runKey
     const portalData = getPortalData() as IPortalData;
     const classInfoUrl = portalData?.portalJWT?.class_info_url;
-    const sourceKey = activityUrl ? makeSourceKey(activityUrl) : window.location.hostname;
     const authDomainUrl = classInfoUrl?.split("/api")[0];
     const offeringBaseUrl = classInfoUrl?.split("/classes")[0]+"/offerings/";
     const offeringId = portalData?.offering.id;


### PR DESCRIPTION
This was done for logged in users, but it wasn't being done for anonymous users.
This caused a problem when working on production because the firebase-app defaults to the dev database.
The sourcekey passing is helpful just be more explicit so the portal-report doesn't have to guess this value.