### PR TITLE
fixes bug with horizontal scroll not scrolling the entire width

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -14,8 +14,7 @@ body {
   display: flex;
   justify-content: center;
   background-color: var(--theme-primary-color);
-  overflow-y: auto;
-  overflow-x: auto;
+  overflow: auto;
 }
 
 .app {

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -15,6 +15,7 @@ body {
   justify-content: center;
   background-color: var(--theme-primary-color);
   overflow-y: auto;
+  overflow-x: auto;
 }
 
 .app {
@@ -72,6 +73,8 @@ body {
 
   .activity {
     width: 1100px;  /* here as fallback in case fixed_width_layout doesn't map to one of the classes below */
+    margin-left: auto;
+    margin-right: auto;
 
     &.fixed-width-1100px {
       width: 1100px;


### PR DESCRIPTION
Demo [here] (https://activity-player.concord.org/branch/horizontal-scroll/?activity=interactive-sizing-demo-question-interactive&page=page_126082)
Make the browser narrow so that horizontal scroll bar appears on the bottom