### PR TITLE
update deployment section in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage-jest
 .yalc
 yalc.lock
 LocalhostCertificates
+CHANGES.md
 
 # Editors
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-### Asset Sizes
-
-| File | Size | % Increase from Previous Release |
-|---|---|---|
-| index.css | x bytes | n/a |
-| index.js | y bytes | n/a |
-

--- a/CHANGES-template.md
+++ b/CHANGES-template.md
@@ -1,0 +1,14 @@
+Version MAJOR.MINOR.PATCH - released MONTHNAME DAY, YEAR
+
+### Bug Fixes
+- Story name [_id_](https://www.pivotaltracker.com/story/show/_id_)
+
+### Features/Improvements
+- Story name [_id_](https://www.pivotaltracker.com/story/show/_id_)
+
+### Asset Size
+
+| File | Size | % Increase from Previous Release |
+|---|---|---|
+| index.css | xyz bytes | xyz% |
+| index.js | xyz bytes | xyz% |

--- a/CHANGES-template.md
+++ b/CHANGES-template.md
@@ -1,14 +1,14 @@
 Version MAJOR.MINOR.PATCH - released MONTHNAME DAY, YEAR
 
-### Bug Fixes
+### Features/Improvements
 - Story name [_id_](https://www.pivotaltracker.com/story/show/_id_)
 
-### Features/Improvements
+### Bug Fixes
 - Story name [_id_](https://www.pivotaltracker.com/story/show/_id_)
 
 ### Asset Size
 
-| File | Size | % Increase from Previous Release |
+| File | Size | % Change from Previous Release |
 |---|---|---|
 | index.css | xyz bytes | xyz% |
 | index.js | xyz bytes | xyz% |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To deploy a production release:
     1. Run `npm run build`
     2. Look at file sizes with `ls dist/assets`
     3. Add file sizes to CHANGES.md
-    4. Look at previous version file sizes from previous version in GitHub and compute the percent change `(prev - new)/prev`
+    4. Look at previous version file sizes from previous version in GitHub and compute the percent change `(new - prev) / prev * 100`
 3. Update package, commit, and tag
     - **Mac or Linux**:
         - Run `npm version -m "$(< CHANGES.md)" [new-version-string]`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Testing this is complicated. Here is one approach:
 
 Production releases to S3 are based on the contents of the /dist folder and are built automatically by GitHub Actions for each branch pushed to GitHub and each merge into production.
 
-The production branch is deployed to https://activity-player.concord.org/
+The production branch is deployed to https://activity-player.concord.org/.
 
 Other branches are deployed to https://activity-player.concord.org/branch/<name>.
 
@@ -56,6 +56,7 @@ To deploy a production release:
 1. Copy CHANGES-template.md to CHANGES.md, and add a list of PT stories related to the release into temporary CHANGES.md
     - Run `git log --reverse <last release tag>...HEAD | grep '#'` to see a list of PR merges and stories that include PT ids in their message
     - In a PT workspace that includes Orange and Teal boards, search for the `label:"activity-player-<new version>" includedone:true`. You can select all, and export as CSV. Then copy the id and title columns.
+    - Review recently merged PRs in GitHub UI
 2. Compute asset sizes.
     1. Run `npm run build`
     2. Look at file sizes with `ls dist/assets`
@@ -69,10 +70,9 @@ To deploy a production release:
         - git-bash: same as above
         - PowerShell: `npm version -m "(type CHANGES.md)" [new-version-string]` might work, I haven't tried it though.
         - Do the steps manually and use a git client so you can paste in the multi line message
-            1. update package.json with the new version
-            2. run `npm install` to update package-lock.json
-            3. create a new commit with the CHANGES.md message
-            4. create a tag `v[new-version-string]` with the CHANGES.md message
+            1. `npm version --no-git-tag-version [new-version-string]` (updates package.json and package-lock.json with the new version)
+            2. create a new commit with the CHANGES.md message
+            3. create a tag `v[new-version-string]` with the CHANGES.md message
 4. Push current branch and tag to GitHub
 5. Create a GitHub Release
     1. Find the new tag at https://github.com/concord-consortium/activity-player/tags open it, and edit it
@@ -80,7 +80,7 @@ To deploy a production release:
     3. Copy the content from CHANGES.md
 6. QA the built version at `https://activity-player.concord.org/versions/v[new-version-string]``
 7. Checkout production
-8. Run `git reset --hard [version]`
+8. Run `git reset --hard v[new-version-string]`
 9. Push production to GitHub
 10. Delete CHANGES.md to clean up your working directory
 

--- a/README.md
+++ b/README.md
@@ -47,23 +47,42 @@ Testing this is complicated. Here is one approach:
 
 Production releases to S3 are based on the contents of the /dist folder and are built automatically by GitHub Actions for each branch pushed to GitHub and each merge into production.
 
-Merges into production are deployed to https://activity-player.concord.org/ (NOTE: production branch has not yet been created and deployment still needs to be configured).
+The production branch is deployed to https://activity-player.concord.org/
 
 Other branches are deployed to https://activity-player.concord.org/branch/<name>.
 
 To deploy a production release:
 
-1. Increment version number in package.json
-2. Create new entry in CHANGELOG.md
-3. Run `git log --pretty=oneline --reverse <last release tag>...HEAD | grep '#' | grep -v Merge` and add contents (after edits if needed to CHANGELOG.md)
-4. Run `npm run build`
-5. Copy asset size markdown table from previous release and change sizes to match new sizes in `dist`
-6. Create `release-<version>` branch and commit changes, push to GitHub, create PR and merge
-7. Checkout master and pull
-8. Checkout production
-9. Run `git merge master --no-ff`
-10. Push production to GitHub
-11. Use https://github.com/concord-consortium/activity-player/releases to create a new release tag
+1. Copy CHANGES-template.md to CHANGES.md, and add a list of PT stories related to the release into temporary CHANGES.md
+    - Run `git log --reverse <last release tag>...HEAD | grep '#'` to see a list of PR merges and stories that include PT ids in their message
+    - In a PT workspace that includes Orange and Teal boards, search for the `label:"activity-player-<new version>" includedone:true`. You can select all, and export as CSV. Then copy the id and title columns.
+2. Compute asset sizes.
+    1. Run `npm run build`
+    2. Look at file sizes with `ls dist/assets`
+    3. Add file sizes to CHANGES.md
+    4. Look at previous version file sizes from previous version in GitHub and compute the percent change `(prev - new)/prev`
+3. Update package, commit, and tag
+    - **Mac or Linux**:
+        - Run `npm version -m "$(< CHANGES.md)" [new-version-string]`
+        - This updates the version in package.json and package-lock.json and creates a commit with the comment from CHANGES.md, and creates a tag with the name `v[new-version-string]` that has a description based on CHANGES.md.
+    - **Windows**: the command above that injects `CHANGES.md` as the message won't work in the standard windows command application.
+        - git-bash: same as above
+        - PowerShell: `npm version -m "(type CHANGES.md)" [new-version-string]` might work, I haven't tried it though.
+        - Do the steps manually and use a git client so you can paste in the multi line message
+            1. update package.json with the new version
+            2. run `npm install` to update package-lock.json
+            3. create a new commit with the CHANGES.md message
+            4. create a tag `v[new-version-string]` with the CHANGES.md message
+4. Push current branch and tag to GitHub
+5. Create a GitHub Release
+    1. Find the new tag at https://github.com/concord-consortium/activity-player/tags open it, and edit it
+    2. Copy the title from CHANGES.md
+    3. Copy the content from CHANGES.md
+6. QA the built version at `https://activity-player.concord.org/versions/v[new-version-string]``
+7. Checkout production
+8. Run `git reset --hard [version]`
+9. Push production to GitHub
+10. Delete CHANGES.md to clean up your working directory
 
 ### Testing
 
@@ -95,7 +114,7 @@ Inside of your `package.json` file:
 * page={n|"page_[id]"}: load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
 * themeButtons:         whether to show theme buttons
 * mode={mode}:          sets mode. Values: "teacher-edition"
-* portalReport:         override default base URL for the student report. https://activity-player.concord.org/ and https://activity-player.concord.org/version/*, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report. 
+* portalReport:         override default base URL for the student report. https://activity-player.concord.org/ and https://activity-player.concord.org/version/*, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
 
 #### User data loading:
 * firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ without a path, defaults to `report-service-pro` every other url `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.


### PR DESCRIPTION
This documents a new process that doesn't track the CHANGELOG in the repository.
It also skips the `release-<version>` branch and PR.

I'm not sure this is the best approach, but I gave it a try, so people can evaluate.

It uses the `npm version` command along with a temporary CHANGES.md file so the same content can be used in multiple places.

It also documents using `git reset --hard` to move production so production doesn't have merge commits which can result in problems if patch releases are made which are not directly part of the mainline branch.

You can see an example release here:
https://github.com/concord-consortium/activity-player/releases/tag/v1.1.0
Here is the commit created by `npm version`
https://github.com/concord-consortium/activity-player/commit/e916e05c9d8ec96a1a682960889771b7c4f527fa
You can see the tag message (different than the release) by going here: 
https://github.com/concord-consortium/activity-player/tags
Then clicking the `...` next to the v1.1.0 tag.

You can read the new readme markdown here:
https://github.com/concord-consortium/activity-player/blob/document-release-process/README.md#deployment