### PR TITLE
Switch from ik language code to repurposed mr code

### DIFF
--- a/src/public/glossary-files/alaska.json
+++ b/src/public/glossary-files/alaska.json
@@ -99,7 +99,7 @@
   ],
   "autoShowMediaInPopup": true,
   "translations": {
-    "ik": {
+    "mr": {
       "weather.word": "",
       "weather.word_mp3_url": "",
       "weather.definition": "",


### PR DESCRIPTION
The mr code was already being used for Inuit.  While Inupiaq has a valid language code of ik we will reuse mr to reuse the glossaries.