### PR TITLE
Plugin API updates to support non-hardcoded plugins

### DIFF
--- a/cypress/integration/opening-reports.test.ts
+++ b/cypress/integration/opening-reports.test.ts
@@ -36,11 +36,12 @@ context("Test Opening Portal Reports from various places", () => {
       it("verify correct link is sent to the portal report", () => {
         cy.get("[data-cy=exit-container] > .show-my-work").should("be.visible").click();
         cy.window().its("open").should("be.calledWith",
-          portalReportUrl + "?runKey=" + runKey +
+          portalReportUrl + "?firebase-app=report-service-dev" +
+            "&sourceKey=example.com" +
+            "&answersSourceKey=authoring.staging.concord.org" +
+            "&runKey=" + runKey +
             "&activity=" + activityStructureUrl +
-            "&resourceUrl=" + activityStructureUrl +
-            "&firebase-app=report-service-dev&sourceKey=example.com" +
-            "&answersSourceKey=authoring.staging.concord.org");
+            "&resourceUrl=" + activityStructureUrl);
       });
     });
     // describe("Open report from completion page", () => {

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -53,14 +53,13 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
       embeddableContainer: embeddableWrapperDivTarget.current || undefined,
       wrappedEmbeddable: embeddable,
       wrappedEmbeddableContainer: embeddableDivTarget.current || undefined,
-      sendCustomMessage,
-      approvedScriptLabel: "teacherEditionTips"
+      sendCustomMessage
     };
     const validPluginContext = validateEmbeddablePluginContextForWrappedEmbeddable(pluginContext);
