### PR TITLE
177118245 update answer fields

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -59,7 +59,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
     }
   }, [embeddableRefId, shouldWatchAnswer]);
 
-    const handleNewInteractiveState = (state: IRuntimeMetadata) => {
+    const handleNewInteractiveState = (state: any) => {
       // Keep interactive state in sync if iFrame is opened in modal popup
       interactiveState.current = state;
 
@@ -187,9 +187,9 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   }));
 
   // embeddable.url_fragment is an optional string (path, query params, hash) that can be defined by author.
-  // Some interactives are authored that way. Note that url_fragment is not merged with the dialog URL. 
-  // Each interactive will be first loaded inline with the url_fragment appended. So it can merge its custom dialog URL 
-  // with this fragment if necessary. ActivityPlayer doesn't have knowledge about URL format and provided url_fragment 
+  // Some interactives are authored that way. Note that url_fragment is not merged with the dialog URL.
+  // Each interactive will be first loaded inline with the url_fragment appended. So it can merge its custom dialog URL
+  // with this fragment if necessary. ActivityPlayer doesn't have knowledge about URL format and provided url_fragment
   // to perform this merge automatically.
   const iframeUrl = activeDialog?.url || (embeddable.url_fragment ? url + embeddable.url_fragment : url);
   const miContainerClass = questionNumber ? "managed-interactive has-question-number" : "managed-interactive";

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -4,7 +4,7 @@ import { IframeRuntime, IframeRuntimeImperativeAPI } from "./iframe-runtime";
 import useResizeObserver from "@react-hook/resize-observer";
 import {
   ICloseModal, INavigationOptions,
-  ICustomMessage, IRuntimeMetadata, IShowDialog, IShowLightbox, IShowModal, ISupportedFeatures
+  ICustomMessage, IShowDialog, IShowLightbox, IShowModal, ISupportedFeatures
 } from "@concord-consortium/lara-interactive-api";
 import { PortalDataContext } from "../../portal-data-context";
 import { IManagedInteractive, IMwInteractive, LibraryInteractiveData, IExportableAnswerMetadata } from "../../../types";

