### PR TITLE
Fix linked interactive preview [#180446636]

### DIFF
--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -163,11 +163,13 @@ describe("Firestore", () => {
 
     const exportableAnswer = getAnswerWithMetadata(interactiveState, embeddable) as IExportableAnswerMetadata;
 
+    const created = createdString();
     createOrUpdateAnswer(exportableAnswer);
 
     expect(appMock.firestore().doc).toHaveBeenCalledWith(`sources/localhost/answers/${exportableAnswer.id}`);
     expect(appMock.firestore().doc().set).toHaveBeenCalledWith({
       version: 1,
+      created,
       answer: "anonymous test",
       answer_text: "anonymous test",
       id: exportableAnswer.id,

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -307,6 +307,7 @@ export function createOrUpdateAnswer(answer: IExportableAnswerMetadata) {
   } else {
     const anonymousAnswer: AnonymousRuntimeAnswerMetadata = {
       ...answer,
+      created: createdString(),
       source_key: portalData.database.sourceKey,
       resource_url: portalData.resourceUrl,
       tool_id: portalData.toolId,


### PR DESCRIPTION
This adds the created field to anonymous answers which is used by the CFM to determine when to show the preview of the two linked states.