### PR TITLE
TEST BRANCH: Switch glossary pluging url to test glossary v3.13.0-pre.4

### DIFF
--- a/src/public/offline-activities/glossary-test-v1.json
+++ b/src/public/offline-activities/glossary-test-v1.json
@@ -71,11 +71,11 @@
       "component_label": "glossary",
       "approved_script": {
         "name": "Glossary (test offline saves with language switcher)",
-        "url": "https://glossary-plugin.concord.org/branch/177305115-add-language-switcher/plugin.js",
+        "url": "https://glossary-plugin.concord.org/version/v3.13.0-pre.4/plugin.js",
         "label": "glossary",
         "description": "This plugin provides the glossary activity plugin",
         "version": 3,
-        "json_url": "https://glossary-plugin.concord.org/branch/177305115-add-language-switcher/manifest.json",
+        "json_url": "https://glossary-plugin.concord.org/version/v3.13.0-pre.4/manifest.json",
         "authoring_metadata": "{\"components\":[{\"label\":\"glossary\",\"name\":\"Activity\",\"scope\":\"activity\",\"guiAuthoring\":true}]}"
       }
     }

--- a/src/public/offline-manifests/glossary-test-v1.json
+++ b/src/public/offline-manifests/glossary-test-v1.json
@@ -60,7 +60,7 @@
     "https://fonts.gstatic.com/s/lato/v17/S6u9w4BMUTPHh6UVSwiPGQ.woff2",
     "https://fonts.gstatic.com/s/lato/v17/S6uyw4BMUTPHjx4wXg.woff2",
     "https://models-resources.s3.amazonaws.com/glossary-resources/custom-apo/alaska-v1.json?__noUrlRewrite",
-    "models-resources/glossary-plugin/branch/176579659-add-offline-saves/manifest.json",
-    "models-resources/glossary-plugin/branch/176579659-add-offline-saves/plugin.js"
+    "https://glossary-plugin.concord.org/version/v3.13.0-pre.4/manifest.json",
+    "https://glossary-plugin.concord.org/version/v3.13.0-pre.4/plugin.js"
    ]
 }


### PR DESCRIPTION
** DO NOT REVIEW/MERGE - this PR exists to build a version of the offline glossary that points to the logging fix build of the glossary plugin**