### PR TITLE
add plugin support when loading from sequence intro page

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -186,8 +186,9 @@ export class App extends React.PureComponent<IProps, IState> {
       this.setState(newState as IState);
 
       this.LARA = initializeLara();
-      loadLearnerPluginState(activity, teacherEditionMode).then(() => {
-        loadPluginScripts(this.LARA, activity, this.handleLoadPlugins, teacherEditionMode);
+      const activities: Activity[] = sequence ? sequence.activities : [activity];
+      loadLearnerPluginState(activities, teacherEditionMode).then(() => {
+        loadPluginScripts(this.LARA, activities, this.handleLoadPlugins, teacherEditionMode);
       });
 
       Modal.setAppElement("#app");

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -44,11 +44,13 @@ const sampleActivities: {[name: string]: Activity} = {
 import sampleSequence from "../data/sample-sequence.json";
 import sampleSequenceEmptyFields from "../data/sample-sequence-empty-fields.json";
 import sampleSequenceWithQuestions from "../data/sample-sequence-with-questions.json";
+import sampleSequenceTE from "../data/sample-sequence-te.json";
 
 const sampleSequences: {[name: string]: Sequence} = {
   "sample-sequence": sampleSequence as Sequence,
   "sample-sequence-empty-fields": sampleSequenceEmptyFields as Sequence,
   "sample-sequence-with-questions": sampleSequenceWithQuestions as Sequence,
+  "sample-sequence-te": sampleSequenceTE as Sequence,
 };
 
 export  { sampleActivities, sampleSequences };

--- a/src/data/sample-sequence-te.json
+++ b/src/data/sample-sequence-te.json
@@ -1,0 +1,285 @@
+{
+  "abstract": "",
+  "description": "",
+  "display_title": "",
+  "logo": "",
+  "runtime": "Activity Player",
+  "theme_id": null,
+  "thumbnail_url": "",
+  "title": "TE Test Sequence",
+  "project": null,
+  "activities": [
+    {
+      "description": "<p>This is a test activity which is contained within a sequence and uses the teacher edition plugin.</p>",
+      "editor_mode": 0,
+      "id": 21123,
+      "layout": 0,
+      "name": "TE Test 1",
+      "notes": "",
+      "related": "",
+      "runtime": "Activity Player",
+      "show_submit_button": true,
+      "student_report_enabled": true,
+      "thumbnail_url": "",
+      "time_to_complete": null,
+      "version": 1,
+      "theme_name": null,
+      "project": null,
+      "pages": [
+        {
+          "additional_sections": {},
+          "embeddable_display_mode": "stacked",
+          "id": 309275,
+          "is_completion": false,
+          "is_hidden": false,
+          "layout": "l-6040",
+          "name": null,
+          "position": 1,
+          "show_header": true,
+          "show_info_assessment": false,
+          "show_interactive": false,
+          "show_sidebar": false,
+          "sidebar": null,
+          "sidebar_title": "Did you know?",
+          "toggle_info_assessment": false,
+          "embeddables": [
+            {
+              "embeddable": {
+                "content": "<p>This page contains a TE windowshade.</p>",
+                "is_callout": true,
+                "is_full_width": true,
+                "is_hidden": false,
+                "name": "",
+                "type": "Embeddable::Xhtml",
+                "ref_id": "273341-Embeddable::Xhtml"
+              },
+              "section": "header_block"
+            },
+            {
+              "embeddable": {
+                "plugin": {
+                  "id": 5225,
+                  "description": null,
+                  "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"theoryAndBackground\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"This is a windowshade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+                  "approved_script_label": "teacherEditionTips",
+                  "component_label": "windowShade",
+                  "approved_script": {
+                    "name": "Teacher Edition (master)",
+                    "url": "https://teacher-edition-tips-plugin.concord.org/plugin.js",
+                    "label": "teacherEditionTips",
+                    "description": "This plugin provides Teacher Edition components",
+                    "version": 3,
+                    "json_url": "https://teacher-edition-tips-plugin.concord.org/manifest.json",
+                    "authoring_metadata": "{\"components\":[{\"label\":\"windowShade\",\"name\":\"Window Shades\",\"scope\":\"embeddable\",\"guiAuthoring\":true},{\"label\":\"sideTip\",\"name\":\"Side Tips\",\"scope\":\"embeddable\",\"guiAuthoring\":true},{\"label\":\"questionWrapper\",\"name\":\"Question Wrapper\",\"scope\":\"embeddable-decoration\",\"decorates\":[\"Embeddable::MultipleChoice\",\"Embeddable::OpenResponse\",\"Embeddable::ImageQuestion\",\"ManagedInteractive\",\"MwInteractive\",\"ImageInteractive\",\"VideoInteractive\"],\"guiAuthoring\":true,\"guiPreview\":true}]}"
+                  }
+                },
+                "is_hidden": false,
+                "is_full_width": true,
+                "type": "Embeddable::EmbeddablePlugin",
+                "ref_id": "4899-Embeddable::EmbeddablePlugin"
+              },
+              "section": "header_block"
+            }
+          ]
+        },
+        {
+          "additional_sections": {},
+          "embeddable_display_mode": "stacked",
+          "id": 309278,
+          "is_completion": false,
+          "is_hidden": false,
+          "layout": "l-6040",
+          "name": null,
+          "position": 2,
+          "show_header": true,
+          "show_info_assessment": false,
+          "show_interactive": false,
+          "show_sidebar": false,
+          "sidebar": null,
+          "sidebar_title": "Did you know?",
+          "toggle_info_assessment": false,
+          "embeddables": [
+            {
+              "embeddable": {
+                "content": "<p>This page contains a TE sidetip.</p>",
+                "is_callout": true,
+                "is_full_width": true,
+                "is_hidden": false,
+                "name": "",
+                "type": "Embeddable::Xhtml",
+                "ref_id": "273342-Embeddable::Xhtml"
+              },
+              "section": "header_block"
+            },
+            {
+              "embeddable": {
+                "plugin": {
+                  "id": 5228,
+                  "description": null,
+                  "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"This is a sidetip\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
+                  "approved_script_label": "teacherEditionTips",
+                  "component_label": "sideTip",
+                  "approved_script": {
+                    "name": "Teacher Edition (master)",
+                    "url": "https://teacher-edition-tips-plugin.concord.org/plugin.js",
+                    "label": "teacherEditionTips",
+                    "description": "This plugin provides Teacher Edition components",
+                    "version": 3,
+                    "json_url": "https://teacher-edition-tips-plugin.concord.org/manifest.json",
+                    "authoring_metadata": "{\"components\":[{\"label\":\"windowShade\",\"name\":\"Window Shades\",\"scope\":\"embeddable\",\"guiAuthoring\":true},{\"label\":\"sideTip\",\"name\":\"Side Tips\",\"scope\":\"embeddable\",\"guiAuthoring\":true},{\"label\":\"questionWrapper\",\"name\":\"Question Wrapper\",\"scope\":\"embeddable-decoration\",\"decorates\":[\"Embeddable::MultipleChoice\",\"Embeddable::OpenResponse\",\"Embeddable::ImageQuestion\",\"ManagedInteractive\",\"MwInteractive\",\"ImageInteractive\",\"VideoInteractive\"],\"guiAuthoring\":true,\"guiPreview\":true}]}"
+                  }
+                },
+                "is_hidden": false,
+                "is_full_width": true,
+                "type": "Embeddable::EmbeddablePlugin",
+                "ref_id": "4902-Embeddable::EmbeddablePlugin"
+              },
+              "section": "header_block"
+            }
+          ]
+        }
+      ],
+      "plugins": [],
+      "type": "LightweightActivity",
+      "export_site": "Lightweight Activities Runtime and Authoring",
+      "position": 1
+    },
+    {
+      "description": "<p>This is a test activity which is contained within a sequence and uses the teacher edition plugin.</p>",
+      "editor_mode": 0,
+      "id": 21124,
+      "layout": 0,
+      "name": "TE Test 2",
+      "notes": "",
+      "related": "",
+      "runtime": "Activity Player",
+      "show_submit_button": true,
+      "student_report_enabled": true,
+      "thumbnail_url": "",
+      "time_to_complete": null,
+      "version": 1,
+      "theme_name": null,
+      "project": null,
+      "pages": [
+        {
+          "additional_sections": {},
+          "embeddable_display_mode": "stacked",
+          "id": 309276,
+          "is_completion": false,
+          "is_hidden": false,
+          "layout": "l-6040",
+          "name": null,
+          "position": 1,
+          "show_header": true,
+          "show_info_assessment": false,
+          "show_interactive": false,
+          "show_sidebar": false,
+          "sidebar": null,
+          "sidebar_title": "Did you know?",
+          "toggle_info_assessment": false,
+          "embeddables": [
+            {
+              "embeddable": {
+                "content": "<p>This page contains a TE windowshade</p>",
+                "is_callout": true,
+                "is_full_width": true,
+                "is_hidden": false,
+                "name": "",
+                "type": "Embeddable::Xhtml",
+                "ref_id": "273339-Embeddable::Xhtml"
+              },
+              "section": "header_block"
+            },
+            {
+              "embeddable": {
+                "plugin": {
+                  "id": 5226,
+                  "description": null,
+                  "author_data": "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"theoryAndBackground\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"This is a window shade.\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
+                  "approved_script_label": "teacherEditionTips",
+                  "component_label": "windowShade",
+                  "approved_script": {
+                    "name": "Teacher Edition (master)",
+                    "url": "https://teacher-edition-tips-plugin.concord.org/plugin.js",
+                    "label": "teacherEditionTips",
+                    "description": "This plugin provides Teacher Edition components",
+                    "version": 3,
+                    "json_url": "https://teacher-edition-tips-plugin.concord.org/manifest.json",
+                    "authoring_metadata": "{\"components\":[{\"label\":\"windowShade\",\"name\":\"Window Shades\",\"scope\":\"embeddable\",\"guiAuthoring\":true},{\"label\":\"sideTip\",\"name\":\"Side Tips\",\"scope\":\"embeddable\",\"guiAuthoring\":true},{\"label\":\"questionWrapper\",\"name\":\"Question Wrapper\",\"scope\":\"embeddable-decoration\",\"decorates\":[\"Embeddable::MultipleChoice\",\"Embeddable::OpenResponse\",\"Embeddable::ImageQuestion\",\"ManagedInteractive\",\"MwInteractive\",\"ImageInteractive\",\"VideoInteractive\"],\"guiAuthoring\":true,\"guiPreview\":true}]}"
+                  }
+                },
+                "is_hidden": false,
+                "is_full_width": true,
+                "type": "Embeddable::EmbeddablePlugin",
+                "ref_id": "4900-Embeddable::EmbeddablePlugin"
+              },
+              "section": "header_block"
+            }
+          ]
+        },
+        {
+          "additional_sections": {},
+          "embeddable_display_mode": "stacked",
+          "id": 309277,
+          "is_completion": false,
+          "is_hidden": false,
+          "layout": "l-6040",
+          "name": null,
+          "position": 2,
+          "show_header": true,
+          "show_info_assessment": false,
+          "show_interactive": false,
+          "show_sidebar": false,
+          "sidebar": null,
+          "sidebar_title": "Did you know?",
+          "toggle_info_assessment": false,
+          "embeddables": [
+            {
+              "embeddable": {
+                "content": "<p>This page contains a TE sidetip.</p>",
+                "is_callout": true,
+                "is_full_width": true,
+                "is_hidden": false,
+                "name": "",
+                "type": "Embeddable::Xhtml",
+                "ref_id": "273340-Embeddable::Xhtml"
+              },
+              "section": "header_block"
+            },
+            {
+              "embeddable": {
+                "plugin": {
+                  "id": 5227,
+                  "description": null,
+                  "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"This is a sidetip\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
+                  "approved_script_label": "teacherEditionTips",
+                  "component_label": "sideTip",
+                  "approved_script": {
+                    "name": "Teacher Edition (master)",
+                    "url": "https://teacher-edition-tips-plugin.concord.org/plugin.js",
+                    "label": "teacherEditionTips",
+                    "description": "This plugin provides Teacher Edition components",
+                    "version": 3,
+                    "json_url": "https://teacher-edition-tips-plugin.concord.org/manifest.json",
+                    "authoring_metadata": "{\"components\":[{\"label\":\"windowShade\",\"name\":\"Window Shades\",\"scope\":\"embeddable\",\"guiAuthoring\":true},{\"label\":\"sideTip\",\"name\":\"Side Tips\",\"scope\":\"embeddable\",\"guiAuthoring\":true},{\"label\":\"questionWrapper\",\"name\":\"Question Wrapper\",\"scope\":\"embeddable-decoration\",\"decorates\":[\"Embeddable::MultipleChoice\",\"Embeddable::OpenResponse\",\"Embeddable::ImageQuestion\",\"ManagedInteractive\",\"MwInteractive\",\"ImageInteractive\",\"VideoInteractive\"],\"guiAuthoring\":true,\"guiPreview\":true}]}"
+                  }
+                },
+                "is_hidden": false,
+                "is_full_width": true,
+                "type": "Embeddable::EmbeddablePlugin",
+                "ref_id": "4901-Embeddable::EmbeddablePlugin"
+              },
+              "section": "header_block"
+            }
+          ]
+        }
+      ],
+      "plugins": [],
+      "type": "LightweightActivity",
+      "export_site": "Lightweight Activities Runtime and Authoring",
+      "position": 2
+    }
+  ],
+  "type": "Sequence",
+  "export_site": "Lightweight Activities Runtime and Authoring"
+}

--- a/src/utilities/plugin-utils.test.ts
+++ b/src/utilities/plugin-utils.test.ts
@@ -60,12 +60,12 @@ describe("Plugin utility functions", () => {
     });
 
     it("works in teacher edition mode", () => {
-      const usedPlugins = findUsedPlugins(activity, true);
+      const usedPlugins = findUsedPlugins([activity], true);
       expect(usedPlugins.map(p => p.plugin.approved_script_label)).toEqual(["teacherEditionTips", "glossary"]);
     });
 
     it("works in non teacher edition mode", () => {
-      const usedPlugins = findUsedPlugins(activity, false);
+      const usedPlugins = findUsedPlugins([activity], false);
       expect(usedPlugins.map(p => p.plugin.approved_script_label)).toEqual(["glossary"]);
     });
   });
@@ -93,13 +93,13 @@ describe("Plugin utility functions", () => {
     });
 
     it("handles teacher edition mode", () => {
-      loadPluginScripts(MockLARA, activity, handleLoadPlugins, true);
+      loadPluginScripts(MockLARA, [activity], handleLoadPlugins, true);
       expect(MockLARA.Plugins.setNextPluginLabel).toHaveBeenCalledTimes(2);
       expect(handleLoadPlugins).toHaveBeenCalledTimes(1);
     });
 
     it("handles non teacher edition mode", () => {
-      loadPluginScripts(MockLARA, activity, handleLoadPlugins, false);
+      loadPluginScripts(MockLARA, [activity], handleLoadPlugins, false);
       expect(MockLARA.Plugins.setNextPluginLabel).toHaveBeenCalledTimes(1);
       expect(handleLoadPlugins).toHaveBeenCalledTimes(1);
     });
@@ -164,12 +164,12 @@ describe("Plugin utility functions", () => {
     });
 
     it("returns the state for all plugins in teacher mode", async () => {
-      const pluginState = await loadLearnerPluginState(activity, true);
+      const pluginState = await loadLearnerPluginState([activity], true);
       expect(pluginState).toEqual(["test 1", "test 2"]);
     });
 
     it("returns the state for all plugins in non teacher mode", async () => {
-      const pluginState = await loadLearnerPluginState(activity, false);
+      const pluginState = await loadLearnerPluginState([activity], false);
       expect(pluginState).toEqual(["test 1"]);
     });
   });

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -32,31 +32,33 @@ export const addUsedPlugin = (plugin: Plugin) => {
   }
 };
 