-    if (validPluginContext && teacherEditionMode && pluginsLoaded) {
+    if (validPluginContext && pluginsLoaded) {
       initializePlugin(validPluginContext);
     }
-  }, [LARA, linkedPluginEmbeddable, embeddable, teacherEditionMode, pluginsLoaded]);
+  }, [LARA, linkedPluginEmbeddable, embeddable, pluginsLoaded]);
 
   useImperativeHandle(ref, () => ({
     requestInteractiveState: () => {
@@ -93,10 +92,10 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
     qComponent = <div>Content type not supported</div>;
   }
 
-  // The following conditional prevents teacher edition containers from being rendered 
-  // when not in teacher edition mode. LARA handles this differently by using a mutation observer 
-  // (see https://github.com/concord-consortium/lara/blob/master/app/views/plugins/_show.haml). 
-  // It would be better to do that here as well if we update Activity Player to not use direct 
+  // The following conditional prevents teacher edition containers from being rendered
+  // when not in teacher edition mode. LARA handles this differently by using a mutation observer
+  // (see https://github.com/concord-consortium/lara/blob/master/app/views/plugins/_show.haml).
+  // It would be better to do that here as well if we update Activity Player to not use direct
   // dependencies on teacherEditionMode.
   if (qComponent === undefined) {
     return null;

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -64,7 +64,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
     // Keep interactive state in sync if iFrame is opened in modal popup
     interactiveState.current = state;
 
-    const exportableAnswer = getAnswerWithMetadata(state, props.embeddable as IManagedInteractive, answerMeta.current);
+    const exportableAnswer = getAnswerWithMetadata(state, props.embeddable, answerMeta.current);
     if (exportableAnswer) {
       createOrUpdateAnswer(exportableAnswer);
     }

--- a/src/components/activity-page/plugins/embeddable-plugin-sidetip.test.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin-sidetip.test.tsx
@@ -7,6 +7,7 @@ describe("Embeddable Sidetip component", () => {
   it("renders component", () => {
     const embeddable: IEmbeddablePlugin = {
       "plugin": {
+        "id": 1,
         "description": null,
         "author_data": "{\"tipType\":\"sideTip\",\"sideTip\":{\"content\":\"this is a sidetip\",\"mediaType\":\"none\",\"mediaURL\":\"\"}}",
         "approved_script_label": "teacherEditionTips",

--- a/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin-sidetip.tsx
@@ -19,8 +19,7 @@ export const EmbeddablePluginSideTip: React.FC<IProps> = (props) => {
       initializePlugin({
         LARA,
         embeddable,
-        embeddableContainer: embeddableDivTarget.current,
-        approvedScriptLabel: "teacherEditionTips"
+        embeddableContainer: embeddableDivTarget.current
       });
     }
   }, [LARA, embeddable, pluginsLoaded]);

--- a/src/components/activity-page/plugins/embeddable-plugin.tsx
+++ b/src/components/activity-page/plugins/embeddable-plugin.tsx
@@ -20,7 +20,6 @@ export const EmbeddablePlugin: React.FC<IProps> = (props) => {
         LARA,
         embeddable,
         embeddableContainer: divTarget.current || undefined,
-        approvedScriptLabel: "teacherEditionTips"
       };
       const validPluginContext = validateEmbeddablePluginContextForPlugin(pluginContext);
       if (validPluginContext && pluginsLoaded) {

--- a/src/components/activity-page/plugins/glossary-plugin.test.tsx
+++ b/src/components/activity-page/plugins/glossary-plugin.test.tsx
@@ -7,6 +7,7 @@ describe("Glossary Plugin component", () => {
   it("renders component", () => {
     const embeddable: IEmbeddablePlugin = {
       "plugin": {
+        "id": 1,
         "description": null,
         "author_data": "{\"version\":\"1.0\",\"glossaryResourceId\":\"ISnn8j8r2veEFjPCx3XH\",\"s3Url\":\"https://token-service-files.s3.amazonaws.com/glossary-plugin/ISnn8j8r2veEFjPCx3XH/glossary.json\"}",
         "approved_script_label": "glossary",

--- a/src/components/activity-page/plugins/glossary-plugin.tsx
+++ b/src/components/activity-page/plugins/glossary-plugin.tsx
@@ -20,8 +20,7 @@ export const GlossaryPlugin: React.FC<IProps> = (props) => {
     const pluginContext: IPartialEmbeddablePluginContext = {
       LARA,
       embeddable,
-      embeddableContainer: divTarget.current || undefined,
-      approvedScriptLabel: "glossary"
+      embeddableContainer: divTarget.current || undefined
     };
     const validPluginContext = validateEmbeddablePluginContextForPlugin(pluginContext);
     if (validPluginContext && pluginsLoaded) {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -193,8 +193,9 @@ export class App extends React.PureComponent<IProps, IState> {
 
       this.LARA = initializeLara();
       const activities: Activity[] = sequence ? sequence.activities : [activity];
-      loadLearnerPluginState(activities, teacherEditionMode).then(() => {
-        loadPluginScripts(this.LARA, activities, this.handleLoadPlugins, teacherEditionMode);
+
+      loadLearnerPluginState(activities).then(() => {
+        loadPluginScripts(this.LARA, activities, this.handleLoadPlugins);
       });
 
       Modal.setAppElement("#app");

--- a/src/data/sample-activity-glossary-plugin-example-interactive.json
+++ b/src/data/sample-activity-glossary-plugin-example-interactive.json
@@ -621,6 +621,7 @@
   ],
   "plugins": [
     {
+      "id": 21,
       "description": null,
       "author_data": "{\"version\":\"1.0\",\"glossaryResourceId\":\"ISnn8j8r2veEFjPCx3XH\",\"s3Url\":\"https://token-service-files.s3.amazonaws.com/glossary-plugin/ISnn8j8r2veEFjPCx3XH/glossary.json\"}",
       "approved_script_label": "glossary",

--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -4,6 +4,7 @@ import { DefaultManagedInteractive } from "./test-utils/model-for-tests";
 import { getAnswerWithMetadata } from "./utilities/embeddable-utils";
 import { IExportableAnswerMetadata } from "./types";
 import firebase from "firebase/app";
+import { RawClassInfo } from "./portal-api";
 import "firebase/firestore";
 
 describe("Firestore", () => {
@@ -88,7 +89,8 @@ describe("Firestore", () => {
       resourceUrl: "http://example/resource",
       toolId: "activity-player.concord.org",
       userType: "learner",
-      runRemoteEndpoint: "https://example.com/learner/1234"
+      runRemoteEndpoint: "https://example.com/learner/1234",
+      rawClassInfo: {} as RawClassInfo
     });
 
     const embeddable = {
@@ -250,7 +252,8 @@ describe("Firestore", () => {
             class_info_url: "http://example.com/4",
             offering_id: 8
           },
-          runRemoteEndpoint: "http://example.com/5"
+          runRemoteEndpoint: "http://example.com/5",
+          rawClassInfo: {} as RawClassInfo
         });
       });
 

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -145,7 +145,7 @@ export const setAnonymousPortalData = (_portalData: IAnonymousPortalData) => {
 
 type DocumentsListener = (docs: firebase.firestore.DocumentData[]) => void;
 
-const watchAnswerDocs = (listener: DocumentsListener, questionId?: string) => {
+const getAnswerDocsQuery = (questionId?: string) => {
   if (!portalData) {
     throw new Error("Must set portal data first");
   }
@@ -167,7 +167,11 @@ const watchAnswerDocs = (listener: DocumentsListener, questionId?: string) => {
   if (questionId) {
     query = query.where("question_id", "==", questionId);
   }
+  return query;
+};
 
+const watchAnswerDocs = (listener: DocumentsListener, questionId?: string) => {
+  const query = getAnswerDocsQuery(questionId);
   // Note that query.onSnapshot returns unsubscribe method.
   return query.onSnapshot((snapshot: firebase.firestore.QuerySnapshot<firebase.firestore.DocumentData>) => {
     if (!snapshot.empty) {
@@ -182,6 +186,17 @@ const watchAnswerDocs = (listener: DocumentsListener, questionId?: string) => {
   });
 };
 
+const getAnswerDocs = (questionId?: string) => {
+  const query = getAnswerDocsQuery(questionId);
+  // Note that query.onSnapshot returns unsubscribe method.
+  return query.get().then(snapshot => {
+    if (!snapshot.empty) {
+      return snapshot.docs.map(doc => doc.data());
+    }
+    return [];
+  });
+};
+
 const firestoreDocToWrappedAnswer = (doc: firebase.firestore.DocumentData) => {
   const getInteractiveState = () => {
     const reportState = JSON.parse(doc.report_state);
@@ -193,6 +208,30 @@ const firestoreDocToWrappedAnswer = (doc: firebase.firestore.DocumentData) => {
     interactiveState
   };
   return wrappedAnswer;
+};
+
+export const getAnswer = (embeddableRefId: string): Promise<WrappedDBAnswer | null> => {
+  const questionId = refIdToAnswersQuestionId(embeddableRefId);
+  return getAnswerDocs(questionId)
+    .then((answers: firebase.firestore.DocumentData[]) => {
+      if (answers.length === 0) {
+        return null;
+      }
+      if (answers.length > 1) {
+        console.warn(
+          "Found multiple answer objects for the same question. It might be result of early " +
+          "ActivityPlayer versions. Your data might be corrupted."
+        );
+      }
+      return firestoreDocToWrappedAnswer(answers[0]);
+    });
+};
+
+export const getAllAnswers = (): Promise<WrappedDBAnswer[]>  => {
+  return getAnswerDocs()
+    .then((answers: firebase.firestore.DocumentData[]) =>
+      answers.map(doc => firestoreDocToWrappedAnswer(doc))
+    );
 };
 
 // Watches ONE question answer defined by embeddableRefId.

--- a/src/lara-plugin/plugin-api/types.ts
+++ b/src/lara-plugin/plugin-api/types.ts
@@ -127,6 +127,13 @@ export interface IEmbeddableRuntimeContext {
    @param message The message to be sent
    ****************************************************************************/
   sendCustomMessage: (message: ICustomMessage) => void;
+  /****************************************************************************
+   Function that enables or disables sharing of the embeddable answer with the whole class.
+   Returns promise that resolves when update is complete.
+
+   @param shared true enables sharing with class, false disables it
+   ****************************************************************************/
+   setAnswerSharedWithClass: (shared: boolean) => Promise<void>;
 }
 
 export interface IPluginAuthoringContext {

--- a/src/portal-types.ts
+++ b/src/portal-types.ts
@@ -1,4 +1,5 @@
 import { FirebaseAppName } from "./firebase-db";
+import { RawClassInfo } from "./portal-api";
 
 export interface ILTIPartial {
   platformId: string;      // portal
@@ -49,6 +50,7 @@ export interface IPortalData extends ILTIPartial {
   rawPortalJWT?: string;
   portalJWT?: PortalJWT;
   runRemoteEndpoint: string;
+  rawClassInfo: RawClassInfo;
 }
 
 export interface IAnonymousPortalData {

--- a/src/test-utils/model-for-tests.ts
+++ b/src/test-utils/model-for-tests.ts
@@ -97,6 +97,7 @@ export const DefaultTEWindowshadeComponent: IEmbeddablePlugin = {
   is_hidden: false,
   is_full_width: false,
   plugin: {
+    id: 12,
     description: null,
     author_data: "{\"tipType\":\"windowShade\",\"windowShade\":{\"windowShadeType\":\"theoryAndBackground\",\"layout\":\"mediaLeft\",\"initialOpenState\":true,\"content\":\"this is a windowshade\",\"content2\":\"\",\"mediaType\":\"none\",\"mediaCaption\":\"Last, First. \\\"Title of Work.\\\" Year created. Site Title [OR] Publisher. Gallery [OR] Location. http://www.url.com.\",\"mediaURL\":\"\"}}",
     approved_script_label: "teacherEditionTips",

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface ApprovedScript {
 }
 
 export interface Plugin {
+  id: number;
   description: string | null;
   author_data: string;
   approved_script_label: string;
@@ -236,6 +237,8 @@ export interface IExportableAnswerMetadataBase {
   report_state: string;
   // tracks the most recently written details for each attachment
   attachments?: Record<string, IReadableAttachmentInfo>;
+  // allows sharing answer with other students in the same class
+  shared_with?: "context" | null;
 }
 
 export interface IExportableInteractiveAnswerMetadata extends IExportableAnswerMetadataBase {

--- a/src/utilities/embeddable-utils.ts
+++ b/src/utilities/embeddable-utils.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import { IRuntimeMetadata } from "@concord-consortium/lara-interactive-api";
 import {
-  IExportableAnswerMetadata, IManagedInteractive, IReportState, IExportableMultipleChoiceAnswerMetadata,
+  IExportableAnswerMetadata, IReportState, IExportableMultipleChoiceAnswerMetadata,
   IExportableOpenResponseAnswerMetadata, IExportableInteractiveAnswerMetadata, IExportableImageQuestionAnswerMetadata,
   Embeddable
 } from "../types";
@@ -37,8 +37,8 @@ export const questionType = (rawAuthoredState: string | null | undefined): strin
 
 export const getAnswerWithMetadata = (
     interactiveState: unknown,
-    embeddable: IManagedInteractive,
-    oldAnswerMeta?: IExportableAnswerMetadata): (IExportableAnswerMetadata | void) => {
+    embeddable: {ref_id: string, authored_state?: string | null},
+    oldAnswerMeta?: IExportableAnswerMetadata): IExportableAnswerMetadata => {
 
   const reportState: IReportState = {
     mode: "report",

--- a/src/utilities/get-attachments-manager-options.test.ts
+++ b/src/utilities/get-attachments-manager-options.test.ts
@@ -1,3 +1,4 @@
+import { RawClassInfo } from "../portal-api";
 import { IAnonymousPortalData, IPortalData } from "../portal-types";
 import { getAttachmentsManagerOptions } from "./get-attachments-manager-options";
 
@@ -64,7 +65,8 @@ describe("getAttachmentsManagerOptions", () => {
       },
       basePortalUrl: mockBasePortalUrl,
       rawPortalJWT: mockRawPortalJWT,
-      runRemoteEndpoint: mockRunRemoteEndpoint
+      runRemoteEndpoint: mockRunRemoteEndpoint,
+      rawClassInfo: {} as RawClassInfo
     };
 
     it("returns correct options based on Portal data", async () => {

--- a/src/utilities/report-utils.test.ts
+++ b/src/utilities/report-utils.test.ts
@@ -34,12 +34,13 @@ describe("getReportUrl", () => {
 
       expect(reportURL).toEqual(
         kDevPortalReportUrl
-        + "?runKey=" + runKey
-        + "&activity=https://lara.example.com/activities/345"
-        + "&resourceUrl=https://lara.example.com/activities/345"
-        + "&firebase-app=report-service-dev"
+        + "?firebase-app=report-service-dev"
         + "&sourceKey=lara.example.com"
         + "&answersSourceKey=activity-player.unexisting.url.com"
+        + "&runKey=" + runKey
+        + "&activity=https://lara.example.com/activities/345"
+        + "&resourceUrl=https://lara.example.com/activities/345"
+
       );
     });
 
@@ -50,12 +51,12 @@ describe("getReportUrl", () => {
 
       expect(reportURL).toEqual(
         kDevPortalReportUrl
-        + "?runKey=" + runKey
-        + "&activity=https://lara.example.com/activities/345"
-        + "&resourceUrl=https://lara.example.com/activities/345"
-        + "&firebase-app=report-service-dev"
+        + "?firebase-app=report-service-dev"
         + "&sourceKey=lara.example.com"
         + "&answersSourceKey=activity-player.unexisting.url.com"
+        + "&runKey=" + runKey
+        + "&activity=https://lara.example.com/activities/345"
+        + "&resourceUrl=https://lara.example.com/activities/345"
       );
     });
 
@@ -66,18 +67,17 @@ describe("getReportUrl", () => {
 
       expect(reportURL).toEqual(
         kDevPortalReportUrl
-        + "?runKey=" + runKey
-        + "&activity=https://lara.example.com/activities/345"
-        + "&resourceUrl=https://lara.example.com/activities/345"
-        + "&firebase-app=report-service-pro"
+        + "?firebase-app=report-service-pro"
         + "&sourceKey=lara.example.com"
         + "&answersSourceKey=activity-player.unexisting.url.com"
+        + "&runKey=" + runKey
+        + "&activity=https://lara.example.com/activities/345"
+        + "&resourceUrl=https://lara.example.com/activities/345"
       );
     });
   });
 
   describe("without a run key" , () => {
-
     it("returns a valid reportURL", () => {
       window.history.replaceState({}, "Test", basicParams);
 
@@ -85,13 +85,13 @@ describe("getReportUrl", () => {
 
       expect(reportURL).toEqual(
         kDevPortalReportUrl
-        + "?class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
-        + "&firebase-app=report-service-dev"
+        + "?firebase-app=report-service-dev"
+        + "&sourceKey=lara.example.com"
+        + "&answersSourceKey=activity-player.unexisting.url.com"
+        + "&class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
         + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
         + "&reportType=offering"
         + "&studentId=abc345"
-        + "&sourceKey=lara.example.com"
-        + "&answersSourceKey=activity-player.unexisting.url.com"
         + "&auth-domain=https://example.com");
     });
 
@@ -101,14 +101,35 @@ describe("getReportUrl", () => {
 
       expect(reportURL).toEqual(
         kDevPortalReportUrl
-        + "?class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
-        + "&firebase-app=report-service-pro"
+        + "?firebase-app=report-service-pro"
+        + "&sourceKey=lara.example.com"
+        + "&answersSourceKey=activity-player.unexisting.url.com"
+        + "&class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
         + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
         + "&reportType=offering"
         + "&studentId=abc345"
+        + "&auth-domain=https://example.com");
+    });
+  });
+
+  describe("when iframeQuestionId is provided" , () => {
+
+    it("returns a valid reportURL", () => {
+      window.history.replaceState({}, "Test", basicParams);
+
+      const reportURL = getReportUrl("mw_interactive_123");
+
+      expect(reportURL).toEqual(
+        kDevPortalReportUrl
+        + "?firebase-app=report-service-dev"
         + "&sourceKey=lara.example.com"
         + "&answersSourceKey=activity-player.unexisting.url.com"
-        + "&auth-domain=https://example.com");
+        + "&class=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fclasses%2F123"
+        + "&offering=https%3A%2F%2Fexample.com%2Fapi%2Fv1%2Fofferings%2Foffering-123"
+        + "&reportType=offering"
+        + "&studentId=abc345"
+        + "&auth-domain=https://example.com"
+        + "&iframeQuestionId=mw_interactive_123");
     });
   });
 });

--- a/src/utilities/report-utils.ts
+++ b/src/utilities/report-utils.ts
@@ -4,6 +4,7 @@ import { firebaseAppName } from "../portal-api";
 import { IPortalData } from "../portal-types";
 import { getCanonicalHostname, isProductionOrigin } from "./host-utils";
 import { getResourceUrl } from "../lara-api";
+import { refIdToAnswersQuestionId } from "./embeddable-utils";
 
 // *** IMPORTANT NOTE ***
 // When you change these URLs you need to edit the portal-report Auth Client in
@@ -46,24 +47,26 @@ const makeSourceKey = (url: string | null) => {
   return url ? parseUrl(url.toLowerCase()).hostname : "";
 };
 
-export const getReportUrl = () => {
+export const getReportUrl = (questionRefId?: string) => {
   const reportLink = portalReportBaseUrl();
   const reportFirebaseApp = firebaseAppName();
   const resourceUrl = getResourceUrl();
-  const runKey= queryValue("runKey");
+  const runKey = queryValue("runKey");
   // Sometimes the location of the answers is overridden with a report-source param
   const answerSource = queryValue("report-source") || getCanonicalHostname();
-  const sourceKey = resourceUrl ? makeSourceKey(resourceUrl) : getCanonicalHostname();
+  // `sourceKey` might be useful to add during local development, usually to point to app.lara.docker.<username>
+  // since local LARA instance would be publish resources at this path.
+  const sourceKey = queryValue("sourceKey") || (resourceUrl ? makeSourceKey(resourceUrl) : getCanonicalHostname());
+
+  let result = reportLink
+    + "?firebase-app="+reportFirebaseApp
+    + "&sourceKey="+sourceKey
+    + "&answersSourceKey="+answerSource;
 
   if (runKey) {
-    return reportLink
-            + "?"
-            + "runKey=" + runKey
+    result += "&runKey=" + runKey
             + "&activity=" + resourceUrl
-            + "&resourceUrl=" + resourceUrl
-            + "&firebase-app="+reportFirebaseApp
-            + "&sourceKey="+sourceKey
-            + "&answersSourceKey="+answerSource;
+            + "&resourceUrl=" + resourceUrl;
   }
   else {
     // We know this is a IPortalData because there is no runKey
@@ -75,19 +78,21 @@ export const getReportUrl = () => {
     const offeringUrl = encodeURIComponent(offeringBaseUrl + offeringId);
     const studentId = portalData?.platformUserId;
 
-    return reportLink
-            + "?"
-            // In the future we should be able to drop this because the portal
-            // report should be able to get all the info it needs from the
-            // offering url
-            + "class=" + encodeURIComponent(classInfoUrl || "")
-            + "&firebase-app="+reportFirebaseApp
+    // In the future we should be able to drop this because the portal
+    // report should be able to get all the info it needs from the
+    // offering url
+    result += "&class=" + encodeURIComponent(classInfoUrl || "")
             + "&offering=" + offeringUrl
             + "&reportType=offering&studentId="+studentId
-            + "&sourceKey="+sourceKey
-            + "&answersSourceKey="+answerSource
             + "&auth-domain="+authDomainUrl;
   }
+
+  if (questionRefId) {
+    // Limit report to a single question.
+    result += "&iframeQuestionId=" + refIdToAnswersQuestionId(questionRefId);
+  }
+
+  return result;
 };
 
 export const showReport = () => {


### PR DESCRIPTION
This PR adds missing Plugin APIs, removes hardcoded references to plugin labels, and tries to refactor or fix some pieces. My attempt to support Sharing Plugin and other non-hardcoded plugins. If there's ever more time to refactor things, I'd try to remove all the hardcoded plugin references. I don't understand why it ended up being implemented that way. But maybe I'm just missing some issues, and this PR that partially removes that, causes some issues I'm not aware of.

I was testing it locally using an activity with Teacher Edition tips, Glossary and Sharing Plugin. It seems to work for me. Note that:
- I've removed references to all the plugin labels like "glossary", "teacherEditionTips", etc. That way multiple plugins types can be loaded. But I don't know why it was implemented before and if I'm not breaking something.
- I've removed checking if we're in the TeacherEdition mode in the AP. Teacher Edition plugin does it itself, so I don't know why AP was doing it. Again, am I breaking something?

There's an issue that I've commented on, but didn't try to fix, as I'm worried it'd break student data:
https://www.pivotaltracker.com/story/show/179634819
If there's no production data yet, I'd recommend fixing that, as it's gonna be more difficult to fix it later.

Also, I think that AP won't support two plugins wrapping the same interactive (for example TE and Sharing):
https://www.pivotaltracker.com/story/show/179634899