### PR TITLE
Add method for loading a specific activity in a sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Inside of your `package.json` file:
 
 * activity={id|url}:                  load sample-activity {id} or load json from specified url
 * sequence={id|url}:                  load sample-sequence {id} or load json from specified url
-* sequence-activity={activityNumber}: load a specific activity within a sequence, where activityNumber corresponds to the activity's placement in the order of sequenced activities. 1 = first activity, 2 = second activity, etc.
+* sequenceActivity={n|activity_[id]}: load activity n where n corresponds to the activity's placement in the order of sequenced activities (1 = first activity, 2 = second activity, etc.), or by the activity's unique ID
 * page={n|"page_[id]"}:               load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
 * themeButtons:                       whether to show theme buttons
 * mode={mode}:                        sets mode. Values: "teacher-edition"

--- a/README.md
+++ b/README.md
@@ -121,12 +121,13 @@ Inside of your `package.json` file:
 ## Url Parameters
 ### Note: these are subject to change
 
-* activity={id|url}:    load sample-activity {id} or load json from specified url
-* sequence={id|url}:    load sample-sequence {id} or load json from specified url
-* page={n|"page_[id]"}: load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
-* themeButtons:         whether to show theme buttons
-* mode={mode}:          sets mode. Values: "teacher-edition"
-* portalReport:         override default base URL for the student report. `https://activity-player.concord.org/`, `https://activity-player-offline.concord.org/`, `https://activity-player.concord.org/version/*`, and `https://activity-player-offline.concord.org/version/*`, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
+* activity={id|url}:                  load sample-activity {id} or load json from specified url
+* sequence={id|url}:                  load sample-sequence {id} or load json from specified url
+* sequence-activity={activityNumber}: load a specific activity within a sequence, where activityNumber corresponds to the activity's placement in the order of sequenced activities. 1 = first activity, 2 = second activity, etc.
+* page={n|"page_[id]"}:               load page n, where 0 is the activity introduction, 1 is the first page and [id] in "page_[id]" refers to an internal integer id of the page model exported from LARA.
+* themeButtons:                       whether to show theme buttons
+* mode={mode}:                        sets mode. Values: "teacher-edition"
+* portalReport:                       override default base URL for the student report. `https://activity-player.concord.org/`, `https://activity-player-offline.concord.org/`, `https://activity-player.concord.org/version/*`, and `https://activity-player-offline.concord.org/version/*`, default to a versioned URL defined as a constant in the code `kProductionPortalReportUrl`. Every other url defaults to the master branch of the portal-report.
 
 #### User data loading:
 * firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ and https://activity-player-offline.concord.org/ without a path, defaults to `report-service-pro` every other url defaults to `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.

--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -8,6 +8,11 @@ context("Test the overall app", () => {
     cy.visit("?activity=sample-activity-multiple-layout-types&preview");
     activityPage.getPage(2).click();
   });
+  describe("URL",() => {
+    it("verify URL does not include sequenceActivity param",()=>{
+      cy.url().should("not.contain", "sequenceActivity");
+    });
+  });
   describe("Sidebar",() => {
     it("verify sidebar opens",()=>{
       const content="Lorem ipsum dolor sit amet, consectetur adipiscing elit.";

--- a/cypress/integration/sequence-page.test.ts
+++ b/cypress/integration/sequence-page.test.ts
@@ -17,6 +17,30 @@ context("Test sequences", () => {
       activityPage.getHeader().should("contain", "Sequence");
       sequencePage.getThumbnails().eq(0).click();
       activityPage.getHeader().should("contain", "Sequence");
+      cy.url().should("contain", "sequence-activity=1");
+    });
+  });
+  describe("test sequence nav", () => {
+    before(() => {
+      cy.visit("?sequence=sample-sequence&preview");
+      cy.wait(1000);
+    });
+    it("should show the sequence nav menu on an activity page within the sequence", () => {
+      sequencePage.getThumbnails().should("have.length", 5);
+      sequencePage.getThumbnails().eq(0).click();
+      activityPage.getHeader().should("contain", "Sequence");
+      cy.get("[data-cy=sequence-nav-header]").should("contain", "Activity");
+      cy.get("[data-cy=custom-select-header]").should("contain", "1: Sample Sequence Activity 1");
+    });
+    it("should allow navigating between activities within the sequence", () => {
+      cy.get("[data-cy=custom-select-header]").click();
+      cy.get("[data-cy^=list-item-2]").click();
+      cy.get("[data-cy=custom-select-header]").should("contain", "2: Sample Sequence Activity 2");
+      cy.url().should("contain", "sequence-activity=2");
+      cy.get("[data-cy=custom-select-header]").click();
+      cy.get("[data-cy^=list-item-3]").click();
+      cy.get("[data-cy=custom-select-header]").should("contain", "3: Sample Sequence Activity 3");
+      cy.url().should("contain", "sequence-activity=3");
     });
   });
 });

