### PR TITLE
Footer page nav does not enable when all questions submitted

### DIFF
--- a/cypress/integration/workspace.test.ts
+++ b/cypress/integration/workspace.test.ts
@@ -40,14 +40,14 @@ context("Test the overall app", () => {
         cy.get("[data-cy=version-info]").scrollIntoView().should("be.visible");
     });
   });
-describe("accessibility",()=>{
+  describe("accessibility",()=>{
     it("go to correct page when tabbed and keydown enter from page navigation header",()=>{
-      activityPage.getNavPage(2).type("{enter}");
+      activityPage.getNavPage(2).type("{enter}", { force: true });
       activityPage.getSidebarTab().should("be.visible");
     });
 
     it("go to correct page when tabbed and keydown enter from page list",()=>{
-      cy.get("[data-cy=nav-pages] button").eq(1).type("{enter}");
+      cy.get("[data-cy=nav-pages] button").eq(1).type("{enter}", { force: true });
       cy.get("[data-cy=intro-page-content]").should("be.visible");
       cy.get(".page-item").eq(1).focus();
       cy.focused().type("{enter}");

--- a/cypress/integration/workspace.test.ts
+++ b/cypress/integration/workspace.test.ts
@@ -42,12 +42,12 @@ context("Test the overall app", () => {
   });
   describe("accessibility",()=>{
     it("go to correct page when tabbed and keydown enter from page navigation header",()=>{
-      activityPage.getNavPage(2).type("{enter}", { force: true });
+      activityPage.getNavPage(2).type("{enter}");
       activityPage.getSidebarTab().should("be.visible");
     });
 
     it("go to correct page when tabbed and keydown enter from page list",()=>{
-      cy.get("[data-cy=nav-pages] button").eq(1).type("{enter}", { force: true });
+      cy.get("[data-cy=nav-pages] button").eq(1).type("{enter}");
       cy.get("[data-cy=intro-page-content]").should("be.visible");
       cy.get(".page-item").eq(1).focus();
       cy.focused().type("{enter}");

--- a/src/components/activity-header/activity-nav.tsx
+++ b/src/components/activity-header/activity-nav.tsx
@@ -16,9 +16,8 @@ interface IProps {
 export class ActivityNav extends React.PureComponent <IProps> {
   render() {
     const { activityPages, currentPage, fullWidth, lockForwardNav, onPageChange, singlePage } = this.props;
-    const uniqueKey = `activity-nav-${new Date().getTime()}`;
     return (
-      <div key={uniqueKey} className={`activity-nav ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header">
+      <div className={`activity-nav ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header">
         { !singlePage &&
           <NavPages
             pages={activityPages}

--- a/src/components/activity-header/activity-nav.tsx
+++ b/src/components/activity-header/activity-nav.tsx
@@ -16,8 +16,9 @@ interface IProps {
 export class ActivityNav extends React.PureComponent <IProps> {
   render() {
     const { activityPages, currentPage, fullWidth, lockForwardNav, onPageChange, singlePage } = this.props;
+    const uniqueKey = `activity-nav-${new Date().getTime()}`;
     return (
-      <div className={`activity-nav ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header">
+      <div key={uniqueKey} className={`activity-nav ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header">
         { !singlePage &&
           <NavPages
             pages={activityPages}

--- a/src/components/activity-header/nav-pages.tsx
+++ b/src/components/activity-header/nav-pages.tsx
@@ -143,7 +143,8 @@ export class NavPages extends React.Component <IProps, IState> {
 
   private handleChangePage = (page: number) => () => {
     if (!this.state.pageChangeInProgress) {
-      this.setState({ pageChangeInProgress: true }, () => {
+      const allowPageChange = !this.props.lockForwardNav;
+      this.setState({ pageChangeInProgress: allowPageChange }, () => {
         this.props.onPageChange(page);
       });
     }


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177098917

[#177098917]

Adds a unique key to the ActivityNav component to ensure that both instances on a page are updated when all required questions are submitted.