### PR TITLE
update several parts of offline-mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Inside of your `package.json` file:
 * firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ and https://activity-player-offline.concord.org/ without a path, defaults to `report-service-pro` every other url defaults to `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.
 * token={n}:         set by the portal when launching external activity, to authenticate with portal API
 * domain={n}:        set by the portal when launching external activity
-* report-source={id}: which source collection to save data to in firestore (defaults to own hostname)
+* sourceKey={id}:    which source collection to save data to in firestore (defaults to canonical hostname)
 * runkey={uuid}:     set by the app if we are running in anonymous datasaving mode
 * preview:           prevent running in anonymous datasaving mode
 * enableFirestorePersistence: uses local offline firestore cache only

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Inside of your `package.json` file:
 
 * activity={id|url}:    load sample-activity {id} or load json from specified url
 * sequence={id|url}:    load sample-sequence {id} or load json from specified url
+* contentUrl={url}:     override the activity parameter and load the activity content from this contentUrl instead. In this case the activity parameter is still used to make the resourceUrl which identifies the resource structure in the report-service. The computed resourceUrl is also used to identify the answers when running offline.
 * page={n|"page_[id]"}: load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
 * themeButtons:         whether to show theme buttons
 * mode={mode}:          sets mode. Values: "teacher-edition"