--- a/cypress/integration/sequence-page.test.ts
+++ b/cypress/integration/sequence-page.test.ts
@@ -17,7 +17,7 @@ context("Test sequences", () => {
       activityPage.getHeader().should("contain", "Sequence");
       sequencePage.getThumbnails().eq(0).click();
       activityPage.getHeader().should("contain", "Sequence");
-      cy.url().should("contain", "sequenceActivity=1");
+      cy.url().should("contain", "sequenceActivity=activity_1");
     });
   });
   describe("test sequence nav", () => {
@@ -36,11 +36,22 @@ context("Test sequences", () => {
       cy.get("[data-cy=custom-select-header]").click();
       cy.get("[data-cy^=list-item-2]").click();
       cy.get("[data-cy=custom-select-header]").should("contain", "2: Sample Sequence Activity 2");
-      cy.url().should("contain", "sequenceActivity=2");
+      cy.url().should("contain", "sequenceActivity=activity_2");
       cy.get("[data-cy=custom-select-header]").click();
       cy.get("[data-cy^=list-item-3]").click();
       cy.get("[data-cy=custom-select-header]").should("contain", "3: Sample Sequence Activity 3");
-      cy.url().should("contain", "sequenceActivity=3");
+      cy.url().should("contain", "sequenceActivity=activity_3");
+    });
+    it("should always take you to the index page of an activity when navigating to another activity within the sequence", () => {
+      cy.get("[data-cy=custom-select-header]").click();
+      cy.get("[data-cy^=list-item-2]").click();
+      cy.get("[data-cy=custom-select-header]").should("contain", "2: Sample Sequence Activity 2");
+      cy.get("[data-cy=activity-page-links] .page-item").eq(0).click();
+      cy.get("[data-cy=custom-select-header]").click();
+      cy.get("[data-cy^=list-item-3]").click();
+      cy.get("[data-cy=custom-select-header]").should("contain", "3: Sample Sequence Activity 3");
+      cy.get("[data-cy=activity-summary]").should("exist");
+      cy.get("[data-cy=activity-summary]").should("contain", "Sample Sequence Activity 3");
     });
   });
 });

--- a/cypress/integration/sequence-page.test.ts
+++ b/cypress/integration/sequence-page.test.ts
@@ -17,7 +17,7 @@ context("Test sequences", () => {
       activityPage.getHeader().should("contain", "Sequence");
       sequencePage.getThumbnails().eq(0).click();
       activityPage.getHeader().should("contain", "Sequence");
-      cy.url().should("contain", "sequence-activity=1");
+      cy.url().should("contain", "sequenceActivity=1");
     });
   });
   describe("test sequence nav", () => {
@@ -36,11 +36,11 @@ context("Test sequences", () => {
       cy.get("[data-cy=custom-select-header]").click();
       cy.get("[data-cy^=list-item-2]").click();
       cy.get("[data-cy=custom-select-header]").should("contain", "2: Sample Sequence Activity 2");
-      cy.url().should("contain", "sequence-activity=2");
+      cy.url().should("contain", "sequenceActivity=2");
       cy.get("[data-cy=custom-select-header]").click();
       cy.get("[data-cy^=list-item-3]").click();
       cy.get("[data-cy=custom-select-header]").should("contain", "3: Sample Sequence Activity 3");
-      cy.url().should("contain", "sequence-activity=3");
+      cy.url().should("contain", "sequenceActivity=3");
     });
   });
 });

