### PR TITLE
Add 0 as valid cacheable response

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -37,7 +37,7 @@ registerRoute(
     plugins: [
       // Ensure that only requests that result in a 200 status are cached
       new CacheableResponsePlugin({
-        statuses: [200],
+        statuses: [0, 200],
       }),
     ],
   }),


### PR DESCRIPTION
The 0 status code is returned for opaque responses.  Since our fetch based cache filler use the no-cors option we get opaque responses for all external non-cors enabled servers.