### PR TITLE
Add support for an special offline domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ Inside of your `package.json` file:
 * page={n|"page_[id]"}: load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
 * themeButtons:         whether to show theme buttons
 * mode={mode}:          sets mode. Values: "teacher-edition"
-* portalReport:         override default base URL for the student report. https://activity-player.concord.org/ and https://activity-player.concord.org/version/*, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
+* portalReport:         override default base URL for the student report. https://activity-player.concord.org/, https://activity-player-offline.concord.org/, https://activity-player.concord.org/version/\*, and https://activity-player-offline.concord.org/version/\*, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
 
 #### User data loading:
-* firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ without a path, defaults to `report-service-pro` every other url `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.
+* firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ and https://activity-player-offline.concord.org/ without a path, defaults to `report-service-pro` every other url defaults to `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.
 * token={n}:         set by the portal when launching external activity, to authenticate with portal API
 * domain={n}:        set by the portal when launching external activity
 * report-source={id}: which source collection to save data to in firestore (defaults to own hostname)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Inside of your `package.json` file:
 * page={n|"page_[id]"}: load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
 * themeButtons:         whether to show theme buttons
 * mode={mode}:          sets mode. Values: "teacher-edition"
-* portalReport:         override default base URL for the student report. https://activity-player.concord.org/, https://activity-player-offline.concord.org/, https://activity-player.concord.org/version/\*, and https://activity-player-offline.concord.org/version/\*, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
+* portalReport:         override default base URL for the student report. `https://activity-player.concord.org/`, `https://activity-player-offline.concord.org/`, `https://activity-player.concord.org/version/*`, and `https://activity-player-offline.concord.org/version/*`, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
 
 #### User data loading:
 * firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ and https://activity-player-offline.concord.org/ without a path, defaults to `report-service-pro` every other url defaults to `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import { queryValue, setQueryValue } from "./utilities/url-query";
 import { FirebaseAppName } from "./firebase-db";
 import { getResourceUrl } from "./lara-api";
+import { getCanonicalHostname, isProductionOrigin } from "./utilities/host-utils";
 
 interface PortalClassOffering {
   className: string;
@@ -208,7 +209,7 @@ const getPortalJWTWithBearerToken = (basePortalUrl: string, rawToken: string) =>
 };
 
 // The default firebase app name is based on the URL:
-// only https://activity-player.concord.org defaults to report-service-pro
+// only [production-origin] with no path defaults to report-service-pro
 // everything else defaults to report-service-dev
 //
 // The default can be overridden with a firebaseApp URL param
