### PR TITLE
Add method for loading a specific activity in a sequence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,13 @@ Inside of your `package.json` file:
 ## Url Parameters
 ### Note: these are subject to change
 
-* activity={id|url}:    load sample-activity {id} or load json from specified url
-* sequence={id|url}:    load sample-sequence {id} or load json from specified url
-* page={n|"page_[id]"}: load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
-* themeButtons:         whether to show theme buttons
-* mode={mode}:          sets mode. Values: "teacher-edition"
-* portalReport:         override default base URL for the student report. `https://activity-player.concord.org/`, `https://activity-player-offline.concord.org/`, `https://activity-player.concord.org/version/*`, and `https://activity-player-offline.concord.org/version/*`, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
+* activity={id|url}:                  load sample-activity {id} or load json from specified url
+* sequence={id|url}:                  load sample-sequence {id} or load json from specified url
+* sequence-activity={activityNumber}: load a specific activity within a sequence, where activityNumber corresponds to the activity's placement in the order of sequenced activities. 1 = first activity, 2 = second activity, etc.
+* page={n|"page_[id]"}:               load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
+* themeButtons:                       whether to show theme buttons
+* mode={mode}:                        sets mode. Values: "teacher-edition"
+* portalReport:                       override default base URL for the student report. `https://activity-player.concord.org/`, `https://activity-player-offline.concord.org/`, `https://activity-player.concord.org/version/*`, and `https://activity-player-offline.concord.org/version/*`, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
 
 #### User data loading:
 * firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ and https://activity-player-offline.concord.org/ without a path, defaults to `report-service-pro` every other url defaults to `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.

--- a/src/components/activity-header/sequence-nav.tsx
+++ b/src/components/activity-header/sequence-nav.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CustomSelect } from "../custom-select";
 import ActivityIcon from "../../assets/svg-icons/activity-icon.svg";
+import { setQueryValue } from "../../utilities/url-query";
 
 import "./sequence-nav.scss";
 
@@ -15,14 +16,13 @@ export class SequenceNav extends React.PureComponent <IProps> {
 
   render() {
     const { activities, fullWidth, currentActivity } = this.props;
-    const indexedActivities = this.createIndexedActivitiesMap();
     return (
       <div className={`sequence-nav ${fullWidth ? "full" : ""}`} data-cy="sequence-nav-header">
         <div className="select-label">Activity:</div>
         { activities &&
           <CustomSelect
             items={activities.map((a, i) => `${i + 1}: ${a}`)}
-            value={indexedActivities.get(currentActivity)}
+            value={currentActivity}
             HeaderIcon={ActivityIcon}
             onSelectItem={this.handleSelect}
           />
@@ -42,8 +42,9 @@ export class SequenceNav extends React.PureComponent <IProps> {
     const { activities } = this.props;
     const indexedActivities = this.createIndexedActivitiesMap();
     const selectedActivity = indexedActivities.get(item);
-    const activityIndex = activities?.findIndex((activity) => activity === selectedActivity);
-    activityIndex && this.props.onActivityChange(activityIndex);
+    const activityIndex = activities?.findIndex((activity) => activity === selectedActivity) || 0;
+    activityIndex >= 0 && this.props.onActivityChange(activityIndex);
+    activityIndex >= 0 && setQueryValue("sequence-activity", activityIndex + 1);
   }
 
 }

--- a/src/components/custom-select.tsx
+++ b/src/components/custom-select.tsx
@@ -66,7 +66,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
     const currentValue = value || this.state.value;
     return (
       <div className="list-container">
-        <div className={`list ${(this.state.showList ?"show" : "")}`} data-cy="custom-select-list">
+        <div className={`list ${(this.state.showList ? "show" : "")}`} data-cy="custom-select-list">
           { items?.map((item: string, i: number) => {
             const currentClass = currentValue === item ? "selected" : "";
             return (


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178131977

[#178131977]

These changes allow you to load a specific activity within a sequence by adding a `sequence-activity` parameter to an Activity Player sequence's URL. They also add/update a `sequence-activity` param to/in the URL whenever a new activity is selected from the sequence navigation menu.