### PR TITLE
Browser reload should load the same page

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -10,7 +10,7 @@ import { Footer } from "./activity-introduction/footer";
 import { ActivityLayouts, PageLayouts, numQuestionsOnPreviousPages,
          enableReportButton, setDocumentTitle, getPagePositionFromQueryValue,
          getSequenceActivityFromQueryValue, getSequenceActivityId,
-         setAppBackgroundImage } from "../utilities/activity-utils";
+         setAppBackgroundImage, getPageIDFromPosition } from "../utilities/activity-utils";
 import { getActivityDefinition, getSequenceDefinition } from "../lara-api";
 import { ThemeButtons } from "./theme-buttons";
 import { SinglePageContent } from "./single-page/single-page-content";
@@ -456,6 +456,10 @@ export class App extends React.PureComponent<IProps, IState> {
 
   private handleChangePage = (page: number) => {
     const { currentPage, incompleteQuestions, activity } = this.state;
+    const pageID = activity ? getPageIDFromPosition(activity, page) : undefined;
+    if (pageID) {
+      setQueryValue("page", `page_${pageID}`);
+    }
     if (page > currentPage && incompleteQuestions.length > 0) {
       const label = incompleteQuestions[0].navOptions?.message || kDefaultIncompleteMessage;
       this.setShowModal(true, label);

--- a/src/utilities/activity-utils.test.ts
+++ b/src/utilities/activity-utils.test.ts
@@ -1,6 +1,7 @@
 import { Activity } from "../types";
 import { isQuestion, isEmbeddableSectionHidden, getVisibleEmbeddablesOnPage, VisibleEmbeddables,
-  EmbeddableSections, getPageSectionQuestionCount, numQuestionsOnPreviousPages, enableReportButton, getPagePositionFromQueryValue } from "./activity-utils";
+         EmbeddableSections, getPageSectionQuestionCount, numQuestionsOnPreviousPages,
+         enableReportButton, getPagePositionFromQueryValue, getPageIDFromPosition } from "./activity-utils";
 import _activityHidden from "../data/sample-activity-hidden-content.json";
 import _activity from "../data/sample-activity-multiple-layout-types.json";
 import { DefaultTestActivity } from "../test-utils/model-for-tests";
@@ -93,5 +94,10 @@ describe("Activity utility functions", () => {
     expect(getPagePositionFromQueryValue(activity, "page_1001")).toBe(0);
     expect(getPagePositionFromQueryValue(activity, "page_2000")).toBe(2);
     expect(getPagePositionFromQueryValue(activity, "page_3000")).toBe(3);
+  });
+  it("determines the page ID from the page's position value", () => {
+    expect(getPageIDFromPosition(activity, 1)).toBe(1000);
+    expect(getPageIDFromPosition(activity, 2)).toBe(2000);
+    expect(getPageIDFromPosition(activity, 3)).toBe(3000);
   });
 });

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -166,6 +166,15 @@ export const getPagePositionFromQueryValue = (activity: Activity, pageQueryValue
   return Math.max(0, Math.min((parseInt(pageQueryValue, 10) || 0), activity.pages.length));
 };
 
+export const getPageIDFromPosition = (activity: Activity, currentPosition: number): number | null => {
+  for (const page of activity.pages) {
+    if (page.position === currentPosition) {
+      return page.id;
+    }
+  }
+  return null;
+};
+
 export const getSequenceActivityFromQueryValue = (sequence: Sequence, sequenceActivityQueryValue = "0"): number => {
   const activityId = sequenceActivityQueryValue.startsWith("activity_") ? parseInt(sequenceActivityQueryValue.split("_")[1], 10) : NaN;
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/180560270

[#180560270]

- Adds a function for determining a page's ID by its position value. 
- Updates `page` URL param when user navigates to a new page.