--- a/src/components/activity-header/sequence-nav.tsx
+++ b/src/components/activity-header/sequence-nav.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { CustomSelect } from "../custom-select";
 import ActivityIcon from "../../assets/svg-icons/activity-icon.svg";
+import { setQueryValue } from "../../utilities/url-query";
 
 import "./sequence-nav.scss";
 
@@ -15,14 +16,13 @@ export class SequenceNav extends React.PureComponent <IProps> {
 
   render() {
     const { activities, fullWidth, currentActivity } = this.props;
-    const indexedActivities = this.createIndexedActivitiesMap();
     return (
       <div className={`sequence-nav ${fullWidth ? "full" : ""}`} data-cy="sequence-nav-header">
         <div className="select-label">Activity:</div>
         { activities &&
           <CustomSelect
             items={activities.map((a, i) => `${i + 1}: ${a}`)}
-            value={indexedActivities.get(currentActivity)}
+            value={currentActivity}
             HeaderIcon={ActivityIcon}
             onSelectItem={this.handleSelect}
           />
@@ -42,8 +42,9 @@ export class SequenceNav extends React.PureComponent <IProps> {
     const { activities } = this.props;
     const indexedActivities = this.createIndexedActivitiesMap();
     const selectedActivity = indexedActivities.get(item);
-    const activityIndex = activities?.findIndex((activity) => activity === selectedActivity);
-    activityIndex && this.props.onActivityChange(activityIndex);
+    const activityIndex = activities?.findIndex((activity) => activity === selectedActivity) || 0;
+    activityIndex >= 0 && this.props.onActivityChange(activityIndex);
+    activityIndex >= 0 && setQueryValue("sequence-activity", activityIndex + 1);
   }
 
 }

--- a/src/components/activity-header/sequence-nav.tsx
+++ b/src/components/activity-header/sequence-nav.tsx
@@ -44,7 +44,6 @@ export class SequenceNav extends React.PureComponent <IProps> {
     const selectedActivity = indexedActivities.get(item);
     const activityIndex = activities?.findIndex((activity) => activity === selectedActivity) || 0;
     activityIndex >= 0 && this.props.onActivityChange(activityIndex);
-    activityIndex >= 0 && setQueryValue("sequenceActivity", activityIndex + 1);
   }
 
 }

--- a/src/components/activity-header/sequence-nav.tsx
+++ b/src/components/activity-header/sequence-nav.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { CustomSelect } from "../custom-select";
 import ActivityIcon from "../../assets/svg-icons/activity-icon.svg";
-import { setQueryValue } from "../../utilities/url-query";
 
 import "./sequence-nav.scss";
 

--- a/src/components/activity-header/sequence-nav.tsx
+++ b/src/components/activity-header/sequence-nav.tsx
@@ -44,7 +44,7 @@ export class SequenceNav extends React.PureComponent <IProps> {
     const selectedActivity = indexedActivities.get(item);
     const activityIndex = activities?.findIndex((activity) => activity === selectedActivity) || 0;
     activityIndex >= 0 && this.props.onActivityChange(activityIndex);
-    activityIndex >= 0 && setQueryValue("sequence-activity", activityIndex + 1);
+    activityIndex >= 0 && setQueryValue("sequenceActivity", activityIndex + 1);
   }
 
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -6,7 +6,9 @@ import { SequenceNav } from "./activity-header/sequence-nav";
 import { ActivityPageContent } from "./activity-page/activity-page-content";
 import { IntroductionPageContent } from "./activity-introduction/introduction-page-content";
 import { Footer } from "./activity-introduction/footer";
-import { ActivityLayouts, PageLayouts, numQuestionsOnPreviousPages, enableReportButton, setDocumentTitle, getPagePositionFromQueryValue, getSequenceActivityFromQueryValue } from "../utilities/activity-utils";
+import { ActivityLayouts, PageLayouts, numQuestionsOnPreviousPages, 
+         enableReportButton, setDocumentTitle, getPagePositionFromQueryValue, 
+         getSequenceActivityFromQueryValue, getSequenceActivityId } from "../utilities/activity-utils";
 import { getActivityDefinition, getSequenceDefinition } from "../lara-api";
 import { ThemeButtons } from "./theme-buttons";
 import { SinglePageContent } from "./single-page/single-page-content";
@@ -14,7 +16,8 @@ import { WarningBanner } from "./warning-banner";
 import { CompletionPageContent } from "./activity-completion/completion-page-content";
 import { queryValue, queryValueBoolean, setQueryValue } from "../utilities/url-query";
 import { fetchPortalData, IPortalData, firebaseAppName } from "../portal-api";
-import { signInWithToken, initializeDB, setPortalData, initializeAnonymousDB, onFirestoreSaveTimeout, onFirestoreSaveAfterTimeout } from "../firebase-db";
+import { signInWithToken, initializeDB, setPortalData, initializeAnonymousDB, 
+         onFirestoreSaveTimeout, onFirestoreSaveAfterTimeout } from "../firebase-db";
 import { Activity, IEmbeddablePlugin, Sequence } from "../types";
 import { initializeLara, LaraGlobalType } from "../lara-plugin/index";
 import { LaraGlobalContext } from "./lara-global-context";
@@ -111,9 +114,9 @@ export class App extends React.PureComponent<IProps, IState> {
       const sequenceActivityNum = sequence != null
                                     ? getSequenceActivityFromQueryValue(sequence, queryValue("sequenceActivity"))
                                     : 0;
-      const activityIndex = sequence && sequenceActivityNum ? sequenceActivityNum - 1 : 0;
+      const activityIndex = sequence && sequenceActivityNum ? sequenceActivityNum - 1 : undefined;
       const activityPath = queryValue("activity") || kDefaultActivity;
-      const activity: Activity = sequence != null && activityIndex >= 0
+      const activity: Activity = sequence != null && activityIndex && activityIndex >= 0
                                    ? sequence.activities[activityIndex]
                                    : await getActivityDefinition(activityPath);
 
@@ -224,7 +227,13 @@ export class App extends React.PureComponent<IProps, IState> {
     const fullWidth = (currentPage !== 0) && (activity.pages[currentPage - 1].layout === PageLayouts.Responsive);
     const glossaryEmbeddable: IEmbeddablePlugin | undefined = getGlossaryEmbeddable(activity);
     const isCompletionPage = currentPage > 0 && activity.pages[currentPage - 1].is_completion;
-    activityIndex !== undefined && activityIndex >= 0 && setQueryValue("sequenceActivity", activityIndex + 1);
+    const sequenceActivityId = sequence !== undefined ? getSequenceActivityId(sequence, activityIndex) : undefined;
+    const sequenceActivity = sequenceActivityId !== undefined 
+                               ? sequenceActivityId 
+                               : activityIndex !== undefined && activityIndex >= 0
+                                 ? activityIndex + 1
+                                 : undefined;
+    sequenceActivity !== undefined && setQueryValue("sequenceActivity", sequenceActivity);
     return (
       <React.Fragment>
         <Header

--- a/src/components/custom-select.tsx
+++ b/src/components/custom-select.tsx
@@ -66,7 +66,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
     const currentValue = value || this.state.value;
     return (
       <div className="list-container">
-        <div className={`list ${(this.state.showList ?"show" : "")}`} data-cy="custom-select-list">
+        <div className={`list ${(this.state.showList ? "show" : "")}`} data-cy="custom-select-list">
           { items?.map((item: string, i: number) => {
             const currentClass = currentValue === item ? "selected" : "";
             return (

--- a/src/components/sequence-introduction/sequence-introduction.tsx
+++ b/src/components/sequence-introduction/sequence-introduction.tsx
@@ -3,6 +3,7 @@ import { Sequence } from "../../types";
 import { Footer } from "../activity-introduction/footer";
 import { Header } from "../activity-header/header";
 import { SequencePageContent } from "../sequence-introduction/sequence-page-content";
+import { setQueryValue } from "../../utilities/url-query";
 
 interface IProps {
   sequence: Sequence | undefined;
@@ -12,6 +13,7 @@ interface IProps {
 
 export const SequenceIntroduction: React.FC<IProps> = (props) => {
   const { sequence, username, onSelectActivity } = props;
+  setQueryValue("sequenceActivity", "0");
   return (
     !sequence
     ? <div data-cy="sequence-loading">Loading</div>

--- a/src/data/sample-sequence-with-questions.json
+++ b/src/data/sample-sequence-with-questions.json
@@ -9,6 +9,7 @@
   "title": "Sample Sequence Activity Player",
   "activities": [
     {
+      "id": 1,
       "description": "",
       "editor_mode": 0,
       "layout": 0,
@@ -504,6 +505,7 @@
       "position": 1
     },
     {
+      "id": 2,
       "description": "",
       "editor_mode": 0,
       "layout": 0,

--- a/src/data/sample-sequence.json
+++ b/src/data/sample-sequence.json
@@ -9,6 +9,7 @@
   "title": "Test Sequence",
   "activities": [
     {
+      "id": 1,
       "description": "<p>This is a sequence activity.&nbsp; It should appear first.</p>",
       "editor_mode": 0,
       "layout": 0,
@@ -79,6 +80,7 @@
       "position": 1
     },
     {
+      "id": 2,
       "description": "<p>This is a sequence activity.&nbsp; It should appear second.</p>",
       "editor_mode": 0,
       "layout": 0,
@@ -131,6 +133,7 @@
       "position": 2
     },
     {
+      "id": 3,
       "description": "<p>This is a sequence activity.&nbsp; It should appear third.</p>",
       "editor_mode": 0,
       "layout": 0,
@@ -183,6 +186,7 @@
       "position": 3
     },
     {
+      "id": 4,
       "description": "<p>This is a sequence activity.&nbsp; It should appear fourth.</p>",
       "editor_mode": 0,
       "layout": 0,
@@ -253,6 +257,7 @@
       "position": 4
     },
     {
+      "id": 5,
       "description": "<p>This is a sequence activity.&nbsp; It should appear fifth.</p>",
       "editor_mode": 0,
       "layout": 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export interface Page {
 }
 
 export interface Activity {
+  id?: number | null;
   description: string | null;
   editor_mode: number;
   layout: number;

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -1,4 +1,4 @@
-import { Page, Activity, EmbeddableWrapper } from "../types";
+import { Page, Activity, EmbeddableWrapper, Sequence } from "../types";
 import { SidebarConfiguration } from "../components/page-sidebar/sidebar-wrapper";
 import { isQuestion as isEmbeddableQuestion } from "./embeddable-utils";
 
@@ -162,4 +162,23 @@ export const getPagePositionFromQueryValue = (activity: Activity, pageQueryValue
   // page should be in the range [0, <number of pages>].
   // note that page is 1 based for the actual pages in the activity.
   return Math.max(0, Math.min((parseInt(pageQueryValue, 10) || 0), activity.pages.length));
+};
+
+export const getSequenceActivityFromQueryValue = (sequence: Sequence, sequenceActivityQueryValue = "0"): number => {
+  const activityId = sequenceActivityQueryValue.startsWith("activity_") ? parseInt(sequenceActivityQueryValue.split("_")[1], 10) : NaN;
+
+  if (!isNaN(activityId)) {
+    for (const activity of sequence.activities) {
+      if (activity.id === activityId) {
+        // add 1 to the index value because we start counting sequence activities with 1
+        return sequence.activities.indexOf(activity) + 1;
+      }
+    }
+
+    // default to index page when id not found
+    return 0;
+  }
+
+  // activity should be in the range [0, <number of activities>].
+  return Math.max(0, Math.min((parseInt(sequenceActivityQueryValue, 10) || 0), sequence.activities.length));
 };

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -182,3 +182,15 @@ export const getSequenceActivityFromQueryValue = (sequence: Sequence, sequenceAc
   // activity should be in the range [0, <number of activities>].
   return Math.max(0, Math.min((parseInt(sequenceActivityQueryValue, 10) || 0), sequence.activities.length));
 };
+
+export const getSequenceActivityId = (sequence: Sequence, activityIndex: number | undefined): string | undefined => {
+  if (activityIndex !== undefined) {
+    for (const activity of sequence.activities) {
+      if (sequence.activities.indexOf(activity) === activityIndex && activity.id !== undefined) {
+        return `activity_${activity.id}`;
+      }
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178131977

[#178131977]

These changes allow you to load a specific activity within a sequence by adding a `sequence-activity` parameter to an Activity Player sequence's URL. They also add/update a `sequence-activity` param to/in the URL whenever a new activity is selected from the sequence navigation menu or sequence home page.