### PR TITLE
For reference only:  Punt automatic rewrite

### DIFF
--- a/src/public/offline-activities/simple-carousel.json
+++ b/src/public/offline-activities/simple-carousel.json
@@ -70,7 +70,7 @@
               "data": {
                 "aspect_ratio_method": "DEFAULT",
                 "authoring_guidance": "",
-                "base_url": "https://models-resources.concord.org/question-interactives/branch/master/carousel/",
+                "base_url": "https://models-resources.concord.org/question-interactives/branch/append-trailing-slash-for-proxies/carousel/",
                 "click_to_play": false,
                 "click_to_play_prompt": null,
                 "description": "",

--- a/src/public/offline-manifests/simple-carousel.json
+++ b/src/public/offline-manifests/simple-carousel.json
@@ -10,14 +10,14 @@
   "cacheList": [
     "https://fonts.googleapis.com/css?family=Lato",
     "models-resources/logos/grasp-head-logo.png",
-    "models-resources/question-interactives/branch/master/carousel/",
-    "models-resources/question-interactives/branch/master/carousel/assets/index.ef6640fdbaa59e7d870c.css",
-    "models-resources/question-interactives/branch/master/carousel/assets/index.ef6640fdbaa59e7d870c.js",
-    "models-resources/question-interactives/branch/master/image/",
-    "models-resources/question-interactives/branch/master/image/assets/index.ef6640fdbaa59e7d870c.css",
-    "models-resources/question-interactives/branch/master/image/assets/index.ef6640fdbaa59e7d870c.js",
-    "models-resources/question-interactives/branch/master/open-response/",
-    "models-resources/question-interactives/branch/master/open-response/assets/index.ef6640fdbaa59e7d870c.css",
-    "models-resources/question-interactives/branch/master/open-response/assets/index.ef6640fdbaa59e7d870c.js"
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/carousel/",
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/carousel/assets/index.22798d8692a336486386.css",
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/carousel/assets/index.22798d8692a336486386.js",
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/image/",
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/image/assets/index.22798d8692a336486386.css",
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/image/assets/index.22798d8692a336486386.js",
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/open-response/",
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/open-response/assets/index.22798d8692a336486386.css",
+    "models-resources/question-interactives/branch/append-trailing-slash-for-proxies/open-response/assets/index.22798d8692a336486386.js"
   ]
 }

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -233,9 +233,10 @@ export const rewriteModelsResourcesUrl = (oldUrl: string) => {
 export const rewriteModelsResourcesUrls = (activity: Activity) => {
   // do not rewrite urls when running in Cypress, otherwise the sample activity iframes do not load causing timeouts
   if (runningInCypress) { return activity;}
-
-  walkObject(activity, (s) => rewriteModelsResourcesUrl(s));
-
+  // TODO: 2021-03-30 NP/SC — For now we are going to rewrite urls by hand...
+  // TODO: Some nested resources (image refs inside image question interactives
+  // TODO: Can't be naively rewritten.
+  // walkObject(activity, (s) => rewriteModelsResourcesUrl(s));
   return activity;
 };
 


### PR DESCRIPTION
@scytacki -- We talked about punting automatic models-resources URL rewrite. This does that.

I haven't tested it extensively.

We would merge this temporarily only if we wanted to manually rewrite URLs in the offline-activity definitions.