-export const findUsedPlugins = (activity: Activity, teacherEditionMode: boolean) => {
-  // search each page for teacher edition plugin use
-  for (let page = 0; page < activity.pages.length; page++) {
-    if (!activity.pages[page].is_hidden) {
-      for (let embeddableNum = 0; embeddableNum < activity.pages[page].embeddables.length; embeddableNum++) {
-        const embeddable = activity.pages[page].embeddables[embeddableNum].embeddable;
-        if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.approved_script_label === "teacherEditionTips" && teacherEditionMode) {
-          addUsedPlugin(embeddable.plugin);
+export const findUsedPlugins = (activities: Activity[], teacherEditionMode: boolean) => {
+  // search current activity or all activities in sequence
+  activities.forEach(activity => {
+    // search each page for teacher edition plugin use
+    for (let page = 0; page < activity.pages.length; page++) {
+      if (!activity.pages[page].is_hidden) {
+        for (let embeddableNum = 0; embeddableNum < activity.pages[page].embeddables.length; embeddableNum++) {
+          const embeddable = activity.pages[page].embeddables[embeddableNum].embeddable;
+          if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.plugin?.approved_script_label === "teacherEditionTips" && teacherEditionMode) {
+            addUsedPlugin(embeddable.plugin);
+          }
         }
       }
     }
-  }
 
-  // search plugin array for glossary plugin use
-  activity.plugins.forEach((activityPlugin: Plugin) => {
-    if (activityPlugin.approved_script_label === "glossary") {
-      addUsedPlugin(activityPlugin);
-    }
+    // search plugin array for glossary plugin use
+    activity.plugins.forEach((activityPlugin: Plugin) => {
+      if (activityPlugin.approved_script_label === "glossary") {
+        addUsedPlugin(activityPlugin);
+      }
+    });
   });
-
   return usedPlugins;
 };
 
-export const loadPluginScripts = (LARA: LaraGlobalType, activity: Activity, handleLoadPlugins: () => void, teacherEditionMode: boolean) => {
-  const plugins = findUsedPlugins(activity, teacherEditionMode);
+export const loadPluginScripts = (LARA: LaraGlobalType, activities: Activity[], handleLoadPlugins: () => void, teacherEditionMode: boolean) => {
+  const plugins = findUsedPlugins(activities, teacherEditionMode);
   plugins.forEach((usedPlugin) => {
     // set plugin label
     const pluginLabel = "plugin" + usedPlugin.id;
@@ -107,8 +109,8 @@ export const validateEmbeddablePluginContextForWrappedEmbeddable =
 };
 
 // loads the learner plugin state into the firebase write-through cache
-export const loadLearnerPluginState = async (activity: Activity, teacherEditionMode: boolean) => {
-  const plugins = findUsedPlugins(activity, teacherEditionMode);
+export const loadLearnerPluginState = async (activities: Activity[], teacherEditionMode: boolean) => {
+  const plugins = findUsedPlugins(activities, teacherEditionMode);
   return await Promise.all(plugins.map(async (plugin) => await getLearnerPluginState(plugin.id)));
 };
 


### PR DESCRIPTION
This PR adds support for plugins (including things like teacher edition content) when the initial loaded content is a sequence without a current activity specified - in this case we load the sequence intro page.  Code changes now search all of the activities within the sequence to determine which plugins, if any, need to be initialized.  Previously no activity content was searched and no plugins were initialized.
Changes includes:
- new sample data
- pass array of activities to `loadLearnerPluginState` and `loadPluginScripts`.  This array is made up of all of the activities in the sequence or the current activity.
- search array of activities to determine if we need to load plugin data