### PR TITLE
Update site manifest to make start_url and icons relative paths

### DIFF
--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -3,7 +3,7 @@
   "name": "Activity Player",
   "lang": "en",
   "description": "Concord Consortium Activity Player",
-  "start_url": "/index.html?offline=true",
+  "start_url": "index.html",
   "background_color": "#ea6d2f",
   "theme_color": "#2da343",
   "dir": "ltr",
@@ -11,67 +11,67 @@
   "orientation": "any",
   "icons": [
     {
-      "src": "/icons/android-icon-192x192.png",
+      "src": "icons/android-icon-192x192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "/icons/apple-icon-180x180.png",
+      "src": "icons/apple-icon-180x180.png",
       "type": "image/png",
       "sizes": "180x180"
     },
     {
-      "src": "/icons/apple-icon-152x152.png",
+      "src": "icons/apple-icon-152x152.png",
       "type": "image/png",
       "sizes": "152x152"
     },
     {
-      "src": "/icons/apple-icon-144x144.png",
+      "src": "icons/apple-icon-144x144.png",
       "type": "image/png",
       "sizes": "144x144"
     },
     {
-      "src": "/icons/apple-icon-120x120.png",
+      "src": "icons/apple-icon-120x120.png",
       "type": "image/png",
       "sizes": "120x120"
     },
     {
-      "src": "/icons/apple-icon-114x114.png",
+      "src": "icons/apple-icon-114x114.png",
       "type": "image/png",
       "sizes": "114x114"
     },
     {
-      "src": "/icons/favicon-96x96.png",
+      "src": "icons/favicon-96x96.png",
       "type": "image/png",
       "sizes": "96x96"
     },
     {
-      "src": "/icons/apple-icon-76x76.png",
+      "src": "icons/apple-icon-76x76.png",
       "type": "image/png",
       "sizes": "76x76"
     },
     {
-      "src": "/icons/apple-icon-72x72.png",
+      "src": "icons/apple-icon-72x72.png",
       "type": "image/png",
       "sizes": "72x72"
     },
     {
-      "src": "/icons/apple-icon-60x60.png",
+      "src": "icons/apple-icon-60x60.png",
       "type": "image/png",
       "sizes": "60x60"
     },
     {
-      "src": "/icons/apple-icon-57x57.png",
+      "src": "icons/apple-icon-57x57.png",
       "type": "image/png",
       "sizes": "57x57"
     },
     {
-      "src": "/icons/favicon-32x32.png",
+      "src": "icons/favicon-32x32.png",
       "type": "image/png",
       "sizes": "32x32"
     },
     {
-      "src": "/icons/favicon-16x16.png",
+      "src": "icons/favicon-16x16.png",
       "type": "image/png",
       "sizes": "16x16"
     }


### PR DESCRIPTION
This allows the PWA install icon to be seen in the long-lived offline-mode branch