### PR TITLE
Only pins the primary interactive if its height is less than the browser height

### DIFF
--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -137,9 +137,11 @@
     position: relative;
     height: auto;
     .embeddableWrapper {
-      position: sticky;
       top: 10px;
       align-self: flex-start;
+      &.pinned {
+        position: sticky;
+      }
     }
   }
 

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -30,27 +30,27 @@ export const Section: React.FC<IProps> = (props) => {
   const primaryDivRef = useRef<HTMLDivElement>(null);
   const secondaryDivRef = useRef<HTMLDivElement>(null);
   const embeddableRefs: Record<string, React.RefObject<EmbeddableImperativeAPI>> = {};
- // cf. https://www.npmjs.com/package/@react-hook/resize-observer
+  // cf. https://www.npmjs.com/package/@react-hook/resize-observer
   const useSize = (target: any) => {
     const [size, setSize] = React.useState();
     useResizeObserver(target, (entry: any) => setSize(entry.contentRect));
     return size;
   };
-    // use this to get browser height fwhen deiciding to pin or not
-    const [screenHeight, getDimension] = useState({
+  // use this to get browser height when deiciding to pin or not
+  const [screenHeight, getDimension] = useState({
+    dynamicHeight: window.innerHeight
+  });
+  const setDimension = () => {
+    getDimension({
       dynamicHeight: window.innerHeight
     });
-    const setDimension = () => {
-      getDimension({
-        dynamicHeight: window.innerHeight
-      });
-    };
-    useEffect(() => {
-      window.addEventListener("resize", setDimension);
-      return(() => {
-          window.removeEventListener("resize", setDimension);
-      });
-    }, [screenHeight]);
+  };
+  useEffect(() => {
+    window.addEventListener("resize", setDimension);
+    return(() => {
+      window.removeEventListener("resize", setDimension);
+    });
+  }, [screenHeight]);
 
   const renderEmbeddables = (embeddablesToRender: EmbeddableType[], questionNumStart: number, isSingleColumn?: boolean) => {
     let questionNumber = questionNumStart;


### PR DESCRIPTION
Demo [here](https://activity-player.concord.org/branch/no-pinning/?activity=interactive-sizing-demo-question-interactive&mode=teacher-edition)
On Page 3, if you change the height of the interactive to be larger than the browser window, the interactive should jump to the top of the div and not be pinned. If you change the height of the browser to be shorter than the interactive, the interactive should not be pinned as you scroll.
On page 16, If you open click on the teacher tip and the teacher tip makes the primary column taller, the interactive should not be pinned.
On page 14, it uses the total height of both interactives to determine whether to pin or not. 