### PR TITLE
Update Attachments Manager to create resources with context access rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6520,9 +6520,9 @@
       }
     },
     "@concord-consortium/token-service": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/token-service/-/token-service-2.0.0.tgz",
-      "integrity": "sha512-S85e8ZMtgazhzW7pFHDUbeG9hMUkDJqbxcGOS4jKbYMG1HfnVYqvCpxUr8xywTXwYpep8Wo+KTqnwKbiWIFPZQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/token-service/-/token-service-2.1.0.tgz",
+      "integrity": "sha512-EHlyB5FBvWz5DiEdeyFlXppKx1UFZdH5f1PnrhI8Zzg+bPizEVa7c3zrzv3Oy+fHuHOpOScZnfPmonuAluiowA=="
     },
     "@cypress/browserify-preprocessor": {
       "version": "3.0.1",
@@ -12652,7 +12652,7 @@
             },
             "ini": {
               "version": "1.3.5",
-              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+              "resolved": false,
               "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
               "dev": true,
               "optional": true

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@aws-sdk/s3-request-presigner": "^3.24.0",
     "@concord-consortium/lara-interactive-api": "^1.1.2",
     "@concord-consortium/text-decorator": "^1.0.2",
-    "@concord-consortium/token-service": "^2.0.0",
+    "@concord-consortium/token-service": "^2.1.0",
     "@react-hook/resize-observer": "^1.2.2",
     "dompurify": "^2.3.0",
     "firebase": "^8.7.0",

--- a/src/utilities/attachments-manager.ts
+++ b/src/utilities/attachments-manager.ts
@@ -54,7 +54,7 @@ export class AttachmentsManager {
       type: "s3Folder",
       name: `${this.learnerId}-${interactiveId}`,
       description: "attachment",
-      accessRuleType: this.isAnonymous() ? "readWriteToken" : "user"
+      accessRuleType: this.isAnonymous() ? "readWriteToken" : ["user", "context"]
     });
     this.resources[folderResource.id] = folderResource as S3Resource;
     return {


### PR DESCRIPTION
[#179181324]

Update Attachments Manager to create resources with context access rule, so teachers have access to students' attachments too.

This PR depends on @concord-consortium/token-service client v2.1.0. The only change in this client is to allow the client app to specify multiple access rules (https://github.com/concord-consortium/token-service/commit/08f3272c7772e26aa126f8fc99b95be8c7e1dafd). I was necessary here. I just published the new client version a moment ago. Note that the token service will automatically add "user" rule if there's only "context" specified, but I think it's better to be explicit and treat this feature as a backup option only.

Also, this means that all the attachments created up to now won't work in the teacher report. We'd need to go over all of them and add "context" access rule in Firestore manually. But since it's only on staging, I guess that's fine. Just a warning in case someone would like to test his older activity in the report (when the implementation there is ready).
