### PR TITLE
Save plugin state when exporting student data to JSON

### DIFF
--- a/src/storage/dexie-storage.ts
+++ b/src/storage/dexie-storage.ts
@@ -4,7 +4,7 @@ import { IIndexedDBAnswer } from "./storage-facade";
 
 // We need to ensure a version match between data stored and exported
 // version 5: switched from activity to resource_url field for identifying answer's activity
-export const kOfflineAnswerSchemaVersion = 5;
+export const kOfflineAnswerSchemaVersion = 6;
 export interface IDexiePluginRecord {
   pluginId: number,
   state: string|null

--- a/src/storage/dexie-storage.ts
+++ b/src/storage/dexie-storage.ts
@@ -3,8 +3,12 @@ import { OfflineActivity, LogMessage } from "../types";
 import { IIndexedDBAnswer } from "./storage-facade";
 
 // We need to ensure a version match between data stored and exported
-// version 5: switched from activity to resource_url field for identifing answers's activity
+// version 5: switched from activity to resource_url field for identifying answer's activity
 export const kOfflineAnswerSchemaVersion = 5;
+export interface IDexiePluginRecord {
+  pluginId: number,
+  state: string|null
+}
 
 // Copy and pasted from the example: https://dexie.org/docs/Typescript
 export class DexieStorage extends Dexie {
@@ -12,8 +16,8 @@ export class DexieStorage extends Dexie {
   // (just to inform Typescript. Instantiated by Dexie in stores() method)
   logs: Dexie.Table<LogMessage, number>;
   offlineActivities: Dexie.Table<OfflineActivity, string>;
-  answers: Dexie.Table<IIndexedDBAnswer, string>; // number = type of the primkey
-  pluginStates: Dexie.Table<{pluginId: number, state: string|null}>;
+  answers: Dexie.Table<IIndexedDBAnswer, string>; // number = type of the primary key
+  pluginStates: Dexie.Table<IDexiePluginRecord, number>;
 
   constructor () {
     // the database was called ActivityPlayer, but changes to the offlineActivities


### PR DESCRIPTION

This will make saving plugin state easier to demo tomorrow.

It just adds the plugin states to the JSON export of student data.
