### PR TITLE
Switch glossary to use s3 url

### DIFF
--- a/src/public/offline-activities/glossary-test-v1.json
+++ b/src/public/offline-activities/glossary-test-v1.json
@@ -66,7 +66,7 @@
   "plugins": [
     {
       "description": null,
-      "author_data": "{\"version\":\"1.0\",\"glossaryResourceId\":\"upZ83jqTZAZuoQqRAfAb\",\"s3Url\":\"glossary-files/alaska.json\"}",
+      "author_data": "{\"version\":\"1.0\",\"glossaryResourceId\":\"upZ83jqTZAZuoQqRAfAb\",\"s3Url\":\"https://models-resources.s3.amazonaws.com/glossary-resources/custom-apo/alaska-v1.json\"}",
       "approved_script_label": "glossary",
       "component_label": "glossary",
       "approved_script": {

--- a/src/public/offline-manifests/glossary-test-v1.json
+++ b/src/public/offline-manifests/glossary-test-v1.json
@@ -59,8 +59,8 @@
     "https://fonts.gstatic.com/s/lato/v17/S6u9w4BMUTPHh50XSwiPGQ.woff2",
     "https://fonts.gstatic.com/s/lato/v17/S6u9w4BMUTPHh6UVSwiPGQ.woff2",
     "https://fonts.gstatic.com/s/lato/v17/S6uyw4BMUTPHjx4wXg.woff2",
+    "https://models-resources.s3.amazonaws.com/glossary-resources/custom-apo/alaska-v1.json",
     "models-resources/glossary-plugin/branch/176579659-add-offline-saves/manifest.json",
-    "models-resources/glossary-plugin/branch/176579659-add-offline-saves/plugin.js",
-    "glossary-files/alaska.json"
+    "models-resources/glossary-plugin/branch/176579659-add-offline-saves/plugin.js"
    ]
 }


### PR DESCRIPTION
This was done so that it isn't included in the build and it isn't rewriten to a local models-resources url so the glossary dashboard can load it.