### PR TITLE
Remove "Import Work From File" button

### DIFF
--- a/src/components/activity-introduction/introduction-page-content.tsx
+++ b/src/components/activity-introduction/introduction-page-content.tsx
@@ -15,7 +15,6 @@ export const IntroductionPageContent: React.FC<IProps> = (props) => {
   const { activity, onPageChange } = props;
   return (
     <div className="intro-content" data-cy="intro-page-content">
-      <ImportAnswers />
       <div className="introduction">
         <ActivitySummary
           activityName={activity.name}


### PR DESCRIPTION
We are worried kids are going to click this button without knowing what it does, and possibly loose data.

We are going to remove it for now, possibly bring it back someplace less tempting in the future.

[#177461457]

Story: https://www.pivotaltracker.com/n/projects/2441249/stories/177461457