### PR TITLE
Added test glossary activity [#177479101]

### DIFF
--- a/src/public/offline-activities/glossary-test-v1.json
+++ b/src/public/offline-activities/glossary-test-v1.json
@@ -1,0 +1,85 @@
+{
+  "description": "",
+  "editor_mode": 0,
+  "layout": 0,
+  "name": "Simple AP with Glossary (master)",
+  "notes": "",
+  "project_id": null,
+  "related": "",
+  "runtime": "Activity Player",
+  "show_submit_button": true,
+  "student_report_enabled": true,
+  "thumbnail_url": "",
+  "time_to_complete": null,
+  "version": 1,
+  "theme_name": null,
+  "pages": [
+    {
+      "additional_sections": {},
+      "embeddable_display_mode": "stacked",
+      "id": 308544,
+      "is_completion": false,
+      "is_hidden": false,
+      "layout": "l-full-width",
+      "name": null,
+      "position": 1,
+      "show_header": false,
+      "show_info_assessment": false,
+      "show_interactive": true,
+      "show_sidebar": false,
+      "sidebar": null,
+      "sidebar_title": "Did you know?",
+      "toggle_info_assessment": false,
+      "embeddables": [
+        {
+          "embeddable": {
+            "content": "<p>This is a test of the glossary</p>",
+            "is_callout": true,
+            "is_full_width": false,
+            "is_hidden": false,
+            "name": "",
+            "type": "Embeddable::Xhtml",
+            "ref_id": "272828-Embeddable::Xhtml"
+          },
+          "section": "interactive_box"
+        }
+      ]
+    },
+    {
+      "additional_sections": {},
+      "embeddable_display_mode": "stacked",
+      "is_completion": true,
+      "is_hidden": false,
+      "layout": "l-6040",
+      "name": null,
+      "position": 3,
+      "show_header": false,
+      "show_info_assessment": false,
+      "show_interactive": false,
+      "show_sidebar": false,
+      "sidebar": null,
+      "sidebar_title": "Did you know?",
+      "toggle_info_assessment": false,
+      "embeddables": []
+    }
+  ],
+  "plugins": [
+    {
+      "description": null,
+      "author_data": "{\"version\":\"1.0\",\"glossaryResourceId\":\"tbi7A3rcMmkdxZA4kHgW\",\"s3Url\":\"https://token-service-files.s3.amazonaws.com/glossary-plugin/tbi7A3rcMmkdxZA4kHgW/glossary.json\"}",
+      "approved_script_label": "glossary",
+      "component_label": "glossary",
+      "approved_script": {
+        "name": "Glossary (test offline saves)",
+        "url": "https://glossary-plugin.concord.org/branch/176579659-add-offline-saves/plugin.js",
+        "label": "glossary",
+        "description": "This plugin provides the glossary activity plugin",
+        "version": 3,
+        "json_url": "https://glossary-plugin.concord.org/branch/176579659-add-offline-saves/manifest.json",
+        "authoring_metadata": "{\"components\":[{\"label\":\"glossary\",\"name\":\"Activity\",\"scope\":\"activity\",\"guiAuthoring\":true}]}"
+      }
+    }
+  ],
+  "type": "LightweightActivity",
+  "export_site": "Lightweight Activities Runtime and Authoring"
+}

--- a/src/public/offline-manifests/glossary-test-v1.json
+++ b/src/public/offline-manifests/glossary-test-v1.json
@@ -1,0 +1,17 @@
+{
+  "name": "Glossary Test",
+  "activities": [
+    {
+      "name": "Glossary Test",
+      "resourceUrl": "https://authoring.staging.concord.org/activities/20959",
+      "contentUrl": "offline-activities/glossary-test-v1.json"
+    }
+  ],
+  "cacheList": [
+    "https://fonts.googleapis.com/css2?family=Lato:wght@400;700;900&display=swap",
+    "https://fonts.gstatic.com/s/lato/v17/S6u9w4BMUTPHh50XSwiPGQ.woff2",
+    "https://token-service-files.s3.amazonaws.com/glossary-plugin/tbi7A3rcMmkdxZA4kHgW/glossary.json",
+    "models-resources/glossary-plugin/branch/176579659-add-offline-saves/manifest.json",
+    "models-resources/glossary-plugin/branch/176579659-add-offline-saves/plugin.js"
+  ]
+}


### PR DESCRIPTION
NOTE: for now this points at the unmerged glossary branch.  We can use this activity to document how to update activities and manifests after we merge the glossary branch.