### PR TITLE
Footer page nav does not enable when all questions submitted.

### DIFF
--- a/src/components/activity-header/nav-pages.scss
+++ b/src/components/activity-header/nav-pages.scss
@@ -73,9 +73,6 @@
       outline: none;
       cursor: auto;
       opacity: .35;
-      &.arrow-button {
-        pointer-events: none;
-      }
     }
 
   }

--- a/src/components/activity-header/nav-pages.tsx
+++ b/src/components/activity-header/nav-pages.tsx
@@ -54,7 +54,7 @@ export class NavPages extends React.Component <IProps, IState> {
     return (
       <button
         className={`page-button arrow-button ${pageChangeInProgress || currentPage === 0 ? "disabled" : ""}`}
-        onClick={this.handleChangePage(currentPage - 1)}
+        onClick={this.handlePageChangeRequest(currentPage - 1)}
         aria-label="Previous page"
       >
         <ArrowPrevious className="icon"/>
@@ -69,7 +69,7 @@ export class NavPages extends React.Component <IProps, IState> {
     return (
       <button
         className={`page-button arrow-button ${pageChangeInProgress || currentPage === totalPages || lockForwardNav ? "disabled" : ""}`}
-        onClick={this.handleChangePage(currentPage + 1)}
+        onClick={this.handlePageChangeRequest(currentPage + 1)}
         aria-label="Next page"
       >
         <ArrowNext className="icon"/>
@@ -114,7 +114,7 @@ export class NavPages extends React.Component <IProps, IState> {
           pageNum >= minPage && pageNum <= maxPage
             ? <button
                 className={`page-button ${currentClass} ${completionClass} ${disabledClass}`}
-                onClick={this.handleChangePage(pageNum)}
+                onClick={this.handlePageChangeRequest(pageNum)}
                 key={`page ${pageNum}`}
                 data-cy={`${page.is_completion ? "nav-pages-completion-page-button" : "nav-pages-button"}`}
                 aria-label={`Page ${pageNum}`}
@@ -131,7 +131,7 @@ export class NavPages extends React.Component <IProps, IState> {
     const currentClass = this.props.currentPage === 0 ? "current" : "";
     const { pageChangeInProgress } = this.state;
     return (
-      <button className={`page-button ${currentClass} ${(pageChangeInProgress) ? "disabled" : ""}`} onClick={this.handleChangePage(0)} aria-label="Home">
+      <button className={`page-button ${currentClass} ${(pageChangeInProgress) ? "disabled" : ""}`} onClick={this.handlePageChangeRequest(0)} aria-label="Home">
         <IconHome
           className={`icon ${this.props.currentPage === 0 ? "current" : ""}`}
           width={28}
@@ -141,9 +141,12 @@ export class NavPages extends React.Component <IProps, IState> {
     );
   }
 
-  private handleChangePage = (page: number) => () => {
-    if (!this.state.pageChangeInProgress) {
-      this.setState({ pageChangeInProgress: true }, () => {
+  private handlePageChangeRequest = (page: number) => () => {
+    const { currentPage, lockForwardNav } = this.props;
+    const { pageChangeInProgress } = this.state;
+    if (!pageChangeInProgress) {
+      const allowPageChange = page < currentPage || !lockForwardNav;
+      this.setState({ pageChangeInProgress: allowPageChange }, () => {
         this.props.onPageChange(page);
       });
     }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -43,7 +43,7 @@ import { LaraDataContext } from "./lara-data-context";
 import "./app.scss";
 
 const kDefaultActivity = "sample-activity-multiple-layout-types";   // may eventually want to get rid of this
-const kDefaultIncompleteMessage = "Please submit an answer first.";
+const kDefaultIncompleteMessage = "You must submit an answer for all required questions before advancing to another page.";
 
 // User will see the idle warning after kMaxIdleTime
 const kMaxIdleTime = 20 * 60 * 1000; // 20 minutes


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/177098917

[#177098917]

These changes refactor the nav button click handler to better deal with cases when a page change is not allowed. Most importantly, `pageChangeInProgress` is only set to `true` when page changing is allowed. This prevents `pageChangeInProgress` from inadvertently disabling nav buttons when they should be enabled.