### PR TITLE
Fix sequence drop-down nav doesn't take you to home page of activity.

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -417,7 +417,8 @@ export class App extends React.PureComponent<IProps, IState> {
     this.setState((prevState) =>
       ({ activity: prevState.sequence?.activities[activityNum],
          showSequenceIntro: false,
-         activityIndex: activityNum
+         activityIndex: activityNum,
+         currentPage: 0
       })
     );
   }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177958767

[#177958767]

In `handleSelectActivity` set `currentPage` to 0 so the selected activity always begins at its home page.