### PR TITLE
Fix get attachment url for new interactives [#180916194]

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -236,9 +236,10 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   };
 
   const handleGetAttachmentUrlRequest = async (request: IAttachmentUrlRequest): Promise<IAttachmentUrlResponse> => {
-    const answerMetadata = await getAnswerMetadata(request.interactiveId);
-    if (!answerMetadata) {
-      return { error: "error getting attachment url: no answer metadata", requestId: request.requestId };
+    // the answerMetadata does not exist for interactives that have never been saved before now
+    let answerMetadata: IExportableAnswerMetadata = answerMeta.current || {} as any;
+    if (request.interactiveId) {
+      answerMetadata = (await getAnswerMetadata(request.interactiveId)) || ({} as any);
     }
     return await handleGetAttachmentUrl({
       request,


### PR DESCRIPTION
The interactiveId is optional and should only be present for linked interactives.  Before this fix the interactiveId was required and this caused writes of new interactives to fail as they had no existing metadata.

This aligns AP with the Lara code.