### PR TITLE
Fixes styling so there is no gap between collapsed column header and primary column

### DIFF
--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -43,12 +43,11 @@
   }
 
   &.r_4060 {
+    grid-template-columns: minmax(45px, auto) repeat(9, 1fr);
     .column.primary {
       grid-column: span 6;
       &.expand {
         grid-column: span 9;
-        width: 105%;
-        left: -50px;
       }
     }
     .column.secondary {
@@ -83,12 +82,11 @@
   }
 
   &.r_3070 {
+    grid-template-columns: minmax(45px, auto) repeat(9, 1fr);
     .column.primary {
       grid-column: span 7;
       &.expand {
         grid-column: span 9;
-        width: 105%;
-        left: -50px;
       }
     }
     .column.secondary {

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -28,10 +28,6 @@
       grid-column: span 6;
       &.expand {
         grid-column: span 9;
-        &.max-aspect-ratio {
-          width: 105%;
-          left: -50px;
-        }
       }
     }
     .column.secondary {
@@ -51,8 +47,9 @@
       grid-column: span 6;
       &.expand {
         grid-column: span 9;
+        width: 105%;
+        left: -50px;
         &.max-aspect-ratio {
-          width: 105%;
           left: -50px;
         }
       }
@@ -74,10 +71,6 @@
       grid-column: span 7;
       &.expand {
         grid-column: span 9;
-        &.max-aspect-ratio {
-          width: 105%;
-          left: -50px;
-        }
       }
     }
     .column.secondary {

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -49,9 +49,6 @@
         grid-column: span 9;
         width: 105%;
         left: -50px;
-        &.max-aspect-ratio {
-          left: -50px;
-        }
       }
     }
     .column.secondary {
@@ -90,10 +87,8 @@
       grid-column: span 7;
       &.expand {
         grid-column: span 9;
-        &.max-aspect-ratio {
-          width: 105%;
-          left: -50px;
-        }
+        width: 105%;
+        left: -50px;
       }
     }
     .column.secondary {

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -28,6 +28,10 @@
       grid-column: span 6;
       &.expand {
         grid-column: span 9;
+        &.max-aspect-ratio {
+          width: 105%;
+          left: -50px;
+        }
       }
     }
     .column.secondary {
@@ -70,6 +74,10 @@
       grid-column: span 7;
       &.expand {
         grid-column: span 9;
+        &.max-aspect-ratio {
+          width: 105%;
+          left: -50px;
+        }
       }
     }
     .column.secondary {
@@ -89,6 +97,10 @@
       grid-column: span 7;
       &.expand {
         grid-column: span 9;
+        &.max-aspect-ratio {
+          width: 105%;
+          left: -50px;
+        }
       }
     }
     .column.secondary {

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -47,6 +47,10 @@
       grid-column: span 6;
       &.expand {
         grid-column: span 9;
+        &.max-aspect-ratio {
+          width: 105%;
+          left: -50px;
+        }
       }
     }
     .column.secondary {
@@ -166,6 +170,12 @@
       padding: 5px;
       flex-direction: column;
       justify-content: flex-start;
+      position: sticky;
+      top: 0;
+      div {
+        transform: rotate(-90deg);
+        top: 20px;
+      }
     }
 
     div {
@@ -173,17 +183,6 @@
       position: relative;
       white-space: nowrap;
       width: 30px;
-    }
-
-    &.collapsed {
-      height: 350px;
-      width: 45px;
-      padding: 5px;
-
-      div {
-        transform: rotate(-90deg);
-        top: 20px;
-      }
     }
   }
 }

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -64,7 +64,10 @@ export const Section: React.FC<IProps> = (props) => {
   };
 
   const renderPrimaryEmbeddables = (primaryEmbeddablesToRender: EmbeddableType[], questionNumStart: number) => {
-    const containerClass = classNames("column", layout, "primary", {"expand": isSecondaryCollapsed});
+    const maxAspectRatioEmbeddables = primaryEmbeddablesToRender.filter(e => e.aspect_ratio_method === "MAX");
+    const hasMaxAspectRatio = maxAspectRatioEmbeddables.length > 0;
+    const containerClass = classNames("column", layout, "primary", {"expand": isSecondaryCollapsed && hasMaxAspectRatio},
+                                      {"max-aspect-ratio": hasMaxAspectRatio});
     return (
         <div className={containerClass} ref={primaryDivRef} data-cy="section-column-primary">
           <div className="embeddableWrapper">

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -66,7 +66,7 @@ export const Section: React.FC<IProps> = (props) => {
   const renderPrimaryEmbeddables = (primaryEmbeddablesToRender: EmbeddableType[], questionNumStart: number) => {
     const maxAspectRatioEmbeddables = primaryEmbeddablesToRender.filter(e => e.aspect_ratio_method === "MAX");
     const hasMaxAspectRatio = maxAspectRatioEmbeddables.length > 0;
-    const containerClass = classNames("column", layout, "primary", {"expand": isSecondaryCollapsed && hasMaxAspectRatio},
+    const containerClass = classNames("column", layout, "primary", {"expand": isSecondaryCollapsed},
                                       {"max-aspect-ratio": hasMaxAspectRatio});
     return (
         <div className={containerClass} ref={primaryDivRef} data-cy="section-column-primary">

--- a/src/convert-old-lara/convert.ts
+++ b/src/convert-old-lara/convert.ts
@@ -118,10 +118,10 @@ const newSectionsResource = (resourcePage: legacyPageType): SectionType[] => {
     case "r-4060":
       sectionLayout = "60-40";
       break;
-    case "l-3070":
+    case "l-7030":
       sectionLayout = "70-30";
       break;
-    case "r-7030":
+    case "r-3070":
       sectionLayout = "30-70";
   }
   const headerBlockEmbeddables: legacyEmbeddableType[] = [];

--- a/src/convert-old-lara/convert.ts
+++ b/src/convert-old-lara/convert.ts
@@ -119,10 +119,10 @@ const newSectionsResource = (resourcePage: legacyPageType): SectionType[] => {
       sectionLayout = "60-40";
       break;
     case "l-7030":
-      sectionLayout = "70-30";
+      sectionLayout = "30-70";
       break;
     case "r-3070":
-      sectionLayout = "30-70";
+      sectionLayout = "70-30";
   }
   const headerBlockEmbeddables: legacyEmbeddableType[] = [];
   const primaryBlockEmbeddables: legacyEmbeddableType[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface EmbeddableBase {
   ref_id: string;
   embeddable_ref_id?: string;
   column?: "primary" | "secondary" | null;
+  aspect_ratio_method?: "DEFAULT" | "MANUAL" | "MAX";
 }
 
 export interface IManagedInteractive extends EmbeddableBase {


### PR DESCRIPTION
Current behavior is there is a gap between the primary and secondary column when you collapsed the secondary column.
![image](https://user-images.githubusercontent.com/7716653/150246715-ec93ba3a-701a-40e8-8e2a-c77e31fb1261.png)

This changes the 
Demo [here](https://activity-player.concord.org/branch/collapsed-column-gap/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F21423.json)