### PR TITLE
179466149 increase coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Inside of your `package.json` file:
 * firebaseApp={id}:  override default firebase app. https://activity-player.concord.org/ and https://activity-player-offline.concord.org/ without a path, defaults to `report-service-pro` every other url defaults to `report-service-dev`. For example https://activity-player.concord.org/branch/foo will use `report-service-dev` by default.
 * token={n}:         set by the portal when launching external activity, to authenticate with portal API
 * domain={n}:        set by the portal when launching external activity
-* report-source={id}: which source collection to save data to in firestore (defaults to own hostname)
+* answersSourceKey={id}: which source collection to save data to in firestore (defaults to own hostname)
 * runkey={uuid}:     set by the app if we are running in anonymous datasaving mode
 * preview:           prevent running in anonymous datasaving mode
 * enableFirestorePersistence: uses local offline firestore cache only

--- a/cypress.json
+++ b/cypress.json
@@ -6,5 +6,12 @@
   "fixturesFolder": "src/data",
   "defaultCommandTimeout": 8000,
   "projectId": "etatiy",
-  "chromeWebSecurity": false
+  "chromeWebSecurity": false,
+  "env": {
+    "portal_domain": "https://learn.staging.concord.org",
+    "portal_launch_path": "/users/5465/portal/offerings/2044.run_resource_html",
+    "portal_username": "scypress",
+    "portal_password": "cypress",
+    "answers_source_key": "cypress-test"
+  }
 }

--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -1,5 +1,5 @@
 import ActivityPage from "../support/elements/activity-page";
-import { getIframeBody } from "../support/elements/iframe";
+import { getInIframe } from "../support/elements/iframe";
 
 const activityPage = new ActivityPage;
 
@@ -52,8 +52,7 @@ context("Test the overall app", () => {
     it("verify we can load a managed interactive",()=>{
       cy.visit("?activity=sample-activity-1&preview");
       activityPage.getNavPage(2).click();
-      cy.wait(500);
-      getIframeBody("body").find("[data-cy=choices-container]").should("be.visible");
+      getInIframe("body", "[data-cy=choices-container]").should("be.visible");
     });
   });
   describe("Hidden pages",()=>{

--- a/cypress/integration/data-saving-anonymous.ts
+++ b/cypress/integration/data-saving-anonymous.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import ActivityPage from "../support/elements/activity-page";
-import { getIframeBody } from "../support/elements/iframe";
+import { getInIframe } from "../support/elements/iframe";
 
 const activityPage = new ActivityPage;
 
@@ -28,8 +28,7 @@ context("Saving and loading data as an anonymous user", () => {
 
       cy.visit(activityUrlWithRunKey + "&clearFirestorePersistence");
       activityPage.getNavPage(2).click();
-      cy.wait(1000);
-      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).click({force: true});
+      getInIframe("body", "[data-cy=choices-container] input").eq(1).click({force: true});
 
       // unfortunately we have to wait for the data to be posted to firestore, which happens after a
       // delay to prevent spamming the database.
@@ -42,8 +41,7 @@ context("Saving and loading data as an anonymous user", () => {
       // this should force the activity player to load the data back in from the runKey
       cy.visit(activityUrlWithRunKey);
       activityPage.getNavPage(2).click();
-      cy.wait(1000);
-      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).should("be.checked");
+      getInIframe("body", "[data-cy=choices-container] input").eq(1).should("be.checked");
     });
 
     it("we can remove a runKey and we will no longer see our data", () => {
@@ -52,8 +50,7 @@ context("Saving and loading data as an anonymous user", () => {
       // Answer the question
       cy.visit(activityUrlWithRunKey + "&clearFirestorePersistence");
       activityPage.getNavPage(2).click();
-      cy.wait(1000);
-      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).click({force: true});
+      getInIframe("body", "[data-cy=choices-container] input").eq(1).click({force: true});
 
       // unfortunately we have to wait for the data to be posted to firestore, which happens after a
       // delay to prevent spamming the database.
@@ -65,14 +62,12 @@ context("Saving and loading data as an anonymous user", () => {
       // Make sure the answer is actually saved in storage
       cy.visit(activityUrlWithRunKey);
       activityPage.getNavPage(2).click();
-      cy.wait(1000);
-      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).should("be.checked");
+      getInIframe("body", "[data-cy=choices-container] input").eq(1).should("be.checked");
 
       // Look at the page without a runKey
       cy.visit(activityUrl);
       activityPage.getNavPage(2).click();
-      cy.wait(1000);
-      getIframeBody("body").find("[data-cy=choices-container] input").eq(1).should("not.be.checked");
+      getInIframe("body", "[data-cy=choices-container] input").eq(1).should("not.be.checked");
     });
   });
 });

