### PR TITLE
Hide "Show My Work" when we can't run a report.

### DIFF
--- a/src/components/activity-completion/completion-page-content.scss
+++ b/src/components/activity-completion/completion-page-content.scss
@@ -84,6 +84,13 @@
         fill: $cc-orange-dark1;
         margin-right: 5px;
       }
+      &.disabled {
+        cursor: default;
+        opacity: 0.4;
+        &:hover{
+          background-color: $cc-orange-light1;
+        }
+      }
     }
     h1 {
       flex-basis: 100%;

--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -33,6 +33,7 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
     onShowSequence } = props;
 
   const [answers, setAnswers] = useState<any>();
+  const [canProvideStudentReport, setCanProvideStudentReport] = useState<boolean>();
 
   const handleExit = () => {
     if (sequence) {
@@ -85,6 +86,7 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
 
   useEffect(() => {
     const storage = getStorage();
+    setCanProvideStudentReport(storage.canProvideStudentReport());
     storage.watchAllAnswers(answerMetas => {
       setAnswers(answerMetas);
     });
@@ -121,7 +123,7 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
   }
 
   const exitContainerClass = showReportBackupOptions ? "exit-container with-backup-options" : "exit-container";
-  const showStudentReportButton = showStudentReport && getStorage().canProvideStudentReport();
+  const showStudentReportButton = showStudentReport && canProvideStudentReport;
   return (
     !answers
       ? <div className="completion-page-content" data-cy="completion-page-content">

--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -121,7 +121,7 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
   }
 
   const exitContainerClass = showReportBackupOptions ? "exit-container with-backup-options" : "exit-container";
-
+  const showStudentReportButton = showStudentReport && getStorage().canProvideStudentReport();
   return (
     !answers
       ? <div className="completion-page-content" data-cy="completion-page-content">
@@ -165,10 +165,16 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
           <div className={exitContainerClass} data-cy="exit-container">
             <h1>Summary of Work: <span className="activity-title">{activityTitle}</span></h1>
             <SummaryTable questionsStatus={progress.questionsStatus} />
-            {showStudentReport && <button className="button show-my-work" onClick={handleShowAnswers}><IconCompletion width={24} height={24} />Show My Work</button>}
-            {(!sequence || isLastActivityInSequence) && 
+              { showStudentReportButton &&
+                  <button
+                    className="button show-my-work"
+                    onClick={handleShowAnswers}>
+                      <IconCompletion width={24} height={24} />
+                      Show My Work
+                  </button>}
+            {(!sequence || isLastActivityInSequence) &&
               <div className="exit-button">
-                <span>or</span>
+                { showStudentReportButton && <span>or</span> }
                 <button className="textButton" onClick={handleExit}>Exit</button>
               </div>
             }

--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -167,13 +167,22 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
           <div className={exitContainerClass} data-cy="exit-container">
             <h1>Summary of Work: <span className="activity-title">{activityTitle}</span></h1>
             <SummaryTable questionsStatus={progress.questionsStatus} />
-              { showStudentReportButton &&
-                  <button
-                    className="button show-my-work"
-                    onClick={handleShowAnswers}>
-                      <IconCompletion width={24} height={24} />
-                      Show My Work
-                  </button>}
+              { showStudentReportButton
+                  ?
+                    <button
+                      className="button show-my-work"
+                      onClick={handleShowAnswers}>
+                        <IconCompletion width={24} height={24} />
+                        Show My Work
+                    </button>
+                  :
+                    <button
+                      className="button show-my-work disabled"
+                      disabled={true}>
+                        <IconCompletion width={24} height={24} />
+                        Show My Work
+                    </button>
+              }
             {(!sequence || isLastActivityInSequence) &&
               <div className="exit-button">
                 { showStudentReportButton && <span>or</span> }

--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -185,7 +185,7 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
               }
             {(!sequence || isLastActivityInSequence) &&
               <div className="exit-button">
-                { showStudentReportButton && <span>or</span> }
+                <span>or</span>
                 <button className="textButton" onClick={handleExit}>Exit</button>
               </div>
             }

--- a/src/storage/data-sync-tracker.ts
+++ b/src/storage/data-sync-tracker.ts
@@ -79,7 +79,6 @@ export class DataSyncTracker {
   }
 
   receivedPluginStatus(status: IPluginSyncUpdate) {
-    console.log(">==== PLUGIN SYNC ==>", status);
     // We don't reset the timer if the status is fail or ok, which are terminal.
     if(status.status===("started" || "working")) {
       if(status.status === "started") {


### PR DESCRIPTION
On the completion page, we gray out/disable the "Show My Work" button unless we can run a report.

This should have been a small change, but I got derailed by a failing test, and then remembered that we were supposed to disable a button instead of removing it.

[#177461358] -- Hide "Show My Work" when we can't run a report

PT Story: https://www.pivotaltracker.com/story/show/177461358