### PR TITLE
Fix all sequences have the same wrong HTML title value

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -144,7 +144,7 @@ export class App extends React.PureComponent<IProps, IState> {
       const preview = queryValueBoolean("preview") || teacherEditionMode;
 
       const newState: Partial<IState> = {activity, activityIndex, currentPage, showThemeButtons, showWarning, showSequenceIntro, sequence, teacherEditionMode};
-      setDocumentTitle(activity, currentPage);
+      setDocumentTitle({activity, pageNumber: currentPage, sequence, sequenceActivityNum});
 
       let classHash = "";
       let role = "unknown";
@@ -471,7 +471,7 @@ export class App extends React.PureComponent<IProps, IState> {
     } else if (page >= 0 && (activity && page <= activity.pages.length)) {
       const navigateAway = () => {
         this.setState({ currentPage: page, incompleteQuestions: [] });
-        setDocumentTitle(activity, page);
+        setDocumentTitle({activity, pageNumber: page});
         Logger.updateActivityPage(page);
         Logger.log({
           event: LogEventName.change_activity_page,

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -25,6 +25,13 @@ export interface PageSectionQuestionCount {
   InteractiveBlock: number;
 }
 
+interface ISetDocumentTitleParams {
+  activity: Activity | undefined;
+  pageNumber: number;
+  sequence?: Sequence;
+  sequenceActivityNum?: number;
+}
+
 export const isSectionHidden = (section: SectionType) => {
   return section.is_hidden;
 };
@@ -161,19 +168,23 @@ export const setAppBackgroundImage = (backgroundImageUrl?: string) => {
   el?.style.setProperty("background-repeat", "no-repeat");
 };
 
-export const setDocumentTitle = (activity: Activity | undefined, pageNumber: number) => {
+export const setDocumentTitle = (params: ISetDocumentTitleParams) => {
+  const { activity, pageNumber, sequence, sequenceActivityNum } = params;
+  const setTabTitle = (title: string, pages: Page[]) => {
+    document.title = pageNumber === 0
+      ? title
+      : `Page ${pageNumber} ${pages[pageNumber - 1].name || title}`;
+  };
 
-  if (activity) {
-    const setTabTitle = (pages: Page[]) => {
-      document.title = pageNumber === 0
-      ? activity.name
-      : `Page ${pageNumber} ${pages[pageNumber - 1].name || activity.name}`;
-    };
+  if (sequence && sequenceActivityNum === 0) {
+    const sequenceTitle = sequence.display_title || sequence.title || "Sequence";
+    setTabTitle(sequenceTitle, []);
+  } else if (activity) {
     const visiblePages = activity.pages.filter(p => !p.is_hidden);
     if (queryValue("author-preview")) {
-      setTabTitle(activity.pages);
+      setTabTitle(activity.name, activity.pages);
     } else {
-      setTabTitle(visiblePages);
+      setTabTitle(activity.name, visiblePages);
     }
   }
 };


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/178676995

[#178676995]

These changes set `document.title` to the sequence title when viewing a sequence's home page. Previously, when viewing a sequence home page, `document.title` would be inadvertently set to "Sample Layout Types".