### PR TITLE
using val-loader to add service worker hash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22863,6 +22863,73 @@
         }
       }
     },
+    "val-loader": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/val-loader/-/val-loader-2.1.2.tgz",
+      "integrity": "sha512-slp7F4QaEE3h2dCKb28ulCkgVYqpbTcx9u/8or+lpWGOn5v7+hrQXZ+dGbblrIf2LBkVZBCiinLh7DgYO4Ds5g==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+          "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "dev": true
+        },
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "typescript": "^4.0.2",
     "url-loader": "^4.1.0",
     "utility-types": "^3.10.0",
+    "val-loader": "^2.1.2",
     "wait-on": "^5.2.0",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "build:dev": "webpack",
     "apo:dev:build": "npm-run-all clean build:dev",
     "clean": "rimraf dist",
-    "lint:others": "eslint -c \".eslintrc.build.js\" \"./src/**/*.{json,js,jsx,ts,tsx}\" --ignore-pattern \"/src/lara-plugin/**/*\" --ignore-pattern \"/src/lib/**/*\"",
+    "lint:others": "eslint -c \".eslintrc.build.js\" \"./src/**/*.{json,js,jsx,ts,tsx}\" --ignore-pattern \"/src/lara-plugin/**/*\" --ignore-pattern \"/src/lib/**/*\" --ignore-pattern \"/src/webpack-utils/**/*\" ",
     "lint:plugins": "eslint -c \"./src/lara-plugin/.eslintrc.js\" \"./src/lara-plugin\"",
     "lint:lib": "eslint -c \"./src/lib/.eslintrc.js\" \"./src/lib\"",
     "lint:build": "npm run lint:others && npm run lint:plugins && npm run lint:lib",

--- a/src/components/install-app.tsx
+++ b/src/components/install-app.tsx
@@ -7,6 +7,7 @@ import { getOfflineManifest, saveOfflineManifestToOfflineActivities,
 import { OfflineManifest } from "../types";
 import { OfflineManifestLoadingModal } from "./offline-manifest-loading-modal";
 import { queryValue } from "../utilities/url-query";
+import serviceWorkerHash from "../webpack-utils/service-worker-hash";
 
 interface IState {
   serviceWorkerVersionInfo?: string;
@@ -203,7 +204,7 @@ export class InstallApp extends React.PureComponent<IProps, IState> {
   }
 
   render() {
-    const appVersionInfo = (window as any).__appVersionInfo;
+    const appVersionInfo = (window as any).__appVersionInfo + " hash: " + serviceWorkerHash;
     const {serviceWorkerVersionInfo, offlineManifest, offlineManifestId,
       loadingOfflineManifest, installedApplicationUrls,
       installedContentUrls} = this.state;

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -10,6 +10,8 @@ import { CacheOnly, NetworkFirst } from "workbox-strategies";
 // import { CacheableResponsePlugin } from "workbox-cacheable-response";
 import { RangeRequestsPlugin } from "workbox-range-requests";
 
+import serviceWorkerHash from "./webpack-utils/service-worker-hash";
+
 const ignoredGets: RegExp[] = [
   /\/sockjs-node\/info/,                           // webpack-dev-server
   /\.hot-update\./,                                // webpack-dev-server
@@ -256,7 +258,7 @@ addEventListener("message", (event) => {
 
       case "GET_VERSION_INFO":
         console.log("Got version info request");
-        event.ports[0].postMessage(versionInfo);
+        event.ports[0].postMessage(versionInfo + " hash: " + serviceWorkerHash);
         break;
     }
   }

--- a/src/webpack-utils/.eslintrc.js
+++ b/src/webpack-utils/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    extends: "../../.eslintrc.js",
+    rules: {
+      "@typescript-eslint/no-require-imports": "off",
+    },
+    env: {
+      node: true,
+    },
+};

--- a/src/webpack-utils/service-worker-hash.js
+++ b/src/webpack-utils/service-worker-hash.js
@@ -4,7 +4,7 @@ const path = require("path");
 
 module.exports = (options, loaderContext) => {
 
-  const filePath = path.join(__dirname, "../service-worker.ts")
+  const filePath = path.join(__dirname, "../service-worker.ts");
   const hash = crypto.createHash("sha256");
   const serviceWorkerHash = hash
     .update(fs.readFileSync(filePath).toString())

--- a/src/webpack-utils/service-worker-hash.js
+++ b/src/webpack-utils/service-worker-hash.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const crypto = require("crypto");
+const path = require("path");
+
+module.exports = (options, loaderContext) => {
+
+  const filePath = path.join(__dirname, "../service-worker.ts")
+  const hash = crypto.createHash("sha256");
+  const serviceWorkerHash = hash
+    .update(fs.readFileSync(filePath).toString())
+    .digest("hex")
+    .substr(0, 8);
+
+  return {
+    code: `module.exports = "${serviceWorkerHash}"`,
+    dependencies: [
+      filePath
+    ]
+  };
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,14 @@ module.exports = (env, argv) => {
       }
     }
   };
+  const serviceWorkerHashLoader = {
+    test: /service-worker-hash.js$/,
+    use: [
+      {
+        loader: `val-loader`,
+      },
+    ],
+  };
 
   return [
     // service-worker (not auto-bundled but registered in app)
@@ -62,6 +70,7 @@ module.exports = (env, argv) => {
               replace: serviceWorkerVersionInfo,
             }
           },
+          serviceWorkerHashLoader,
           {
             test: /\.ts$/,
             loader: "ts-loader",
@@ -114,6 +123,7 @@ module.exports = (env, argv) => {
               replace: serviceWorkerVersionInfo,
             }
           },
+          serviceWorkerHashLoader,
           {
             test: /\.tsx?$/,
             loader: "ts-loader"


### PR DESCRIPTION
This isn't very pretty, but it seems to work.
Might be better to put all of the version info in the val-loader file,
then at least all of the logic is in the same place.