### PR TITLE
Fixed flash of "no offline activities found" at startup when loading a manifest

### DIFF
--- a/cypress/integration/offline-manifest.test.ts
+++ b/cypress/integration/offline-manifest.test.ts
@@ -50,7 +50,8 @@ context("Test using offline manifests", () => {
 
       // verify clicking on activity loads it and closes the launcher
       activityPage.getOfflineManifestLoadingDialog({timeout: 0}).should("not.exist");
-      activityPage.getOfflineActivityList().contains("AP Smoke Test").click();
+      activityPage.getOfflineActivityList().contains("AP Smoke Test");
+      activityPage.getOfflineActivityList().click();
       activityPage.getActivityTitle().should("be.visible").and("contain", "AP Smoke Test");
     });
   });

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -102,6 +102,7 @@ export class App extends React.PureComponent<IProps, IState> {
     const offlineManifestAuthoringId = getOfflineManifestAuthoringId();
 
     const offlineManifestId = queryValue("offlineManifest");
+    const loadingOfflineManifest = !!offlineManifestId;
 
     this.state = {
       currentPage: 0,
@@ -115,7 +116,7 @@ export class App extends React.PureComponent<IProps, IState> {
       pluginsLoaded: false,
       errorType: null,
       idle: false,
-      loadingOfflineManifest: false,
+      loadingOfflineManifest,
       offlineMode: (queryValue("offline") === "true") || !!offlineManifestAuthoringId || !!offlineManifestId,
       offlineManifestAuthoringActivities: [],
       offlineManifestAuthoringCacheList: [],
@@ -212,7 +213,7 @@ export class App extends React.PureComponent<IProps, IState> {
 
   async componentDidMount() {
     try {
-      const {offlineManifestId, offlineManifestAuthoringId} = this.state;
+      const {offlineManifestId, offlineManifestAuthoringId, loadingOfflineManifest} = this.state;
 
       let offlineManifestAuthoringData: OfflineManifestAuthoringData | undefined;
       if (offlineManifestAuthoringId) {
@@ -220,7 +221,6 @@ export class App extends React.PureComponent<IProps, IState> {
       }
 
       let offlineManifest: OfflineManifest | undefined = undefined;
-      const loadingOfflineManifest = !!offlineManifestId;
       if (offlineManifestId) {
         offlineManifest = await getOfflineManifest(offlineManifestId);
 


### PR DESCRIPTION
The flag that denotes the manifest is loading has been hoisted into the constructor from the componentDidMount method so that the initial render does not flash an error message about no offline activites found before the manifest starts loading.