### PR TITLE
Pins collapsible header when collapsed and interactive is taller

### DIFF
--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -166,6 +166,12 @@
       padding: 5px;
       flex-direction: column;
       justify-content: flex-start;
+      position: sticky;
+      top: 0;
+      div {
+        transform: rotate(-90deg);
+        top: 20px;
+      }
     }
 
     div {
@@ -173,17 +179,6 @@
       position: relative;
       white-space: nowrap;
       width: 30px;
-    }
-
-    &.collapsed {
-      height: 350px;
-      width: 45px;
-      padding: 5px;
-
-      div {
-        transform: rotate(-90deg);
-        top: 20px;
-      }
     }
   }
 }


### PR DESCRIPTION
Demo [here](https://activity-player.concord.org/branch/pin-collapsible-header/?activity=interactive-sizing-demo-question-interactive&page=page_139538). 
Make the window wide so the interactive is taller than collapsed secondary column. Scroll down, and collapsed header should be pinned.