### PR TITLE
Fix state saving on page change

### DIFF
--- a/cypress/integration/data-saving-anonymous.ts
+++ b/cypress/integration/data-saving-anonymous.ts
@@ -19,23 +19,21 @@ context("Saving and loading data as an anonymous user", () => {
     });
   });
 
-  describe("Saving and loading data", () => {
+  describe("Data saving", () => {
     const runKey = uuidv4();
     const activityUrl = "?activity=sample-activity-1&enableFirestorePersistence";
 
-    it("we can use a runKey to retrieve data previously persisted", () => {
+    it("happens automatically after a small delay", () => {
+      // Data is being saved in two ways:
+      // 1. After a small delay (to prevent spamming the database)
+      // 2. When user changes the activity pages using header navigation.
+      // This test focuses on 1. case.
       const activityUrlWithRunKey = activityUrl + "&runKey=" + runKey;
-
       cy.visit(activityUrlWithRunKey + "&clearFirestorePersistence");
       activityPage.getNavPage(2).click();
       getInIframe("body", "[data-cy=choices-container] input").eq(1).click({force: true});
 
-      // unfortunately we have to wait for the data to be posted to firestore, which happens after a
-      // delay to prevent spamming the database.
-      // The fastest and most reliable way to kick it off seems to be 1. blur, 2. wait, 3. navigate away
-      cy.get("[data-cy=account-owner").click({force: true});
       cy.wait(3000);
-      activityPage.getNavPage(1).click();
 
       // We are essentially reloading the page here but in this case we are not clearing the persistance first
       // this should force the activity player to load the data back in from the runKey
@@ -44,7 +42,33 @@ context("Saving and loading data as an anonymous user", () => {
       getInIframe("body", "[data-cy=choices-container] input").eq(1).should("be.checked");
     });
 
-    it("we can remove a runKey and we will no longer see our data", () => {
+    it("is enforced when user changes the page", () => {
+      // Data is being saved in two ways:
+      // 1. After a small delay (to prevent spamming the database)
+      // 2. When user changes the activity pages using header navigation.
+      // This test focuses on 2. case.
+      const activityUrlWithRunKey = activityUrl + "&runKey=" + runKey;
+      cy.visit(activityUrlWithRunKey + "&clearFirestorePersistence");
+
+      // Select a MC answer on page 2, immediately (!) change page to 1, and then change page to 2 again.
+      // Answer should not be lost, as AP should request all the interactive states before switching a page.
+      // Do NOT use any cy.wait in this test, as it'll break its purpose. If this test fails, it most likely means
+      // that one of the Imperative API #requestInteractiveState(s) functions is broken.
+      activityPage.getNavPage(2).click();
+      cy.contains("Question #2");
+      getInIframe("body", "[data-cy=choices-container] input").eq(1).click({force: true});
+
+      activityPage.getNavPage(1).click();
+      activityPage.getNavPage(1).should("have.class", "current");
+      cy.contains("Question #1");
+
+      activityPage.getNavPage(2).click();
+      activityPage.getNavPage(2).should("have.class", "current");
+      cy.contains("Question #2");
+      getInIframe("body", "[data-cy=choices-container] input").eq(1).should("be.checked");
+    });
+
+    it("is bound to runKey (after removing it, users no longer will see their data)", () => {
       const activityUrlWithRunKey = activityUrl + "&runKey=" + runKey;
 
       // Answer the question
@@ -52,12 +76,8 @@ context("Saving and loading data as an anonymous user", () => {
       activityPage.getNavPage(2).click();
       getInIframe("body", "[data-cy=choices-container] input").eq(1).click({force: true});
 
-      // unfortunately we have to wait for the data to be posted to firestore, which happens after a
-      // delay to prevent spamming the database.
-      // The fastest and most reliable way to kick it off seems to be 1. blur, 2. wait, 3. navigate away
       cy.get("[data-cy=account-owner").click({force: true});
       cy.wait(3000);
-      activityPage.getNavPage(1).click();
 
       // Make sure the answer is actually saved in storage
       cy.visit(activityUrlWithRunKey);

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -23,7 +23,7 @@ interface IProps {
   teacherEditionMode?: boolean;
   setNavigation?: (id: string, options: INavigationOptions) => void;
   pluginsLoaded: boolean;
-  embeddableRef?: React.Ref<EmbeddableImperativeAPI>;
+  ref?: React.Ref<EmbeddableImperativeAPI>;
 }
 
 export interface EmbeddableImperativeAPI {
@@ -32,7 +32,7 @@ export interface EmbeddableImperativeAPI {
 
 type ISendCustomMessage = (message: ICustomMessage) => void;
 
-export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((props, embeddableRef) => {
+export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
   const { embeddable, sectionLayout, activityLayout, linkedPluginEmbeddable, displayMode, questionNumber, setNavigation, teacherEditionMode, pluginsLoaded } = props;
   const handleSetNavigation = useCallback((options: INavigationOptions) => {
     setNavigation?.(embeddable.ref_id, options);
@@ -63,10 +63,8 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
     }
   }, [LARA, linkedPluginEmbeddable, embeddable, pluginsLoaded]);
 
-  useImperativeHandle(embeddableRef, () => ({
-    requestInteractiveState: () => {
-      return managedInteractiveRef.current?.requestInteractiveState() || Promise.resolve();
-    }
+  useImperativeHandle(ref, () => ({
+    requestInteractiveState: () => managedInteractiveRef.current?.requestInteractiveState() || Promise.resolve()
   }));
 
   const handleSetSupportedFeatures = useCallback((container: HTMLElement, features: ISupportedFeatures) => {


### PR DESCRIPTION
AP should request all the interactives state on page change. This was initially implemented here: https://github.com/concord-consortium/activity-player/pull/103.

However, this feature got broken when sections support was added and the `Section` component was inserted between `ActivityPageContent` and `Embeddable` components.

This PR also updates Cypress tests related to data saving. We had tests that could actually detect the problem - they were saving user data and changing pages, but... there were explicit `cy.wait` commands that prevented that from being actually tested and detected (also, comments suggested like this feature never existed). So, I've updated these tests to focus on two separate cases:
- automatic saving after a delay
- automatic saving on page change

I tried to comment out my recent updates and the Cypress test failed as expected.


