### PR TITLE
switch to cors requests when loading offline manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "superagent": "^6.1.0",
     "workbox-precaching": "^6.0.2",
     "workbox-webpack-plugin": "^6.0.2",
+    "workbox-range-requests": "^6.0.2",
     "workbox-window": "^6.0.2"
   }
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -206,6 +206,10 @@ export class App extends React.PureComponent<IProps, IState> {
           case "GET_REQUEST":
             if (offlineManifestAuthoringId) {
               this.setState((prevState) => {
+                // TODO: we only allow cors requests, so it would be helpful to authors
+                // if we checked whether the url can be requested with cors and if not
+                // we notify the author about the invalid url
+                
                 // make sure all models-resources requests use the base folder
                 const url = event.data.url.replace(/.*models-resources\//, "models-resources/");
                 let {offlineManifestAuthoringCacheList} = prevState;

--- a/src/offline-manifest-api.ts
+++ b/src/offline-manifest-api.ts
@@ -45,7 +45,7 @@ export const cacheOfflineManifest = (options: CacheOfflineManifestOptions) => {
   const {offlineManifest, onCachingStarted, onUrlCached, onUrlCacheFailed, onAllUrlsCached, onAllUrlsCacheFailed} = options;
   const urls = offlineManifest.activities.map(a => a.contentUrl).concat(offlineManifest.cacheList);
   const loadingPromises = urls.map(url => {
-    return fetch(url, {mode: "no-cors"})
+    return fetch(url, {mode: "cors"})
       .then(() => onUrlCached(url))
       .catch(err => onUrlCacheFailed(url, err));
   });

--- a/src/public/offline-manifests/precipitating-change-v1.json
+++ b/src/public/offline-manifests/precipitating-change-v1.json
@@ -200,7 +200,6 @@
     "models-resources/precip-models/ak-w-cities.png",
     "models-resources/precip-models/lesson-4-ak-v3.html",
     "models-resources/precip-models/precip-rule-ak-v5.html",
-    "models-resources/question-interactives/version/v0.6.1/image",
     "models-resources/question-interactives/version/v1.1.0/carousel/",
     "models-resources/question-interactives/version/v1.1.0/carousel/assets/index.43fd80fcbaa142f3b07e.css",
     "models-resources/question-interactives/version/v1.1.0/carousel/assets/index.43fd80fcbaa142f3b07e.js",

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -21,12 +21,12 @@ const precacheEntries = [
 
 precacheAndRoute(precacheEntries, {
   // Ignore most URL parameters. We want to ignore the runKey on index.html
-  // as well as other paramters on index.html
+  // as well as other parameters on index.html
   // The exception are the params needed by the lato request above
-  // This approach of not ignoring family and dispaly is hacking.
+  // This approach of not ignoring family and display is hacking.
   // It'd be better if we just ignored all params on index.html and let other
   // params go through. We are about to change this precaching code, so it
-  // it doesn't seem worth the effort to find a better way
+  // doesn't seem worth the effort to find a better way
   ignoreURLParametersMatching: [/(?!(family|display))/]
 });
 


### PR DESCRIPTION
doing this exposed an issue with the existing code. There are two css files referenced
by index.html that are referenced before we start installing the offline manifest.
These references were breaking the cache.
My solution is to add them to the pre-cache so they are available before the index.html
request even happens (when the page is controlled).

This also adds the range-request plugin which is needed to support videos.
And it removes a broken url from production pc manifest.

I think part of this is that by using cors we are see any download errors. With no-cors
those download errors are cached as if they succeeded so we never knew they failed

Note: I ran `npm install`, but no changes showed up in package-lock.json