--- a/cypress/integration/opening-reports.test.ts
+++ b/cypress/integration/opening-reports.test.ts
@@ -13,7 +13,7 @@ context("Test Opening Portal Reports from various places", () => {
     const activityPlayerUrl = "?" +
       "activity="+activityExportUrl+
       "resourceUrl="+activityExportUrl+
-      "&report-source=authoring.staging.concord.org" +
+      "&answersSourceKey=authoring.staging.concord.org" +
       "&runKey="+runKey;
 
     before(() => {

--- a/cypress/integration/portal-launch.test.ts
+++ b/cypress/integration/portal-launch.test.ts
@@ -1,0 +1,72 @@
+context("Launch AP From the Portal", () => {
+  /*
+    Because cypress can't jump domains this uses cy.request to log into the portal as a student.
+    Then ask the portal to launch an assignment, that already exists in the portal.
+    This gives us a redirect URL that we can modify and cypress can visit,
+    and then check if things load properly.
+
+    Note this is going to put some bogus data into the report-service-dev database.
+    It will have properties that match the portal assignment, but the saved answers
+    will be from a different activity. The answersSourceKey is set so this bogus data
+    doesn't conflict with any real answers from the portal assignment.
+  */
+  describe("Loading sample activity", () => {
+    beforeEach(() => {
+      /* 
+        Cookies should be cleared automatically, but that doesn't seem to happen
+        with cy.request to other domains.
+        The use of {domain: null} is an undocumented feature that I found here:
+        https://github.com/cypress-io/cypress/issues/408
+        Without this, the tests will typically pass, but if you leave your cypress browser
+        open long enough, then an invalid cookie will be sent when the test is run and
+        the login will fail in a strange way. It returns success, but doesn't set a valid
+        cookie.
+      */
+      cy.clearCookies({domain: null});
+
+      const portalDomain = Cypress.env("portal_domain");
+      const portalUsername = Cypress.env("portal_username");
+      const portalPassword = Cypress.env("portal_password");
+      const portalLaunchPath = Cypress.env("portal_launch_path");
+
+      // Login as a student
+      cy.request({
+        url: `${portalDomain}/api/v1/users/sign_in`,
+        method: "POST",
+        body: {
+          "user[login]": portalUsername,
+          "user[password]": portalPassword
+        },
+        form: true
+      })
+      .its("status").should("equal", 200);
+
+      // Run an AP assignment, in order to get the params from the portal
+      cy.request({
+        url: `${portalDomain}${portalLaunchPath}`,
+        method: "GET",
+        followRedirect: false
+      })
+      .then((resp) => {
+        expect(resp.status).to.eq(302);
+        expect(resp.redirectedToUrl).to.match(/^https:\/\/activity-player\.concord\.org/)
+        const url = new URL(resp.redirectedToUrl);
+        var params = new URLSearchParams(url.search);
+        return params.get("token");
+      })
+      .as("portalToken");
+
+    });
+
+    // A regular 'function' syntax is used instead '=>' so cypress can control what
+    // 'this' is
+    it("can open one sample activity", function () {
+      const portalDomain = Cypress.env("portal_domain");
+      const answersSourceKey = Cypress.env("answers_source_key");
+
+      cy.visit(`?activity=sample-activity-1&token=${this.portalToken}` +
+        `&domain=${portalDomain}/&answersSourceKey=${answersSourceKey}`);
+      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+    });
+  });
+});

--- a/cypress/integration/portal-launch.test.ts
+++ b/cypress/integration/portal-launch.test.ts
@@ -1,3 +1,8 @@
+import ActivityPage from "../support/elements/activity-page";
+import { getInIframe } from "../support/elements/iframe";
+
+const activityPage = new ActivityPage;
+
 context("Launch AP From the Portal", () => {
   /*
     Because cypress can't jump domains this uses cy.request to log into the portal as a student.
@@ -10,63 +15,97 @@ context("Launch AP From the Portal", () => {
     will be from a different activity. The answersSourceKey is set so this bogus data
     doesn't conflict with any real answers from the portal assignment.
   */
-  describe("Loading sample activity", () => {
-    beforeEach(() => {
-      /* 
-        Cookies should be cleared automatically, but that doesn't seem to happen
-        with cy.request to other domains.
-        The use of {domain: null} is an undocumented feature that I found here:
-        https://github.com/cypress-io/cypress/issues/408
-        Without this, the tests will typically pass, but if you leave your cypress browser
-        open long enough, then an invalid cookie will be sent when the test is run and
-        the login will fail in a strange way. It returns success, but doesn't set a valid
-        cookie.
-      */
-      cy.clearCookies({domain: null});
+  beforeEach(() => {
+    /*
+      Cookies should be cleared automatically, but that doesn't seem to happen
+      with cy.request to other domains.
+      The use of {domain: null} is an undocumented feature that I found here:
+      https://github.com/cypress-io/cypress/issues/408
+      Without this, the tests will typically pass, but if you leave your cypress browser
+      open long enough, then an invalid cookie will be sent when the test is run and
+      the login will fail in a strange way. It returns success, but doesn't set a valid
+      cookie.
+    */
+    cy.clearCookies({domain: null});
 
-      const portalDomain = Cypress.env("portal_domain");
-      const portalUsername = Cypress.env("portal_username");
-      const portalPassword = Cypress.env("portal_password");
-      const portalLaunchPath = Cypress.env("portal_launch_path");
+    const portalDomain = Cypress.env("portal_domain");
+    const portalUsername = Cypress.env("portal_username");
+    const portalPassword = Cypress.env("portal_password");
+    const portalLaunchPath = Cypress.env("portal_launch_path");
 
-      // Login as a student
-      cy.request({
-        url: `${portalDomain}/api/v1/users/sign_in`,
-        method: "POST",
-        body: {
-          "user[login]": portalUsername,
-          "user[password]": portalPassword
-        },
-        form: true
-      })
-      .its("status").should("equal", 200);
+    // Login as a student
+    cy.request({
+      url: `${portalDomain}/api/v1/users/sign_in`,
+      method: "POST",
+      body: {
+        "user[login]": portalUsername,
+        "user[password]": portalPassword
+      },
+      form: true
+    })
+    .its("status").should("equal", 200);
 
-      // Run an AP assignment, in order to get the params from the portal
-      cy.request({
-        url: `${portalDomain}${portalLaunchPath}`,
-        method: "GET",
-        followRedirect: false
-      })
-      .then((resp) => {
-        expect(resp.status).to.eq(302);
-        expect(resp.redirectedToUrl).to.match(/^https:\/\/activity-player\.concord\.org/)
-        const url = new URL(resp.redirectedToUrl);
-        var params = new URLSearchParams(url.search);
-        return params.get("token");
-      })
-      .as("portalToken");
+    // Run an AP assignment, in order to get the params from the portal
+    cy.request({
+      url: `${portalDomain}${portalLaunchPath}`,
+      method: "GET",
+      followRedirect: false
+    })
+    .then((resp) => {
+      expect(resp.status).to.eq(302);
+      expect(resp.redirectedToUrl).to.match(/^https:\/\/activity-player\.concord\.org/)
+      const url = new URL(resp.redirectedToUrl);
+      var params = new URLSearchParams(url.search);
+      return params.get("token");
+    })
+    .as("portalToken");
 
-    });
+  });
 
-    // A regular 'function' syntax is used instead '=>' so cypress can control what
-    // 'this' is
-    it("can open one sample activity", function () {
-      const portalDomain = Cypress.env("portal_domain");
-      const answersSourceKey = Cypress.env("answers_source_key");
+  // A regular 'function' syntax is used instead '=>' so cypress can control what
+  // 'this' is
+  it("can open a sample activity", function () {
+    const portalDomain = Cypress.env("portal_domain");
+    const answersSourceKey = Cypress.env("answers_source_key");
 
-      cy.visit(`?activity=sample-activity-1&token=${this.portalToken}` +
-        `&domain=${portalDomain}/&answersSourceKey=${answersSourceKey}`);
-      cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
-    });
+    cy.visit(`?activity=sample-activity-1&token=${this.portalToken}` +
+      `&domain=${portalDomain}/&answersSourceKey=${answersSourceKey}`);
+    cy.get("[data-cy=activity-summary]").should("contain", "Single Page Test Activity");
+  });
+
+  // A regular 'function' syntax is used instead '=>' so cypress can control what
+  // 'this' is
+  it("can work with the interactive sharing plugin", function () {
+    const portalDomain = Cypress.env("portal_domain");
+    const answersSourceKey = Cypress.env("answers_source_key");
+
+    cy.visit(`?activity=sample-interactive-sharing&token=${this.portalToken}` +
+      `&domain=${portalDomain}/&answersSourceKey=${answersSourceKey}`);
+    cy.get("[data-cy=activity-summary]").should("contain", "Test Interactive Sharing");
+    activityPage.getNavPage(1).click();
+
+    getInIframe("body", "textarea").clear().type("hello world");
+
+    // HACK: This test assumes the interactive has already been shared
+    // because this AP is "launched" from the portal it will restore its state each time
+    // it is launched. If you are using this with a new portal, class, assignment, or student
+    // then you need to share something first by uncommenting the following 3 lines and
+    // running the test:
+    // cy.get('[data-tip="Share this"]').click();
+    // cy.get('body').should("contain", "Your work  has been shared with your class.");
+    // cy.get('.share-modal--titleBarContents--SharingPluginV1>svg').eq(1).click();  // click the close button
+
+
+    cy.get('[data-tip="Stop sharing"]').click();
+
+    cy.get('[data-tip="Share this"]').click();
+    cy.get('body').should("contain", "Your work  has been shared with your class.");
+    // click the close button
+    cy.get('.share-modal--titleBarContents--SharingPluginV1>svg').eq(1).click();
+
+    cy.get('[data-tip="View class work"]').click();
+    cy.get('.left-nav--students--SharingPluginV1').eq(0).click();
+    cy.get('iframe[src^="https://portal-report.concord.org"]')
+
   });
 });

--- a/cypress/support/elements/iframe.js
+++ b/cypress/support/elements/iframe.js
@@ -4,10 +4,10 @@ export const getInIframe = (outerSelector, innerSelector) => {
   return cy.get(outerSelector)
   // First make sure the innerSelector exists by wrapping the whole search
   // for it in a should function. If anything in the should function throws an
-  // exception or failes a test then the should function will automatically re-run
+  // exception or fails a test then the should function will automatically re-run
   .should(($el) => {
     // direct jQuery is used here because the cypress command for wrap, find, and its
-    // run asyncrhously, and create confusing log message.
+    // run asynchronously, and create confusing log message.
 
     // Get the body element of the first iframe
     const $firstIframe = $el.find("iframe")

--- a/cypress/support/elements/iframe.js
+++ b/cypress/support/elements/iframe.js
@@ -1,21 +1,27 @@
-export const getIframeDocument = (outerSelector) => {
-  return cy.get(outerSelector)
-  .get("iframe")
-  // Cypress yields jQuery element, which has the real
-  // DOM element under property "0".
-  // From the real DOM iframe element we can get
-  // the "document" element, it is stored in "contentDocument" property
-  // Cypress "its" command can access deep properties using dot notation
-  // https://on.cypress.io/its
-  .its("0.contentDocument").should("exist");
-};
+export const getInIframe = (outerSelector, innerSelector) => {
+  let $innerResult;
 
-export const getIframeBody = (outerSelector) => {
-  // get the document
-  return getIframeDocument(outerSelector)
-  // automatically retries until body is loaded
-  .its("body").should("not.be.undefined")
-  // wraps "body" DOM element to allow
-  // chaining more Cypress commands, like ".find(...)"
-  .then(cy.wrap);
-};
+  return cy.get(outerSelector)
+  // First make sure the innerSelector exists by wrapping the whole search
+  // for it in a should function. If anything in the should function throws an
+  // exception or failes a test then the should function will automatically re-run
+  .should(($el) => {
+    // direct jQuery is used here because the cypress command for wrap, find, and its
+    // run asyncrhously, and create confusing log message.
+
+    // Get the body element of the first iframe
+    const $firstIframe = $el.find("iframe")
+    // This line might throw an exception because the iframe doesn't exist or isn't
+    // loaded yet.  But in that case should will automatically retry
+    const iframeBody = $firstIframe[0].contentDocument.body;
+    $innerResult = Cypress.$(iframeBody).find(innerSelector);
+
+    // Make sure the innerSelect actually finds something
+    // this will print a message to the cypress log
+    expect($innerResult).to.exist;
+  })
+  // Then return the result of that inner selector
+  .then(() => {
+    return $innerResult;
+  });
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -18,6 +18,7 @@ import sampleActivityQISimple from "../data/sample-question-interactive-simple.j
 import sampleActivityQIComplex from "../data/sample-question-interactive-complex.json";
 import sampleActivityLinkedInteractives from "../data/Linked-Interactives-Test_version_1.json";
 import sampleActivityInteractiveSizing from "../data/sample-activity-interactive-sizing.json";
+import sampleActivityInteractiveSharing from "../data/sample-interactive-sharing.json";
 
 const sampleActivities: {[name: string]: Activity} = {
   "sample-activity-1": sampleActivity1 as Activity,
@@ -38,7 +39,8 @@ const sampleActivities: {[name: string]: Activity} = {
   "sample-question-interactive-simple": sampleActivityQISimple as Activity,
   "sample-question-interactive-complex": sampleActivityQIComplex as Activity,
   "sample-activity-linked-interactives": sampleActivityLinkedInteractives as Activity,
-  "sample-activity-interactive-sizing": sampleActivityInteractiveSizing as Activity
+  "sample-activity-interactive-sizing": sampleActivityInteractiveSizing as Activity,
+  "sample-interactive-sharing": sampleActivityInteractiveSharing as Activity
 };
 
 import sampleSequence from "../data/sample-sequence.json";

--- a/src/data/sample-interactive-sharing.json
+++ b/src/data/sample-interactive-sharing.json
@@ -1,0 +1,113 @@
+{
+  "background_image": null,
+  "description": "",
+  "editor_mode": 0,
+  "id": 21316,
+  "layout": 0,
+  "name": "Test Interactive Sharing Plugin",
+  "notes": "",
+  "related": "",
+  "runtime": "Activity Player",
+  "show_submit_button": true,
+  "student_report_enabled": true,
+  "thumbnail_url": "",
+  "time_to_complete": null,
+  "version": 1,
+  "theme_name": null,
+  "project": null,
+  "pages": [{
+    "additional_sections": {},
+    "embeddable_display_mode": "stacked",
+    "id": 310563,
+    "is_completion": false,
+    "is_hidden": false,
+    "layout": "l-6040",
+    "name": null,
+    "position": 1,
+    "show_header": true,
+    "show_info_assessment": false,
+    "show_interactive": false,
+    "show_sidebar": false,
+    "sidebar": null,
+    "sidebar_title": "Did you know?",
+    "toggle_info_assessment": false,
+    "embeddables": [{
+      "embeddable": {
+        "name": "",
+        "url_fragment": null,
+        "authored_state": "{\"version\":1,\"questionType\":\"open_response\",\"prompt\":\"\u003Cp\u003EA simple open response question\u003C/p\u003E\"}",
+        "is_hidden": false,
+        "is_full_width": true,
+        "show_in_featured_question_report": true,
+        "inherit_aspect_ratio_method": true,
+        "custom_aspect_ratio_method": null,
+        "inherit_native_width": true,
+        "custom_native_width": 576,
+        "inherit_native_height": true,
+        "custom_native_height": 435,
+        "inherit_click_to_play": true,
+        "custom_click_to_play": false,
+        "inherit_full_window": true,
+        "custom_full_window": false,
+        "inherit_click_to_play_prompt": true,
+        "custom_click_to_play_prompt": null,
+        "inherit_image_url": true,
+        "custom_image_url": null,
+        "library_interactive": {
+          "data": {
+            "aspect_ratio_method": "DEFAULT",
+            "authoring_guidance": "",
+            "base_url": "https://models-resources.concord.org/question-interactives/branch/master/open-response/",
+            "click_to_play": false,
+            "click_to_play_prompt": null,
+            "description": "This shouldn't be used by any real activities it is still under development.",
+            "enable_learner_state": true,
+            "full_window": false,
+            "has_report_url": false,
+            "image_url": null,
+            "name": "Open Response (master)",
+            "native_height": 435,
+            "native_width": 576,
+            "no_snapshots": false,
+            "show_delete_data_button": false,
+            "thumbnail_url": "",
+            "customizable": false,
+            "authorable": true
+          }
+        },
+        "type": "ManagedInteractive",
+        "ref_id": "4362-ManagedInteractive",
+        "linked_interactives": []
+      },
+      "section": "header_block"
+    }, {
+      "embeddable": {
+        "plugin": {
+          "id": 6724,
+          "description": null,
+          "author_data": "{}",
+          "approved_script_label": "laraSharing",
+          "component_label": "interactives",
+          "approved_script": {
+            "name": "Sharing",
+            "url": "https://lara-sharing-plugin.concord.org/plugin.js",
+            "label": "laraSharing",
+            "description": "This plugin provides the sharing component",
+            "version": 3,
+            "json_url": "https://lara-sharing-plugin.concord.org/manifest.json",
+            "authoring_metadata": "{\"components\":[{\"label\":\"interactives\",\"name\":\"Interactives\",\"scope\":\"embeddable-decoration\",\"guiAuthoring\":true,\"decorates\":[\"MwInteractive\",\"ManagedInteractive\"]}]}"
+          }
+        },
+        "is_hidden": false,
+        "is_full_width": false,
+        "type": "Embeddable::EmbeddablePlugin",
+        "ref_id": "6373-Embeddable::EmbeddablePlugin",
+        "embeddable_ref_id": "4362-ManagedInteractive"
+      },
+      "section": null
+    }]
+  }],
+  "plugins": [],
+  "type": "LightweightActivity",
+  "export_site": "Lightweight Activities Runtime and Authoring"
+}

--- a/src/portal-api.ts
+++ b/src/portal-api.ts
@@ -360,7 +360,7 @@ export const fetchPortalData = async (): Promise<IPortalData> => {
   // This works fine, but for testing the activity player, we may want to load data that was previously
   // saved in a different domain (e.g. authoring.concord.org), so we first check for a "url-source"
   // query parameter.
-  const sourceKey = queryValue("report-source") || parseUrl(offeringData.activityUrl.toLowerCase()).hostname;
+  const sourceKey = queryValue("answersSourceKey") || parseUrl(offeringData.activityUrl.toLowerCase()).hostname;
 
   // for the tool id we want to distinguish activity-player branches, incase this is ever helpful for
   // dealing with mis-matched data when we load data in originally saved on another branch.

--- a/src/utilities/report-utils.ts
+++ b/src/utilities/report-utils.ts
@@ -52,8 +52,8 @@ export const getReportUrl = (questionRefId?: string) => {
   const reportFirebaseApp = firebaseAppName();
   const resourceUrl = getResourceUrl();
   const runKey = queryValue("runKey");
-  // Sometimes the location of the answers is overridden with a report-source param
-  const answerSource = queryValue("report-source") || getCanonicalHostname();
+  // Sometimes the location of the answers is overridden with a answersSourceKey param
+  const answerSource = queryValue("answersSourceKey") || getCanonicalHostname();
   // `sourceKey` might be useful to add during local development, usually to point to app.lara.docker.<username>
   // since local LARA instance would be publish resources at this path.
   const sourceKey = queryValue("sourceKey") || (resourceUrl ? makeSourceKey(resourceUrl) : getCanonicalHostname());


### PR DESCRIPTION
The main goal of this PR is to improve coverage in the AP.

Hopefully simple changes:
- change `report-source` param to `answersSourceKey` to make it consistent with portal-report
- improve how elements in iframes are requested in cypress so wait statements are not needed.
- add a test of the interactive sharing plugin 

### Cypress can launch sample activities from the portal
The test of the interactive sharing plugin requires this feature. 
I considered a few other options for testing the APIs needed to support the interactive sharing plugin, but decided this approach was the best at this time. 
- This launching from the portal was something CLUE already does, but has issues with it.  So the way this PR is doing can be copied into CLUE and solve those issues.
- the interactive sharing plugin uses its own firestore database, so by launching from the portal the request by the plugin to get the JWT for this database will work, and the plugin can write and read from its database without extra mocking.

The approach in CLUE is to use cypress to `visit` the portal and click a 'run' button. But visiting multiple domains only works in cypress if the second-level domain of the two sites matches. So this CLUE test only runs an already released version of CLUE on a `concord.org` domain instead of the currently checked out version.

The approach in this PR is to use `cy.request` to login in and run the assignment without actually visiting the portal site. Cypress does not restrict `cy.request` to the same second-level domain so this approach works. 

Additionally with this `cy.request` the test can load any activity it wants, it doesn't need to launch the activity that was actually assigned in the portal. 

After having implemented this approach I discovered a few problems that are probably going to make this new test flakey. So in the end we might need to replace it:
- all test runs are going to be storing data in the same place in report-service-dev firestore database and the share-plugin-dev firestore database.  So multiple runs happening at the same time could conflict.
- the report-service answers could be isolated by using a unique answersSourceKey for each test run, and then using firestore admin tools to delete this collection after the tests run. However this isn't easy to do with the current share-plugin-dev database. It stores answers under the portal, class, assignment, student, and then interactive id.  The best option I can think of is to dynamically change the activity so it has a different interactive id each time it runs, so then we can clear up the old state and also know that we will always start with an unshared interactive.