### PR TITLE
Disables pointer events when page nav is disabled

### DIFF
--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -61,7 +61,7 @@ context("Test the overall app", () => {
       activityPage.getHomeButton().eq(1).click();
       cy.wait(1000);
       activityPage.getPreviousPageButton().should("have.class", "last-page");
-      activityPage.getNavPage(7).click();
+      activityPage.getCompletionPage().eq(0).click();
       cy.wait(1000);
       activityPage.getNextPageButton().should("have.class", "last-page");
 

--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -56,6 +56,17 @@ context("Test the overall app", () => {
       activityPage.getModalDialogMessage().should("have.length", 0);
     });
   });
+  describe("First and last page",()=>{
+    it("verify arrow navigation is disabled when on the first or last page",()=>{
+      activityPage.getHomeButton().eq(1).click();
+      cy.wait(1000);
+      activityPage.getPreviousPageButton().should("have.class", "last-page");
+      activityPage.getNavPage(7).click();
+      cy.wait(1000);
+      activityPage.getNextPageButton().should("have.class", "last-page");
+
+    });
+  });
   describe("Question Interactives",()=>{
     it("verify we can load a managed interactive",()=>{
       cy.visit("?activity=sample-activity-1&preview");

--- a/cypress/support/elements/activity-page.js
+++ b/cypress/support/elements/activity-page.js
@@ -5,8 +5,17 @@ class ActivityPage {
   getPage(num) {
     return cy.get("[data-cy=activity-page-links]").contains(num);
   }
+  getHomeButton() {
+    return cy.get("[data-cy=home-button]");
+  }
   getNavPage(num) {
     return cy.get("[data-cy=nav-pages]").contains(num);
+  }
+  getPreviousPageButton() {
+    return cy.get("[data-cy=previous-page-button");
+  }
+  getNextPageButton() {
+    return cy.get("[data-cy=next-page-button");
   }
   getSidebarTab() {
     return cy.get("[data-cy=sidebar-tab]");

--- a/cypress/support/elements/activity-page.js
+++ b/cypress/support/elements/activity-page.js
@@ -11,6 +11,9 @@ class ActivityPage {
   getNavPage(num) {
     return cy.get("[data-cy=nav-pages]").contains(num);
   }
+  getCompletionPage() {
+    return cy.get("[data-cy=nav-pages-completion-page-button]");
+  }
   getPreviousPageButton() {
     return cy.get("[data-cy=previous-page-button");
   }

--- a/src/components/activity-header/nav-pages.scss
+++ b/src/components/activity-header/nav-pages.scss
@@ -73,7 +73,13 @@
       outline: none;
       cursor: auto;
       opacity: .35;
+    }
+
+    &.last-page {
       pointer-events: none;
+      outline: none;
+      cursor: auto;
+      opacity: .35;
     }
 
   }

--- a/src/components/activity-header/nav-pages.scss
+++ b/src/components/activity-header/nav-pages.scss
@@ -73,6 +73,7 @@
       outline: none;
       cursor: auto;
       opacity: .35;
+      pointer-events: none;
     }
 
   }

--- a/src/components/activity-header/nav-pages.tsx
+++ b/src/components/activity-header/nav-pages.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import classNames from "classnames";
 import { queryValue } from "../../utilities/url-query";
 import IconHome from "../../assets/svg-icons/icon-home.svg";
 import IconCompletion from "../../assets/svg-icons/icon-completion.svg";
@@ -53,7 +54,7 @@ export class NavPages extends React.Component <IProps, IState> {
     const { pageChangeInProgress } = this.state;
     return (
       <button
-        className={`page-button arrow-button ${pageChangeInProgress || currentPage === 0 ? "disabled" : ""}`}
+        className={`page-button arrow-button ${pageChangeInProgress || currentPage === 0 ? "last-page" : ""}`}
         onClick={this.handlePageChangeRequest(currentPage - 1)}
         aria-label="Previous page"
       >
@@ -66,9 +67,14 @@ export class NavPages extends React.Component <IProps, IState> {
     const { pageChangeInProgress } = this.state;
     const visiblePages = queryValue("author-preview") ? pages : pages.filter((page) => !page.is_hidden);
     const totalPages = visiblePages.length;
+    // 'disabled' class disables navigation but still allows user to click on arrows or page numbers for warning modal to come up
+    // 'last-page' class disables pointer events.
+    const nextButtonClass = classNames("page-button", "arrow-button",
+                                        {"disabled": pageChangeInProgress || lockForwardNav || currentPage === totalPages},
+                                        {"last-page": currentPage === totalPages});
     return (
       <button
-        className={`page-button arrow-button ${pageChangeInProgress || currentPage === totalPages || lockForwardNav ? "disabled" : ""}`}
+        className={nextButtonClass}
         onClick={this.handlePageChangeRequest(currentPage + 1)}
         aria-label="Next page"
       >

--- a/src/components/activity-header/nav-pages.tsx
+++ b/src/components/activity-header/nav-pages.tsx
@@ -57,6 +57,7 @@ export class NavPages extends React.Component <IProps, IState> {
         className={`page-button arrow-button ${pageChangeInProgress || currentPage === 0 ? "last-page" : ""}`}
         onClick={this.handlePageChangeRequest(currentPage - 1)}
         aria-label="Previous page"
+        data-cy="previous-page-button"
       >
         <ArrowPrevious className="icon"/>
       </button>
@@ -77,6 +78,7 @@ export class NavPages extends React.Component <IProps, IState> {
         className={nextButtonClass}
         onClick={this.handlePageChangeRequest(currentPage + 1)}
         aria-label="Next page"
+        data-cy="next-page-button"
       >
         <ArrowNext className="icon"/>
       </button>
@@ -137,7 +139,11 @@ export class NavPages extends React.Component <IProps, IState> {
     const currentClass = this.props.currentPage === 0 ? "current" : "";
     const { pageChangeInProgress } = this.state;
     return (
-      <button className={`page-button ${currentClass} ${(pageChangeInProgress) ? "disabled" : ""}`} onClick={this.handlePageChangeRequest(0)} aria-label="Home">
+      <button className={`page-button ${currentClass} ${(pageChangeInProgress) ? "disabled" : ""}`}
+              onClick={this.handlePageChangeRequest(0)}
+              aria-label="Home"
+              data-cy="home-button"
+      >
         <IconHome
           className={`icon ${this.props.currentPage === 0 ? "current" : ""}`}
           width={28}


### PR DESCRIPTION
Fixes bug when clicking on a disabled page nav button disables the entire page nav. 
(#177501334)[https://www.pivotaltracker.com/story/show/177501334]
Added a separate class for arrow buttons that sets pointer-events to none. I couldn't just add it to the `disabled` class because we still need the pointer-events for when there is a required question to be submitted. The user is still be able to click on the arrow or the page number after the blocker page, and a warning modal appears that an answer needs to be submitted.