@@ -235,7 +236,7 @@ export const firebaseAppName = ():FirebaseAppName => {
   // According to the spec an empty path like https://activity-player.concord.org
   // will still have a pathname of "/", but just to be safe this checks for the
   // falsey pathname
-  if(origin === "https://activity-player.concord.org" &&
+  if(isProductionOrigin(origin) &&
      (!pathname || pathname === "/")) {
     _firebaseAppName = "report-service-pro";
   } else {
@@ -475,7 +476,7 @@ export const anonymousPortalData = (preview: boolean) => {
     toolUserId: "anonymous",
     database: {
       appName: firebaseAppName(),
-      sourceKey: hostname
+      sourceKey: getCanonicalHostname()
     }
   };
   return rawPortalData;

--- a/src/utilities/host-utils.test.ts
+++ b/src/utilities/host-utils.test.ts
@@ -1,0 +1,43 @@
+import { getCanonicalHostname, isOfflineHost, isProductionOrigin } from "./host-utils";
+
+describe("isOfflineHost", () => {
+  it("determines offline mode via the window host value", () => {
+    expect(isOfflineHost("localhost:11000")).toBe(false);
+    expect(isOfflineHost("activity-player.concord.org")).toBe(false);
+    expect(isOfflineHost("localhost:11002")).toBe(true);
+    expect(isOfflineHost("activity-player-offline.concord.org")).toBe(true);
+  });
+});
+
+describe("getCananoicalHostname", () => {
+  const { location } = window;
+  it("returns the canonical hostname", () => {
+    delete (window as any).location;
+
+    const mockLocation = {hostname: ""};
+    (window as any).location = mockLocation;
+
+    mockLocation.hostname = "www.example.com";
+    expect(getCanonicalHostname()).toBe("www.example.com");
+
+    mockLocation.hostname = "activity-player-offline.concord.org";
+    expect(getCanonicalHostname()).toBe("activity-player.concord.org");
+
+    mockLocation.hostname = "activity-player.concord.org";
+    expect(getCanonicalHostname()).toBe("activity-player.concord.org");
+
+
+    (window as any).location = location;
+  });
+});
+
+describe("isProductionOrigin", () => {
+  it("determines the production origin", () => {
+    expect(isProductionOrigin("https://example.com")).toBe(false);
+    expect(isProductionOrigin("https://localhost:11000")).toBe(false);
+    expect(isProductionOrigin("https://activity-player.example.com")).toBe(false);
+    expect(isProductionOrigin("https://activity-player-offline.example.com")).toBe(false);
+    expect(isProductionOrigin("https://activity-player.concord.org")).toBe(true);
+    expect(isProductionOrigin("https://activity-player-offline.concord.org")).toBe(true);
+  });
+});

--- a/src/utilities/host-utils.ts
+++ b/src/utilities/host-utils.ts
@@ -5,7 +5,7 @@ export const getCanonicalHostname = () => {
     return "activity-player.concord.org";
   }
   return window.location.hostname;
-}
+};
 
 export const isProductionOrigin = (origin: string) => {
   return origin === "https://activity-player.concord.org" || origin === "https://activity-player-offline.concord.org";

--- a/src/utilities/host-utils.ts
+++ b/src/utilities/host-utils.ts
@@ -1,0 +1,12 @@
+export const isOfflineHost = (host: string) => (host === "localhost:11002") || (host === "activity-player-offline.concord.org");
+
+export const getCanonicalHostname = () => {
+  if(window.location.hostname === "activity-player-offline.concord.org") {
+    return "activity-player.concord.org";
+  }
+  return window.location.hostname;
+}
+
+export const isProductionOrigin = (origin: string) => {
+  return origin === "https://activity-player.concord.org" || origin === "https://activity-player-offline.concord.org";
+};

--- a/src/utilities/report-utils.ts
+++ b/src/utilities/report-utils.ts
@@ -1,17 +1,17 @@
 import { queryValue } from "../utilities/url-query";
 import { getPortalData } from "../firebase-db";
 import { IPortalData, firebaseAppName } from "../portal-api";
+import { getCanonicalHostname, isProductionOrigin } from "./host-utils";
 
 export const kProductionPortalReportUrl = "https://portal-report.concord.org/version/v4.1.0/index.html";
 export const kDevPortalReportUrl = "https://portal-report.concord.org/branch/master/index.html";
 
 // The default portal report URL is based on the URL:
-// - https://activity-player.concord.org and https://activity-player.concord.org/version/*
+// - [production-origin] and [production-origin]/version/*
 //   defaults to the kProductionPortalReportUrl above
 // - everything else defaults to kDevPortalReportUrl which is should be master
 //
 // The default can be overridden with a portalReport URL param
-const kActivityPlayerOrigin = "https://activity-player.concord.org";
 export const portalReportBaseUrl= ():string => {
   const portalReportUrlParam = queryValue("portalReport");
   if (portalReportUrlParam) {
@@ -22,7 +22,7 @@ export const portalReportBaseUrl= ():string => {
   // According to the spec an empty path like https://activity-player.concord.org
   // will still have a pathname of "/", but just to be safe this checks for the
   // falsey pathname
-  if(origin === kActivityPlayerOrigin &&
+  if(isProductionOrigin(origin) &&
      (!pathname || pathname === "/"
       || pathname.indexOf("/version/") === 0)) {
     return kProductionPortalReportUrl;
@@ -48,8 +48,8 @@ export const getReportUrl = () => {
   const activityUrl = activity? ((activity.split(".json"))[0]).replace("api/v1/","") : "";
   const runKey= queryValue("runKey");
   // Sometimes the location of the answers is overridden with a report-source param
-  const answerSource = queryValue("report-source") || window.location.hostname;
-  const sourceKey = activityUrl ? makeSourceKey(activityUrl) : window.location.hostname;
+  const answerSource = queryValue("report-source") || getCanonicalHostname();
+  const sourceKey = activityUrl ? makeSourceKey(activityUrl) : getCanonicalHostname();
 
   if (runKey) {
     return reportLink


### PR DESCRIPTION
This also extracts the isProductionOrigin logic so the portal-api.ts and report-utils.ts aren't each implementing it