### PR TITLE
hacky untyped fix for the duplicate answers problem

### DIFF
--- a/src/storage/storage-facade.ts
+++ b/src/storage/storage-facade.ts
@@ -224,7 +224,7 @@ class DexieStorageProvider implements IStorageInterface {
     if (!questionAnswerWatchers) {
       return;
     }
-    questionAnswerWatchers.forEach((callback:any) => {
+    questionAnswerWatchers.forEach((callback:IAnswerWatcherCallback) => {
       callback(docToWrappedAnswer(answer));
     });
   }

--- a/src/storage/storage-facade.ts
+++ b/src/storage/storage-facade.ts
@@ -1,7 +1,7 @@
 // import { WrappedDBAnswer, FirebaseAppName } from "./firebase-db";
 import * as FirebaseImp from "./firebase-db";
 import { fetchPortalData, IAnonymousPortalData, IPortalData } from "../portal-api";
-import { IAnonymousMetadataPartial, IExportableAnswerMetadata } from "../types";
+import { IExportableAnswerMetadata } from "../types";
 import { dexieStorage, kOfflineAnswerSchemaVersion } from "./dexie-storage";
 import { refIdToAnswersQuestionId } from "../utilities/embeddable-utils";
 
@@ -190,10 +190,12 @@ class FireStoreStorageProvider implements IStorageInterface {
 }
 
 
+interface IAnswerWatcherCallback { (answer: IWrappedDBAnswer): void }
+type IQuestionWatchersRecord =  Record<string, Array<IAnswerWatcherCallback>>;
 class DexieStorageProvider implements IStorageInterface {
   portalData: IPortalData|IAnonymousPortalData;
   haveFireStoreConnection: boolean;
-  answerWatchers: any;
+  answerWatchers: Record<string, IQuestionWatchersRecord>;
 
   constructor(){
     this.haveFireStoreConnection = false;


### PR DESCRIPTION
This has no tests and isn't typed, but it might be worth merging since it seems to fix a critical bug when demoing this stuff. 
I'll leave it up to you to decide.

I think I problem is described pretty well in the story:
https://www.pivotaltracker.com/story/show/177333639

The technical issue is that the host code using the the storage system is assuming that the watchAnswer callback will be called after the createOrUpdateAnswer is complete.