--- a/cypress/integration/opening-reports.test.ts
+++ b/cypress/integration/opening-reports.test.ts
@@ -12,7 +12,7 @@ context("Test Opening Portal Reports from various places", () => {
     const activityStructureUrl = "https://example.com/activities/123";
     const activityPlayerUrl = "?" +
       "activity="+activityExportUrl+
-      "&report-source=authoring.staging.concord.org" +
+      "&sourceKey=authoring.staging.concord.org" +
       "&runKey="+runKey;
 
     before(() => {

--- a/src/components/offline-activities.tsx
+++ b/src/components/offline-activities.tsx
@@ -18,7 +18,7 @@ const OfflineActivityListRow = (props: {activity: OfflineActivity;  onSelectOffl
 
 interface IProps {
   username: string;
-  onSelectActivity: (activity: Activity, url: string) => void;
+  onSelectActivity: (activity: Activity, resourceUrl: string, contentUrl: string) => void;
 }
 
 interface IState {
@@ -44,8 +44,8 @@ export class OfflineActivities extends React.Component<IProps, IState> {
   handleSelectOfflineActivity = async (offlineActivity: OfflineActivity) => {
     const { onSelectActivity } = this.props;
     try {
-      const activity = await getActivityDefinition(offlineActivity.url);
-      onSelectActivity(activity, offlineActivity.url);
+      const activity = await getActivityDefinition(offlineActivity.contentUrl);
+      onSelectActivity(activity, offlineActivity.resourceUrl, offlineActivity.contentUrl);
     } catch (e) {
       alert("Error loading activity!");
     }
@@ -69,7 +69,7 @@ export class OfflineActivities extends React.Component<IProps, IState> {
         </thead>
         <tbody>
           {offlineActivities.map(offlineActivity =>
-            <OfflineActivityListRow key={offlineActivity.url} activity={offlineActivity} onSelectOfflineActivity={this.handleSelectOfflineActivity} />
+            <OfflineActivityListRow key={offlineActivity.resourceUrl} activity={offlineActivity} onSelectOfflineActivity={this.handleSelectOfflineActivity} />
           )}
         </tbody>
       </table>

--- a/src/offline-manifest-api.ts
+++ b/src/offline-manifest-api.ts
@@ -43,7 +43,7 @@ export interface CacheOfflineManifestOptions {
 
 export const cacheOfflineManifest = (options: CacheOfflineManifestOptions) => {
   const {offlineManifest, onCachingStarted, onUrlCached, onUrlCacheFailed, onAllUrlsCached, onAllUrlsCacheFailed} = options;
-  const urls = offlineManifest.activities.map(a => a.url).concat(offlineManifest.cacheList);
+  const urls = offlineManifest.activities.map(a => a.contentUrl).concat(offlineManifest.cacheList);
   const loadingPromises = urls.map(url => {
     return fetch(url, {mode: "no-cors"})
       .then(() => onUrlCached(url))
@@ -102,7 +102,9 @@ export const getOfflineManifestAuthoringDownloadJSON = (name: string, data: Offl
 export const mergeOfflineManifestWithAuthoringData = (offlineManifest: OfflineManifest, authoringData: OfflineManifestAuthoringData) => {
   const {activities, cacheList} = authoringData;
   offlineManifest.activities.forEach(activity => {
-    if (!activities.find(a => a.url === activity.url)) {
+    // Note: if the contentUrl has changed this is won't update it in the manifest
+    // but in that case it seems reasonable that the author will just manually fix it.
+    if (!activities.find(a => a.resourceUrl === activity.resourceUrl)) {
       activities.push(activity);
     }
   });
@@ -116,12 +118,12 @@ export const mergeOfflineManifestWithAuthoringData = (offlineManifest: OfflineMa
 
 export const saveOfflineManifestToOfflineActivities = async (offlineManifest: OfflineManifest) => {
   const promises = offlineManifest.activities.map(async (offlineManifestActivity) => {
-    const {name, url} = offlineManifestActivity;
-    const offlineActivity = await dexieStorage.offlineActivities.get({url});
+    const {name, resourceUrl, contentUrl} = offlineManifestActivity;
+    const offlineActivity = await dexieStorage.offlineActivities.get({resourceUrl});
     if (offlineActivity) {
-      await dexieStorage.offlineActivities.update(url, {name, url});
+      await dexieStorage.offlineActivities.update(resourceUrl, {name, resourceUrl, contentUrl});
     } else {
-      await dexieStorage.offlineActivities.put({name, url});
+      await dexieStorage.offlineActivities.put({name, resourceUrl, contentUrl});
     }
   });
   await Promise.all(promises);

--- a/src/offline-manifest-api.ts
+++ b/src/offline-manifest-api.ts
@@ -102,7 +102,7 @@ export const getOfflineManifestAuthoringDownloadJSON = (name: string, data: Offl
 export const mergeOfflineManifestWithAuthoringData = (offlineManifest: OfflineManifest, authoringData: OfflineManifestAuthoringData) => {
   const {activities, cacheList} = authoringData;
   offlineManifest.activities.forEach(activity => {
-    // Note: if the contentUrl has changed this is won't update it in the manifest
+    // Note: if the contentUrl has changed this won't update it in the manifest
     // but in that case it seems reasonable that the author will just manually fix it.
     if (!activities.find(a => a.resourceUrl === activity.resourceUrl)) {
       activities.push(activity);

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -419,12 +419,12 @@ export const fetchPortalData = async (opts: IFetchPortalDataOpts = fetchPortalDa
   const offeringData = await getOfferingData({portalJWT, rawPortalJWT, offeringId});
   const [rawFirebaseJWT, firebaseJWT] = await getActivityPlayerFirebaseJWT(basePortalUrl, rawPortalJWT, classInfo.classHash);
 
-  // student data gets saved in different buckets of the DB, the "source," depending on the domain
-  // of the activity.
+  // student data gets saved in different buckets of the DB, the "source," depending on
+  // the canonical hostname.
   // This works fine, but for testing the activity player, we may want to load data that was previously
-  // saved in a different domain (e.g. authoring.concord.org), so we first check for a "url-source"
+  // saved in a different domain (e.g. authoring.concord.org), so we first check for a "sourceKey"
   // query parameter.
-  const sourceKey = queryValue("report-source") || parseUrl(offeringData.activityUrl.toLowerCase()).hostname;
+  const sourceKey = queryValue("sourceKey") || getCanonicalHostname();
 
   const fullName = classInfo.students.find(s => s.id.toString() === portalJWT.uid.toString())?.fullName;
 
@@ -479,7 +479,7 @@ export const anonymousPortalData = (preview: boolean) => {
     toolUserId: "anonymous",
     database: {
       appName: firebaseAppName(),
-      sourceKey: getCanonicalHostname()
+      sourceKey: queryValue("sourceKey") || getCanonicalHostname()
     }
   };
   return rawPortalData;

--- a/src/public/offline-manifests/precipitatingchange-test-v1.json
+++ b/src/public/offline-manifests/precipitatingchange-test-v1.json
@@ -3,7 +3,8 @@
   "activities": [
     {
       "name": "Precipitating Change (TEST)",
-      "url": "offline-activities/precipitatingchange-test-v1.json"
+      "resourceUrl": "https://authoring.staging.concord.org/activities/20944",
+      "contentUrl": "offline-activities/precipitatingchange-test-v1.json"
     }
   ],
   "cacheList": [

--- a/src/public/offline-manifests/precipitatingchange-test-v1.json
+++ b/src/public/offline-manifests/precipitatingchange-test-v1.json
@@ -3,7 +3,7 @@
   "activities": [
     {
       "name": "Precipitating Change (TEST)",
-      "resourceUrl": "https://authoring.staging.concord.org/activities/20944",
+      "resourceUrl": "https://authoring.staging.concord.org/activities/20926",
       "contentUrl": "offline-activities/precipitatingchange-test-v1.json"
     }
   ],

--- a/src/public/offline-manifests/smoke-test-v1.json
+++ b/src/public/offline-manifests/smoke-test-v1.json
@@ -3,7 +3,8 @@
   "activities": [
     {
       "name": "APO Smoke Test",
-      "url": "offline-activities/smoke-test-v1.json"
+      "resourceUrl": "https://authoring.staging.concord.org/activities/20936",
+      "contentUrl": "offline-activities/smoke-test-v1.json"
     }
   ],
   "cacheList": [

--- a/src/storage/dexie-storage.ts
+++ b/src/storage/dexie-storage.ts
@@ -3,7 +3,8 @@ import { OfflineActivity, LogMessage } from "../types";
 import { IIndexedDBAnswer } from "./storage-facade";
 
 // We need to ensure a version match between data stored and exported
-export const kOfflineAnswerSchemaVersion = 4;
+// version 5: switched from activity to resource_url field for identifing answers's activity
+export const kOfflineAnswerSchemaVersion = 5;
 
 // Copy and pasted from the example: https://dexie.org/docs/Typescript
 export class DexieStorage extends Dexie {
@@ -15,28 +16,16 @@ export class DexieStorage extends Dexie {
   pluginStates: Dexie.Table<{pluginId: number, state: string|null}>;
 
   constructor () {
-      super("ActivityPlayer");
-      // FIXME: There is only one version for the whole database.
-      // calling version multiple times is how you can specify a schema for older
-      // versions of the database.
-      this.version(5).stores({
-        logs: "++id, activity"
-      });
-      this.version(kOfflineAnswerSchemaVersion).stores({
-          answers: "id, resource_url, [resource_url+question_id]",
-          pluginStates: "&pluginId"
-      });
-      this.version(3).stores({
-        offlineActivities: "&resourceUrl"  // unique by resourceUrl
-      });
-
-      // Once we fix the version issue, the following code can be used
-      // to clear the old tables since we don't need to worry about
-      // about the old data. I'm not sure what the return value should
-      // be to the upgrade callback
-      // .upgrade(tx => {
-      //   return tx.table("offlineActivities").toCollection().delete();
-      // });
+    // the database was called ActivityPlayer, but changes to the offlineActivities
+    // primary key required deleting that table to upgrade it, so renaming
+    // the database was easier
+    super("ActivityPlayerDb");
+    this.version(kOfflineAnswerSchemaVersion).stores({
+      logs: "++id, activity",
+      answers: "id, resource_url, [resource_url+question_id]",
+      pluginStates: "&pluginId",
+      offlineActivities: "&resourceUrl"  // unique by resourceUrl
+    });
   }
 }
 

--- a/src/storage/dexie-storage.ts
+++ b/src/storage/dexie-storage.ts
@@ -16,16 +16,27 @@ export class DexieStorage extends Dexie {
 
   constructor () {
       super("ActivityPlayer");
+      // FIXME: There is only one version for the whole database.
+      // calling version multiple times is how you can specify a schema for older
+      // versions of the database.
       this.version(5).stores({
         logs: "++id, activity"
       });
       this.version(kOfflineAnswerSchemaVersion).stores({
-          answers: "id, question_id, activity",
+          answers: "id, resource_url, [resource_url+question_id]",
           pluginStates: "&pluginId"
       });
       this.version(3).stores({
-        offlineActivities: "&url"  // unique by url
+        offlineActivities: "&resourceUrl"  // unique by resourceUrl
       });
+
+      // Once we fix the version issue, the following code can be used
+      // to clear the old tables since we don't need to worry about
+      // about the old data. I'm not sure what the return value should
+      // be to the upgrade callback
+      // .upgrade(tx => {
+      //   return tx.table("offlineActivities").toCollection().delete();
+      // });
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,7 +269,8 @@ export interface IAnonymousLearnerPluginState extends IAnonymousMetadataPartial 
 
 export interface OfflineManifestActivity {
   name: string;
-  url: string;
+  resourceUrl: string;
+  contentUrl: string;
 }
 export interface OfflineManifest {
   name: string

--- a/src/utilities/report-utils.ts
+++ b/src/utilities/report-utils.ts
@@ -48,8 +48,8 @@ export const getReportUrl = () => {
   const activity = queryValue("activity");
   const activityUrl = getResourceUrl(activity);
   const runKey = queryValue("runKey");
-  // Sometimes the location of the answers is overridden with a report-source param
-  const answerSource = queryValue("report-source") || getCanonicalHostname();
+  // Sometimes the location of the answers is overridden with a sourceKey param
+  const answerSource = queryValue("sourceKey") || getCanonicalHostname();
   const sourceKey = activityUrl ? makeSourceKey(activityUrl) : getCanonicalHostname();
 
   if (runKey) {


### PR DESCRIPTION
- split the url of the offlineActivity table into a resourceUrl and contentUrl: this makes it possible to load the activity json from a frozen place, but still use the resourceUrl as a id to find the report-structure in the report-service. The resourceUrl also makes it possible to to load new versions of the content without losing all of the answers stored in indexedDb.
- change report-source url parameter to sourceKey (not required for this work, but I've wanted to do it)
- change default sourceKey to use the canonical hostname. This also replaced the unnecessary getting of the hostname from the offering url instead of just getting it from window.location. The two should be the same. And it added the ability to override the sourceKey when running anonymously which wasn't supported well before.
- rename TrackOfflineActivityId to TrackOfflineResourceUrl since that is more accurate now
- add contentUrl query parameter to support the splitting of resourceUrl from contentUrl. In the url parameters the activity parameter cooresponds to the resourceUrl. This parameter wasn't renamed because it is assumed to be there by the portal-report codebase. Also this `activity` parameter is processed into the resourceUrl by stripping out the `api/v1` and `.json`. But if the activity parameter doesn't have those strings it also works fine. So if you are using the contentUrl then you can just set the activity parameter to the resourceUrl.
- change the answers table to store the resource_url field and use that to look up answers.
- change the answers table to look for `resource_url+question_id` since there this no guarruntee that a question_id will be unique outside of the a particular resource_url. For example an author could hand craft a resource instead of using LARA. 
- unify the Dexie schema into a single version. The use of multiple versions did not seem to be implemented right.