### PR TITLE
Fix page scrolling problem on iPads

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -1,6 +1,10 @@
 @import "./vars.scss";
 @import "./tinymce.scss";
 
+body {
+  -webkit-overflow-scrolling: touch;
+}
+
 #app {
   position: fixed;
   top: 0;


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177691426

[#177691426]

LARA applies `-webkit-overflow-scrolling: touch;` to `body` as a way to prevent the scrolling problem described in the PT story, so we've added that here.