### PR TITLE
Fixes author preview tab title

### DIFF
--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -163,10 +163,16 @@ export const setAppBackgroundImage = (backgroundImageUrl?: string) => {
 
 export const setDocumentTitle = (activity: Activity | undefined, pageNumber: number) => {
   if (activity) {
-    const visiblePages = activity.pages.filter(p => !p.is_hidden);
-    document.title = pageNumber === 0
+    if(queryValue("author-preview")) {
+      document.title = pageNumber === 0
       ? activity.name
-      : `Page ${pageNumber} ${visiblePages[pageNumber - 1].name || activity.name}`;
+      : `Page ${pageNumber} ${activity.pages[pageNumber - 1].name || activity.name}`;
+    } else {
+      const visiblePages = activity.pages.filter(p => !p.is_hidden);
+      document.title = pageNumber === 0
+        ? activity.name
+        : `Page ${pageNumber} ${visiblePages[pageNumber - 1].name || activity.name}`;
+    }
   }
 };
 

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -162,16 +162,18 @@ export const setAppBackgroundImage = (backgroundImageUrl?: string) => {
 };
 
 export const setDocumentTitle = (activity: Activity | undefined, pageNumber: number) => {
+
   if (activity) {
-    if(queryValue("author-preview")) {
+    const setTabTitle = (pages: Page[]) => {
       document.title = pageNumber === 0
       ? activity.name
-      : `Page ${pageNumber} ${activity.pages[pageNumber - 1].name || activity.name}`;
+      : `Page ${pageNumber} ${pages[pageNumber - 1].name || activity.name}`;
+    };
+    const visiblePages = activity.pages.filter(p => !p.is_hidden);
+    if (queryValue("author-preview")) {
+      setTabTitle(activity.pages);
     } else {
-      const visiblePages = activity.pages.filter(p => !p.is_hidden);
-      document.title = pageNumber === 0
-        ? activity.name
-        : `Page ${pageNumber} ${visiblePages[pageNumber - 1].name || activity.name}`;
+      setTabTitle(visiblePages);
     }
   }
 };


### PR DESCRIPTION
This is to fix the previous PR on tab titles. It didn't take into account author preview mode, and so AP would show blank pages when author tried to preview an activity that had hidden pages.