### PR TITLE
177370190 workbox updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
       "<rootDir>src/setupTests.js"
     ],
     "transform": {
-      "^.+\\.tsx?$": "ts-jest"
+      "^.+\\.[jt]sx?$": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(workbox-window|workbox-core)/)"
+    ],
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "testPathIgnorePatterns": [
       "/node_modules/",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -30,7 +30,7 @@ import { INavigationOptions } from "@concord-consortium/lara-interactive-api";
 import { Logger, LogEventName } from "../lib/logger";
 import { GlossaryPlugin } from "../components/activity-page/plugins/glossary-plugin";
 import { IdleDetector } from "../utilities/idle-detector";
-import { messageSW, Workbox } from "workbox-window";
+import { messageSW, Workbox } from "workbox-window/index";
 import { getOfflineManifest, getOfflineManifestAuthoringData, getOfflineManifestAuthoringId, OfflineManifestAuthoringData, mergeOfflineManifestWithAuthoringData, saveOfflineManifestToOfflineActivities, setOfflineManifestAuthoringData, setOfflineManifestAuthoringId } from "../offline-manifest-api";
 import { OfflineManifestLoadingModal } from "./offline-manifest-loading-modal";
 import { OfflineActivities } from "./offline-activities";

--- a/src/components/offline-installing.tsx
+++ b/src/components/offline-installing.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { ServiceWorkerStatus } from "../types";
+
+interface IProps {
+  serviceWorkerStatus: ServiceWorkerStatus;
+}
+
+interface IState {
+}
+
+export class OfflineInstalling extends React.Component<IProps, IState> {
+  constructor(props: IProps) {
+    super(props);
+
+    this.state = {
+    };
+  }
+
+  render() {
+    const { serviceWorkerStatus } = this.props;
+    if (serviceWorkerStatus !== "activated") {
+      return (
+        <div>
+          Activity Player Offline is installing.<br/>
+          Current status is: {serviceWorkerStatus}
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          Activity Player Offline is installed.<br/>
+          Reload the page to continue.
+        </div>
+      );
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,19 @@ export interface OfflineActivity extends OfflineManifestActivity {
   // TBD: add class info once that is figured out
 }
 
+// This is a combination of the standard service worker states:
+// installing, installed, activating, activated, redundant
+// https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorker/state
+// With additional states for the initial "unknown" startup state and
+// a "controlling" state which isn't captured as a "state" by the service worker API
+// a "parsed" state is added to satisfy the ServiceWorker types,
+// this state is documented here: https://bitsofco.de/the-service-worker-lifecycle/
+// but it isn't lised in the MDN article above
+// The actual status is more complex than this because there can be external
+// service workers, but perhaps this simplified list
+// will be good enough for deciding what to do with the UI
+export type ServiceWorkerStatus = "unknown" | "parsed" | "installing" | "installed" | "activating" | "activated" | "redundant" | "controlling";
+
 export interface LogMessage {
   application: string;
   run_remote_endpoint?: string;


### PR DESCRIPTION
- import workbox-window/index so we can see the debugging log messages of workbox-window
- use messageSkipWaiting instead of sending our own messages
- put up page loading message so the offline manifest isn't cached before the service worker is controlling the page