### PR TITLE
Non-wrapping plugins should not take up space in the header section

### DIFF
--- a/src/components/activity-page/embeddable.test.tsx
+++ b/src/components/activity-page/embeddable.test.tsx
@@ -4,7 +4,7 @@ import { Embeddable } from "./embeddable";
 import { PageLayouts, EmbeddableSections } from "../../utilities/activity-utils";
 import { mount } from "enzyme";
 import { EmbeddableWrapper, IManagedInteractive } from "../../types";
-import { DefaultManagedInteractive, DefaultXhtmlComponent } from "../../test-utils/model-for-tests";
+import { DefaultManagedInteractive, DefaultXhtmlComponent, DefaultTEWindowshadeComponent } from "../../test-utils/model-for-tests";
 
 describe("Embeddable component", () => {
   it("renders a non-callout text component", () => {
@@ -72,5 +72,31 @@ describe("Embeddable component", () => {
     expect(wrapper.find("iframe").length).toBe(1);
     expect(wrapper.find('[data-cy="iframe-runtime"]').length).toBe(1);
     expect(wrapper.html()).toContain("iframe-runtime");
+  });
+
+  it("renders nothing for a teacher edition window shade when not in teacher edition mode", () => {
+    const embeddableWrapper: EmbeddableWrapper = {
+      "embeddable": {
+        ...DefaultTEWindowshadeComponent
+      },
+      "section": "header_block"
+    };
+
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.Introduction} pluginsLoaded={true} />);
+    expect(wrapper.html()).toBe(null);
+  });
+
+  it("renders HTML for a teacher edition window shade when in teacher edition mode", () => {
+    const embeddableWrapper: EmbeddableWrapper = {
+      "embeddable": {
+        ...DefaultTEWindowshadeComponent
+      },
+      "section": "header_block"
+    };
+
+    const wrapper = mount(<Embeddable embeddableWrapper={embeddableWrapper} teacherEditionMode={true} pageLayout={PageLayouts.Responsive} pageSection={EmbeddableSections.Introduction} pluginsLoaded={true} />);
+    expect(wrapper.html()).not.toBe(null);
+    expect(wrapper.html()).toContain("embeddable");
+    expect(wrapper.html()).toContain("plugin-container");
   });
 });

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -93,6 +93,11 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
     qComponent = <div>Content type not supported</div>;
   }
 
+  // The following conditional prevents teacher edition containers from being rendered 
+  // when not in teacher edition mode. LARA handles this differently by using a mutation observer 
+  // (see https://github.com/concord-consortium/lara/blob/master/app/views/plugins/_show.haml). 
+  // It would be better to do that here as well if we update Activity Player to not use direct 
+  // dependencies on teacherEditionMode.
   if (qComponent === undefined) {
     return null;
   }

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -93,6 +93,10 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
     qComponent = <div>Content type not supported</div>;
   }
 
+  if (qComponent === undefined) {
+    return null;
+  }
+
   const fillContainerWidth = pageSection !== EmbeddableSections.Introduction &&
                              (pageLayout === PageLayouts.FortySixty ||
                               pageLayout === PageLayouts.SixtyForty ||

--- a/src/components/activity-page/plugins/embeddable-plugin.test.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.test.tsx
@@ -2,29 +2,12 @@ import React from "react";
 import { EmbeddablePlugin } from "./embeddable-plugin";
 import { shallow } from "enzyme";
 import { IEmbeddablePlugin } from "../../../types";
+import { DefaultTEWindowshadeComponent } from "../../../test-utils/model-for-tests";
 
 describe("Embeddable component", () => {
   it("renders component", () => {
     const embeddable: IEmbeddablePlugin = {
-      "plugin": {
-        "description": null,
-        "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"theoryAndBackground\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"this is a windowshade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
-        "approved_script_label": "teacherEditionTips",
-        "component_label": "windowShade",
-        "approved_script": {
-          "name": "Teacher Edition",
-          "url": "https://example.com/plugin.js",
-          "label": "teacherEditionTips",
-          "description": "Teacher Edition Plugin",
-          "version": "1.0.0",
-          "json_url": "https://example.com/manifest.json",
-          "authoring_metadata": "{}"
-        }
-      },
-      "is_hidden": false,
-      "is_full_width": false,
-      "type": "Embeddable::EmbeddablePlugin",
-      "ref_id": "2991-Embeddable::EmbeddablePlugin"
+      ...DefaultTEWindowshadeComponent
     };
     const wrapper = shallow(<EmbeddablePlugin embeddable={embeddable} pluginsLoaded={true} />);
     expect(wrapper.find('[data-cy="embeddable-plugin"]').length).toBe(1);

--- a/src/test-utils/model-for-tests.ts
+++ b/src/test-utils/model-for-tests.ts
@@ -1,4 +1,4 @@
-import { Embeddable, EmbeddableWrapper, Page, Activity, LibraryInteractive, IManagedInteractive, IEmbeddableXhtml } from "../types";
+import { Embeddable, EmbeddableWrapper, Page, Activity, LibraryInteractive, IManagedInteractive, IEmbeddableXhtml, IEmbeddablePlugin } from "../types";
 
 export const DefaultTestEmbeddable: Embeddable = {
   type: "MwInteractive",
@@ -80,4 +80,26 @@ export const DefaultXhtmlComponent: IEmbeddableXhtml = {
   is_hidden: false,
   is_full_width: false,
   is_callout: true
+};
+
+export const DefaultTEWindowshadeComponent: IEmbeddablePlugin = {
+  type: "Embeddable::EmbeddablePlugin",
+  ref_id: "123-Embeddable::EmbeddablePlugin",
+  is_hidden: false,
+  is_full_width: false,
+  plugin: {
+    description: null,
+    author_data: "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"theoryAndBackground\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"this is a windowshade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+    approved_script_label: "teacherEditionTips",
+    component_label: "windowShade",
+    approved_script: {
+      name: "Teacher Edition",
+      url: "https://example.com/plugin.js",
+      label: "teacherEditionTips",
+      description: "Teacher Edition Plugin",
+      version: "1.0.0",
+      json_url: "https://example.com/manifest.json",
+      authoring_metadata: "{}"
+    }
+  }
 };


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177732961

[#177732961]

This change makes it so an `.embeddable` wrapper DIV is not returned if the `qComponent` it would be wrapping is undefined.