### PR TITLE
Fixed (some) broken offline-mode Cypress tests

### DIFF
--- a/cypress/integration/offline-manifest.test.ts
+++ b/cypress/integration/offline-manifest.test.ts
@@ -39,26 +39,20 @@ context("Test using offline manifests", () => {
       cy.visit("?offlineManifest=smoke-test");
 
       // verify loading dialog shows and then auto closes
-      activityPage.getOfflineManifestLoadingDialog().should("be.visible").and("contain", "AP Smoke Test");
+      activityPage.getOfflineManifestLoadingDialog().should("be.visible").and("contain", "APO Smoke Test");
 
       // verify offline activities list shows
-      activityPage.getOfflineActivities().should("be.visible").and("contain", "AP Smoke Test");
+      activityPage.getOfflineActivities().should("be.visible").and("contain", "APO Smoke Test");
     });
 
-    /*
-
-    FIXME: COMMENTED OUT TO ENABLE BRANCH BUILD
-
     it("verify offline activities show and clicking an item loads it",() => {
-      cy.visit("?offlineManifest=smoke-test");
+      cy.visit("?offline=true");
 
       // verify clicking on activity loads it and closes the launcher
       activityPage.getOfflineManifestLoadingDialog({timeout: 0}).should("not.exist");
-      activityPage.getOfflineActivityList().contains("AP Smoke Test");
-      activityPage.getOfflineActivityList().click();
-      activityPage.getActivityTitle().should("be.visible").and("contain", "AP Smoke Test");
+      activityPage.getOfflineActivityList().contains("APO Smoke Test");
+      activityPage.getOfflineActivityList().first().click();
+      activityPage.getActivityTitle().should("be.visible").and("contain", "APO Smoke Test");
     });
-
-    */
   });
 });

--- a/cypress/integration/opening-reports.test.ts
+++ b/cypress/integration/opening-reports.test.ts
@@ -23,10 +23,9 @@ context("Test Opening Portal Reports from various places", () => {
         fixture: "sample-activity-1.json"
       }
       );
-      cy.visit(activityPlayerUrl, {
-        onBeforeLoad(win) {
-          cy.stub(win, "open");
-        }
+      cy.visit(activityPlayerUrl);
+      cy.window().then((win) => {
+        cy.stub(win, "open").as("windowOpen");
       });
       activityPage.getPage(3).click();
       cy.wait(1000);
@@ -34,7 +33,7 @@ context("Test Opening Portal Reports from various places", () => {
     describe("Open report from end of activity without completion page", () => {
       it("verify correct link is sent to the portal report", () => {
         cy.get("[data-cy=progress-container] > .button").should("be.visible").click();
-        cy.window().its("open").should("be.calledWith",
+        cy.get("@windowOpen").should("be.calledWith",
           portalReportUrl + "?runKey=" + runKey +
             "&activity=" + activityStructureUrl +
             "&answersSourceKey=authoring.staging.concord.org");

--- a/src/public/offline-manifests/smoke-test.json
+++ b/src/public/offline-manifests/smoke-test.json
@@ -1,8 +1,8 @@
 {
-  "name": "AP Smoke Test",
+  "name": "APO Smoke Test",
   "activities": [
     {
-      "name": "AP Smoke Test",
+      "name": "APO Smoke Test",
       "url": "https://authoring.staging.concord.org/api/v1/activities/20936.json"
     }
   ],


### PR DESCRIPTION
1. Fixed selector in offline-manifest test
2. Fixed window open test in opening-reports test