--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -88,7 +88,7 @@ describe("Firestore", () => {
       resourceUrl: "http://example/resource",
       toolId: "activity-player.concord.org",
       userType: "learner",
-      runRemoteEndpoint: ""
+      runRemoteEndpoint: "https://portal.com/learner/1234"
     });
 
     const embeddable = {
@@ -108,6 +108,7 @@ describe("Firestore", () => {
 
     expect(appMock.firestore().doc).toHaveBeenCalledWith(`sources/localhost/answers/${exportableAnswer.id}`);
     expect(appMock.firestore().doc().set).toHaveBeenCalledWith({
+      version:1,
       answer: "test",
       answer_text: "test",
       context_id: "context-id",
@@ -116,7 +117,7 @@ describe("Firestore", () => {
       platform_user_id: "1",
       question_id: "managed_interactive_123",
       question_type: "open_response",
-      remote_endpoint: "",
+      remote_endpoint: "https://portal.com/learner/1234",
       report_state: "{\"mode\":\"report\",\"authoredState\":\"{\\\"version\\\":1,\\\"questionType\\\":\\\"open_response\\\",\\\"prompt\\\":\\\"<p>Write something:</p>\\\"}\",\"interactiveState\":\"{\\\"answerType\\\":\\\"open_response_answer\\\",\\\"answerText\\\":\\\"test\\\"}\",\"version\":1}",
       resource_link_id: "2",
       resource_url: "http://example/resource",
@@ -139,7 +140,7 @@ describe("Firestore", () => {
       toolId: "activity-player.concord.org",
       toolUserId: "anonymous",
       userType: "learner",
-      runKey: ""
+      runKey: "fake-run-key"
     });
 
     const embeddable = {
@@ -159,16 +160,16 @@ describe("Firestore", () => {
 
     expect(appMock.firestore().doc).toHaveBeenCalledWith(`sources/localhost/answers/${exportableAnswer.id}`);
     expect(appMock.firestore().doc().set).toHaveBeenCalledWith({
+      version: 1,
       answer: "anonymous test",
       answer_text: "anonymous test",
       id: exportableAnswer.id,
-      platform_user_id: "",
+      platform_user_id: "fake-run-key",
       question_id: "managed_interactive_123",
       question_type: "open_response",
-      remote_endpoint: "",
       report_state: "{\"mode\":\"report\",\"authoredState\":\"{\\\"version\\\":1,\\\"questionType\\\":\\\"open_response\\\",\\\"prompt\\\":\\\"<p>Write something:</p>\\\"}\",\"interactiveState\":\"{\\\"answerType\\\":\\\"open_response_answer\\\",\\\"answerText\\\":\\\"anonymous test\\\"}\",\"version\":1}",
       resource_url: "http://example/resource",
-      run_key: "",
+      run_key: "fake-run-key",
       source_key: "localhost",
       submitted: null,
       tool_id: "activity-player.concord.org",

--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -88,7 +88,7 @@ describe("Firestore", () => {
       resourceUrl: "http://example/resource",
       toolId: "activity-player.concord.org",
       userType: "learner",
-      runRemoteEndpoint: "https://portal.com/learner/1234"
+      runRemoteEndpoint: "https://example.com/learner/1234"
     });
 
     const embeddable = {
@@ -117,7 +117,7 @@ describe("Firestore", () => {
       platform_user_id: "1",
       question_id: "managed_interactive_123",
       question_type: "open_response",
-      remote_endpoint: "https://portal.com/learner/1234",
+      remote_endpoint: "https://example.com/learner/1234",
       report_state: "{\"mode\":\"report\",\"authoredState\":\"{\\\"version\\\":1,\\\"questionType\\\":\\\"open_response\\\",\\\"prompt\\\":\\\"<p>Write something:</p>\\\"}\",\"interactiveState\":\"{\\\"answerType\\\":\\\"open_response_answer\\\",\\\"answerText\\\":\\\"test\\\"}\",\"version\":1}",
       resource_link_id: "2",
       resource_url: "http://example/resource",

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -228,32 +228,38 @@ export function createOrUpdateAnswer(answer: IExportableAnswerMetadata) {
 
   let answerDocData: LTIRuntimeAnswerMetadata | AnonymousRuntimeAnswerMetadata;
 
+  const commonFields = {
+    source_key: portalData.database.sourceKey,
+    resource_url: portalData.resourceUrl,
+    tool_id: portalData.toolId
+  };
+
   if (portalData.type === "authenticated") {
     const ltiAnswer: LTIRuntimeAnswerMetadata = {
       ...answer,
+      ...commonFields,
       platform_id: portalData.platformId,
       platform_user_id: portalData.platformUserId.toString(),
       context_id: portalData.contextId,
       resource_link_id: portalData.resourceLinkId,
-      source_key: portalData.database.sourceKey,
-      tool_id: portalData.toolId,
-      resource_url: portalData.resourceUrl,
       run_key: "",
+      remote_endpoint: portalData.runRemoteEndpoint
     };
     answerDocData = ltiAnswer;
   } else {
     const anonymousAnswer: AnonymousRuntimeAnswerMetadata = {
       ...answer,
+      ...commonFields,
       run_key: portalData.runKey,
-      source_key: portalData.database.sourceKey,
-      resource_url: portalData.resourceUrl,
-      tool_id: portalData.toolId,
       tool_user_id: "anonymous",
       platform_user_id: portalData.runKey
     };
     answerDocData = anonymousAnswer;
   }
 
+  // TODO: LARA stores a created field with the date the answer was created
+  // I'm not sure how to do that easily in Firestore, we could at least add
+  // an updatedAt time using Firestore's features.
   const firestoreSetPromise = app.firestore()
     .doc(answersPath(answer.id))
     .set(answerDocData as Partial<firebase.firestore.DocumentData>, {merge: true});
@@ -329,6 +335,7 @@ export const setLearnerPluginState = async (pluginId: number, state: string): Pr
       tool_id: portalData.toolId,
       resource_url: portalData.resourceUrl,
       run_key: "",
+      remote_endpoint: portalData.runRemoteEndpoint,
       pluginId,
       state
       };

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -228,16 +228,12 @@ export function createOrUpdateAnswer(answer: IExportableAnswerMetadata) {
 
   let answerDocData: LTIRuntimeAnswerMetadata | AnonymousRuntimeAnswerMetadata;
 
-  const commonFields = {
-    source_key: portalData.database.sourceKey,
-    resource_url: portalData.resourceUrl,
-    tool_id: portalData.toolId
-  };
-
   if (portalData.type === "authenticated") {
     const ltiAnswer: LTIRuntimeAnswerMetadata = {
       ...answer,
-      ...commonFields,
+      source_key: portalData.database.sourceKey,
+      resource_url: portalData.resourceUrl,
+      tool_id: portalData.toolId,
       platform_id: portalData.platformId,
       platform_user_id: portalData.platformUserId.toString(),
       context_id: portalData.contextId,
@@ -249,7 +245,9 @@ export function createOrUpdateAnswer(answer: IExportableAnswerMetadata) {
   } else {
     const anonymousAnswer: AnonymousRuntimeAnswerMetadata = {
       ...answer,
-      ...commonFields,
+      source_key: portalData.database.sourceKey,
+      resource_url: portalData.resourceUrl,
+      tool_id: portalData.toolId,
       run_key: portalData.runKey,
       tool_user_id: "anonymous",
       platform_user_id: portalData.runKey

--- a/src/lara-api.ts
+++ b/src/lara-api.ts
@@ -1,5 +1,18 @@
 import { sampleActivities, sampleSequences } from "./data";
 import { Activity, Sequence } from "./types";
+import { queryValue } from "./utilities/url-query";
+
+export const getResourceUrl = () => {
+  const sequenceUrl = queryValue("sequence");
+  const activityUrl = queryValue("activity");
+
+  const resourceUrl = sequenceUrl ? sequenceUrl : activityUrl;
+  if (!resourceUrl) {
+    return "";
+  }
+
+  return ((resourceUrl.split(".json"))[0]).replace("api/v1/","");
+}
 
 export const getActivityDefinition = (activity: string): Promise<Activity> => {
   return new Promise((resolve, reject) => {

--- a/src/lara-api.ts
+++ b/src/lara-api.ts
@@ -11,8 +11,8 @@ export const getResourceUrl = () => {
     return "";
   }
 
-  return ((resourceUrl.split(".json"))[0]).replace("api/v1/","");
-}
+  return resourceUrl.split(".json")[0].replace("api/v1/","");
+};
 
 export const getActivityDefinition = (activity: string): Promise<Activity> => {
   return new Promise((resolve, reject) => {

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -3,6 +3,7 @@ import superagent from "superagent";
 import { v4 as uuidv4 } from "uuid";
 import { queryValue, setQueryValue } from "./utilities/url-query";
 import { FirebaseAppName } from "./firebase-db";
+import { getResourceUrl } from "./lara-api";
 
 interface PortalClassOffering {
   className: string;
@@ -431,7 +432,7 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
     platformUserId: firebaseJWT.claims.platform_user_id.toString(),
     contextId: classInfo.classHash,
     toolId,
-    resourceUrl: offeringData.activityUrl,
+    resourceUrl: getResourceUrl(),
     fullName,
     learnerKey: firebaseJWT.claims.user_type === "learner"
                   ? getStudentLearnerKey(portalJWT, firebaseJWT)
@@ -465,14 +466,11 @@ export const anonymousPortalData = (preview: boolean) => {
 
   const hostname = window.location.hostname;
   const toolId = hostname + window.location.pathname;
-  // just save the host and loaded activity-url as the resourceUrl, omitting any other url parameters.
-  // This is currently unused for the purpose of saving and loading data
-  const resourceUrl = hostname + "?activity=" + queryValue("activity");
   const rawPortalData: IAnonymousPortalData = {
     type: "anonymous",
     userType: "learner",
     runKey,
-    resourceUrl,
+    resourceUrl: getResourceUrl(),
     toolId,
     toolUserId: "anonymous",
     database: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,8 @@ export interface ILTIPartial {
   run_key: string;
   source_key: string;
   tool_id: string;
+   // This is not an LTI property but it is required in our authenticated answers
+  remote_endpoint: string;
 }
 
 export interface IAnonymousMetadataPartial {
@@ -208,7 +210,6 @@ export interface IAnonymousMetadataPartial {
  * https://github.com/concord-consortium/lara/blob/c40304a14ef495acdf4f9fd09ea892c7cc98247b/app/models/interactive_run_state.rb#L110
  */
 export interface IExportableAnswerMetadataBase {
-  remote_endpoint: string;
   question_id: string;
   question_type: string;
   id: string;

--- a/src/utilities/embeddable-utils.test.ts
+++ b/src/utilities/embeddable-utils.test.ts
@@ -196,6 +196,43 @@ describe("Embeddable utility functions", () => {
     testGenericInteractive(null);
   });
 
+  it("can create an exportable answer for a generic interactive embeddable with authored state", () => {
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: `{"myConfiguration": "something"}`,
+      ref_id: "123-ManagedInteractive"
+    };
+
+    const interactiveState = {
+      myState: "<state />"
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableInteractiveAnswerMetadata;
+
+    expect(exportableAnswer.id).toBeDefined();          // random uuid
+    // overwrite this id so we can do a full equals test below without a random value
+    exportableAnswer.id = "overwritten-answer-id";
+
+    const expectedReport = JSON.stringify({
+      mode: "report",
+      authoredState: `{"myConfiguration": "something"}`,
+      interactiveState: `{"myState":"<state />"}`,
+      version: 1
+    });
+
+    expect(exportableAnswer).toEqual({
+      version: 1,
+      id: "overwritten-answer-id",
+      type: "interactive_state",
+      question_id: "managed_interactive_123",
+      question_type: "iframe_interactive",
+      answer_text: undefined,
+      report_state: expectedReport,
+      answer: expectedReport,
+      submitted: null
+    });
+  });
+
   it("can create an exportable answer for a generic interactive embeddable with a custom question type", () => {
     const embeddable: IManagedInteractive = {
       ...DefaultManagedInteractive,

--- a/src/utilities/embeddable-utils.test.ts
+++ b/src/utilities/embeddable-utils.test.ts
@@ -184,6 +184,14 @@ describe("Embeddable utility functions", () => {
     testGenericInteractive(false);
   });
 
+  it("can create an exportable answer for a generic interactive that saves 0 for its state", () => {
+    testGenericInteractive(0);
+  });
+
+  it("can create an exportable answer for a generic interactive that saves a number for its state", () => {
+    testGenericInteractive(1.876);
+  });
+
   it("can create an exportable answer for a generic interactive that saves null for its state", () => {
     testGenericInteractive(null);
   });

--- a/src/utilities/embeddable-utils.test.ts
+++ b/src/utilities/embeddable-utils.test.ts
@@ -36,23 +36,26 @@ describe("Embeddable utility functions", () => {
 
     const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableOpenResponseAnswerMetadata;
 
-    expect(exportableAnswer).toBeDefined();
-
-    expect(exportableAnswer.remote_endpoint).toBe("");
-    expect(exportableAnswer.question_id).toBe("managed_interactive_123");
-    expect(exportableAnswer.question_type).toBe("open_response");
     expect(exportableAnswer.id).toBeDefined();          // random uuid
-    expect(exportableAnswer.type).toBe("open_response_answer");
-    expect(exportableAnswer.answer_text).toBe("test");
-    expect(exportableAnswer.answer).toBe("test");
-    expect(exportableAnswer.submitted).toBeNull();
-    const expectedReport = JSON.stringify({
-      mode: "report",
-      authoredState: `{"version":1,"questionType":"open_response","prompt":"<p>Write something:</p>"}`,
-      interactiveState: `{"answerType":"open_response_answer","answerText":"test"}`,
-      version: 1
+    // overwrite this id so we can do a full equals test below without a random value
+    exportableAnswer.id = "overwritten-answer-id";
+
+    expect(exportableAnswer).toEqual({
+      version: 1,
+      id: "overwritten-answer-id",
+      type: "open_response_answer",
+      question_id: "managed_interactive_123",
+      question_type: "open_response",
+      answer_text: "test",
+      answer: "test",
+      submitted: null,
+      report_state: JSON.stringify({
+        mode: "report",
+        authoredState: `{"version":1,"questionType":"open_response","prompt":"<p>Write something:</p>"}`,
+        interactiveState: `{"answerType":"open_response_answer","answerText":"test"}`,
+        version: 1
+      })
     });
-    expect(exportableAnswer.report_state).toBe(expectedReport);
   });
 
   it("can create an exportable answer for an image question embeddable", () => {
@@ -70,62 +73,37 @@ describe("Embeddable utility functions", () => {
 
     const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableImageQuestionAnswerMetadata;
 
-    expect(exportableAnswer).toBeDefined();
-
-    expect(exportableAnswer.remote_endpoint).toBe("");
-    expect(exportableAnswer.question_id).toBe("managed_interactive_123");
-    expect(exportableAnswer.question_type).toBe("image_question");
     expect(exportableAnswer.id).toBeDefined();          // random uuid
-    expect(exportableAnswer.type).toBe("image_question_answer");
-    expect(exportableAnswer.answer_text).toBe("test");
-    expect(exportableAnswer.answer).toEqual({
-      text: "test",
-      image_url: "http://test.snapshot.com"
-    });
-    expect(exportableAnswer.submitted).toBeNull();
-    const expectedReport = JSON.stringify({
-      mode: "report",
-      authoredState: `{"version":1,"questionType":"image_question","prompt":"<p>Write something:</p>"}`,
-      interactiveState: `{"answerType":"image_question_answer","answerText":"test","answerImageUrl":"http://test.snapshot.com"}`,
-      version: 1
-    });
-    expect(exportableAnswer.report_state).toBe(expectedReport);
-  });
+    // overwrite this id so we can do a full equals test below without a random value
+    exportableAnswer.id = "overwritten-answer-id";
 
-  it("can create an exportable answer for a generic interactive embeddable", () => {
-    const embeddable: IManagedInteractive = {
-      ...DefaultManagedInteractive,
-      authored_state: `{"version":1,"questionType":"my_question_type"}`
-    };
-
-    interface IInteractiveState extends IRuntimeInteractiveMetadata {
-      myState: string;
-    }
-    const interactiveState: IInteractiveState = {
-      answerType: "interactive_state",
-      myState: "<state />"
-    };
-
-    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableInteractiveAnswerMetadata;
-
-    expect(exportableAnswer.question_type).toBe("my_question_type");
-    expect(exportableAnswer.type).toBe("interactive_state");
-    expect(exportableAnswer.answer_text).toBeUndefined();
-    const expectedReport = JSON.stringify({
-      mode: "report",
-      authoredState: `{"version":1,"questionType":"my_question_type"}`,
-      interactiveState: `{"answerType":"interactive_state","myState":"<state />"}`,
-      version: 1
-    });
-    expect(exportableAnswer.report_state).toBe(expectedReport);
-    expect(exportableAnswer.answer).toBe(expectedReport);
+    expect(exportableAnswer).toEqual({
+      version: 1,
+      id: "overwritten-answer-id",
+      type: "image_question_answer",
+      question_id: "managed_interactive_123",
+      question_type: "image_question",
+      answer_text: "test",
+      answer: {
+        text: "test",
+        image_url: "http://test.snapshot.com"
+      },
+      submitted: null,
+      report_state: JSON.stringify({
+        mode: "report",
+        authoredState: `{"version":1,"questionType":"image_question","prompt":"<p>Write something:</p>"}`,
+        interactiveState: `{"answerType":"image_question_answer","answerText":"test","answerImageUrl":"http://test.snapshot.com"}`,
+        version: 1
+      })
+    })
   });
 
   it("can create an exportable answer for a submittable multiple choice embeddable", () => {
     const authoredState = `{"version":1,"questionType":"multiple_choice","choices":[{"id":"1","content":"A","correct":false},{"id":"2","content":"B","correct":false}],"prompt":""}`;
     const embeddable: IManagedInteractive = {
       ...DefaultManagedInteractive,
-      authored_state: authoredState
+      authored_state: authoredState,
+      ref_id: "123-ManagedInteractive"
     };
 
     const interactiveState: IRuntimeMultipleChoiceMetadata = {
@@ -135,17 +113,120 @@ describe("Embeddable utility functions", () => {
 
     const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableInteractiveAnswerMetadata;
 
-    expect(exportableAnswer.question_type).toBe("multiple_choice");
-    expect(exportableAnswer.type).toBe("multiple_choice_answer");
-    expect(exportableAnswer.answer_text).toBeUndefined();
+    expect(exportableAnswer.id).toBeDefined();          // random uuid
+    // overwrite this id so we can do a full equals test below without a random value
+    exportableAnswer.id = "overwritten-answer-id";
+
+    expect(exportableAnswer).toEqual({
+      version: 1,
+      id: "overwritten-answer-id",
+      type: "multiple_choice_answer",
+      question_id: "managed_interactive_123",
+      question_type: "multiple_choice",
+      answer_text: undefined,
+      report_state: JSON.stringify({
+        mode: "report",
+        authoredState,
+        interactiveState: `{"answerType":"multiple_choice_answer","selectedChoiceIds":["1"]}`,
+        version: 1
+      }),
+      answer: {"choice_ids": ["1"]},
+      submitted: null
+    });
+  });
+
+  const testGenericInteractive = (interactiveState: any) => {
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: "",
+      ref_id: "123-ManagedInteractive"
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableInteractiveAnswerMetadata;
+
+    expect(exportableAnswer.id).toBeDefined();          // random uuid
+    // overwrite this id so we can do a full equals test below without a random value
+    exportableAnswer.id = "overwritten-answer-id";
+
     const expectedReport = JSON.stringify({
       mode: "report",
-      authoredState,
-      interactiveState: `{"answerType":"multiple_choice_answer","selectedChoiceIds":["1"]}`,
+      authoredState: "",
+      interactiveState: JSON.stringify(interactiveState),
       version: 1
     });
-    expect(exportableAnswer.report_state).toBe(expectedReport);
-    expect(exportableAnswer.answer).toStrictEqual({"choice_ids": ["1"]});
+
+    expect(exportableAnswer).toEqual({
+      version: 1,
+      id: "overwritten-answer-id",
+      type: "interactive_state",
+      question_id: "managed_interactive_123",
+      question_type: "iframe_interactive",
+      answer_text: undefined,
+      report_state: expectedReport,
+      answer: expectedReport,
+      submitted: null
+    });
+  };
+
+  it("can create an exportable answer for a generic interactive without authored state and no meta data", () => {
+    testGenericInteractive({myState: "<state />"});
+  });
+
+  it("can create an exportable answer for a generic interactive that uses a string for its state", () => {
+    testGenericInteractive("<state />");
+  });
+
+  it("can create an exportable answer for a generic interactive that saves '' for its state", () => {
+    testGenericInteractive("");
+  });
+
+  it("can create an exportable answer for a generic interactive that saves false for its state", () => {
+    testGenericInteractive(false);
+  });
+
+  it("can create an exportable answer for a generic interactive that saves null for its state", () => {
+    testGenericInteractive(null);
+  });
+
+  it("can create an exportable answer for a generic interactive embeddable with a custom question type", () => {
+    const embeddable: IManagedInteractive = {
+      ...DefaultManagedInteractive,
+      authored_state: `{"version":1,"questionType":"my_question_type"}`,
+      ref_id: "123-ManagedInteractive"
+    };
+
+    interface IInteractiveState extends IRuntimeInteractiveMetadata {
+      myState: string;
+    }
+    const interactiveState = {
+      answerType: "my_question_type_answer",
+      myState: "<state />"
+    };
+
+    const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableInteractiveAnswerMetadata;
+
+    expect(exportableAnswer.id).toBeDefined();          // random uuid
+    // overwrite this id so we can do a full equals test below without a random value
+    exportableAnswer.id = "overwritten-answer-id";
+
+    const expectedReport = JSON.stringify({
+      mode: "report",
+      authoredState: `{"version":1,"questionType":"my_question_type"}`,
+      interactiveState: `{"answerType":"my_question_type_answer","myState":"<state />"}`,
+      version: 1
+    });
+
+    expect(exportableAnswer).toEqual({
+      version: 1,
+      id: "overwritten-answer-id",
+      type: "my_question_type_answer",
+      question_id: "managed_interactive_123",
+      question_type: "my_question_type",
+      answer_text: undefined,
+      report_state: expectedReport,
+      answer: expectedReport,
+      submitted: null
+    });
   });
 
   it("can create an exportable answer, keeping the id of an existing answer meta", () => {
@@ -161,11 +242,10 @@ describe("Embeddable utility functions", () => {
     };
 
     const originalAnswer: IExportableAnswerMetadata = {
+      id: "open_response_answer_123",
       type: "open_response_answer",
-      remote_endpoint: "",
       question_id: "managed_interactive_123",
       question_type: "open_response",
-      id: "open_response_answer_123",
       submitted: null,
       report_state: "",
       answer: ""
@@ -189,11 +269,10 @@ describe("Embeddable utility functions", () => {
     };
 
     const originalAnswer: IExportableAnswerMetadata = {
+      id: "open_response_answer_123",
       type: "open_response_answer",
-      remote_endpoint: "",
       question_id: "managed_interactive_123",
       question_type: "open_response",
-      id: "open_response_answer_123",
       submitted: null,
       report_state: "",
       answer: ""

--- a/src/utilities/embeddable-utils.test.ts
+++ b/src/utilities/embeddable-utils.test.ts
@@ -1,4 +1,4 @@
-import { IRuntimeMetadata, IRuntimeInteractiveMetadata, IRuntimeMultipleChoiceMetadata } from "@concord-consortium/lara-interactive-api";
+import { IRuntimeMetadata, IRuntimeMultipleChoiceMetadata } from "@concord-consortium/lara-interactive-api";
 import { answersQuestionIdToRefId, refIdToAnswersQuestionId, getAnswerWithMetadata } from "./embeddable-utils";
 import { DefaultManagedInteractive } from "../test-utils/model-for-tests";
 import {
@@ -95,7 +95,7 @@ describe("Embeddable utility functions", () => {
         interactiveState: `{"answerType":"image_question_answer","answerText":"test","answerImageUrl":"http://test.snapshot.com"}`,
         version: 1
       })
-    })
+    });
   });
 
   it("can create an exportable answer for a submittable multiple choice embeddable", () => {
@@ -195,9 +195,6 @@ describe("Embeddable utility functions", () => {
       ref_id: "123-ManagedInteractive"
     };
 
-    interface IInteractiveState extends IRuntimeInteractiveMetadata {
-      myState: string;
-    }
     const interactiveState = {
       answerType: "my_question_type_answer",
       myState: "<state />"

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -21,7 +21,7 @@ export const questionType = (rawAuthoredState: string | null | undefined): strin
   }
 
   // There is a IAuthoringMetadata type, but because we don't know if this has
-  // valid authored state or not, that type isn't not used here.
+  // valid authored state or not, that type isn't used here.
   let authoredState: any = {};
   try {
     authoredState = JSON.parse(rawAuthoredState);

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -1,5 +1,4 @@
 import { v4 as uuidv4 } from "uuid";
-import { IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
 import {
   IExportableAnswerMetadata, IManagedInteractive, IReportState, IExportableMultipleChoiceAnswerMetadata,
   IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata, IExportableImageQuestionAnswerMetadata,

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -36,20 +36,6 @@ export const questionType = (rawAuthoredState: string | null | undefined): strin
   return authoredState.questionType as string;
 };
 
-export const remoteEndpoint = (): string => {
-  const portalData = getPortalData();
-  if (!portalData) {
-    return "";
-  }
-
-  // This is a way to verify the portalData is of type IPortalData
-  if (portalData.type === "authenticated") {
-    return portalData.runRemoteEndpoint;
-  }
-
-  return "";
-};
-
 export const getAnswerWithMetadata = (
     interactiveState: unknown,
     embeddable: IManagedInteractive,

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -5,7 +5,6 @@ import {
   IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata, IExportableImageQuestionAnswerMetadata,
   Embeddable
 } from "../types";
-import { getPortalData } from "../firebase-db";
 
 export const isQuestion = (embeddable: Embeddable) =>
   (embeddable.type === "ManagedInteractive" && embeddable.library_interactive?.data?.enable_learner_state) ||

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -5,6 +5,7 @@ import { LaraGlobalType } from "../lara-plugin";
 import { IEmbeddableContextOptions, IPluginRuntimeContextOptions } from "../lara-plugin/plugins/plugin-context";
 import { Activity, Embeddable, IEmbeddablePlugin, Plugin } from "../types";
 import { queryValue } from "./url-query";
+import { getResourceUrl } from "../lara-api";
 
 export interface UsedPluginInfo {
   id: number;
@@ -119,7 +120,6 @@ export const initializePlugin = (context: IEmbeddablePluginContext) => {
 
   const pluginId = usedPlugin.id;
   const portalData = getPortalData();
-  const activity = queryValue("activity");
   const pluginLabel = `plugin${pluginId}`;
   const pluginContext: IPluginRuntimeContextOptions = {
     type: "runtime",
@@ -138,7 +138,7 @@ export const initializePlugin = (context: IEmbeddablePluginContext) => {
     classInfoUrl: null,
     firebaseJwtUrl: "",
     wrappedEmbeddable: wrappedEmbeddable ? embeddableContextAny : null,
-    resourceUrl: activity? ((activity.split(".json"))[0]).replace("api/v1/","") : ""
+    resourceUrl: getResourceUrl()
   };
   LARA.Plugins.initPlugin(pluginLabel, pluginContext);
 };

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -4,7 +4,6 @@ import { getCachedLearnerPluginState, getLearnerPluginState, getPortalData } fro
 import { LaraGlobalType } from "../lara-plugin";
 import { IEmbeddableContextOptions, IPluginRuntimeContextOptions } from "../lara-plugin/plugins/plugin-context";
 import { Activity, Embeddable, IEmbeddablePlugin, Plugin } from "../types";
-import { queryValue } from "./url-query";
 import { getResourceUrl } from "../lara-api";
 
 export interface UsedPluginInfo {


### PR DESCRIPTION
This fixes the handling of generic interactives that don't have an authored state and or don't specify their type of answer or question. Interactives like that make up the majority of our interactives.

It also handles basic string, null, boolean, and numeric interactiveState

It adds the remote_endpoint to the answer documents. LARA runtime adds this, but the AP was not. This isn't needed to restore data in the AP, or to show it in the portal-report. But it will be needed for efficient searching in the new Athena Reports. 

It improves the tests so we can see the shape of the answer documents better and be notified when new properties are added or properties are removed.

It fixes the resource_url (called resourceUrl in the code) saved in the answer documents. Previously it was a special AP url form which wouldn't match the url in the resource (aka report-structure) stored in the report-service. So if a researcher wanted to search for all answers from a particular activity across offerings they'd have problems with this mis-match AP url form.

It also adds a lot of comments around the conversion of the interactiveState to the answer document.

TODO:
- [x] add test for numeric state
- [x] test coverage
- [x] typing in embeddable-utils.ts