### PR TITLE
try using no-store when loading cache

### DIFF
--- a/src/offline-manifest-api.ts
+++ b/src/offline-manifest-api.ts
@@ -45,7 +45,7 @@ export const cacheOfflineManifest = (options: CacheOfflineManifestOptions) => {
   const {offlineManifest, onCachingStarted, onUrlCached, onUrlCacheFailed, onAllUrlsCached, onAllUrlsCacheFailed} = options;
   const urls = offlineManifest.activities.map(a => a.contentUrl).concat(offlineManifest.cacheList);
   const loadingPromises = urls.map(url => {
-    return fetch(url, {mode: "cors"})
+    return fetch(url, {mode: "cors", cache: "no-store"})
       .then(() => onUrlCached(url))
       .catch(err => onUrlCacheFailed(url, err));
   });


### PR DESCRIPTION
This seems to fix this issue: https://www.pivotaltracker.com/story/show/177481513
I cannot duplicate it on localhost, so I pushed this branch to test it out. 

It is hard to test remotely as well, but I'm pretty confident that it fixes the problem.
I ran the same steps in the story but used 
https://activity-player-offline.concord.org/branch/test-no-store/?offlineManifest=precipitating-change-v1&confirmOfflineManifestInstall=true&firebaseApp=report-service-pro
for the offline part and it worked.

When testing you have to be careful because different branches share the same `cachedGets` cache. So you need to start completely fresh each time.