### PR TITLE
Added unloading option [#181169438]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9219,9 +9219,9 @@
       }
     },
     "@concord-consortium/lara-interactive-api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.3.0.tgz",
-      "integrity": "sha512-reNmLonA0qMzLND0Y1GhHqFdygOP0kDb4oHIWvktyJokzL/cNxOKjv60AlIIs55wm297i6DdFlvLSRR0VgNe6A==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/lara-interactive-api/-/lara-interactive-api-1.5.2.tgz",
+      "integrity": "sha512-ITOMXtOfLfqusMuDSEgVQsv0HI7KdJ+GCtos9IjTDyvu5JdBKk6QLdHOB+bw4hfqKzpNnw8/ZjCaWllFLG7T+Q==",
       "requires": {
         "iframe-phone": "^1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "@aws-sdk/client-s3": "^3.44.0",
     "@aws-sdk/s3-request-presigner": "^3.44.0",
     "@concord-consortium/interactive-api-host": "^0.5.0",
-    "@concord-consortium/lara-interactive-api": "^1.3.0",
+    "@concord-consortium/lara-interactive-api": "^1.5.2",
     "@concord-consortium/text-decorator": "^1.0.2",
     "@concord-consortium/token-service": "^2.1.0",
     "@react-hook/resize-observer": "^1.2.5",

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -3,7 +3,7 @@ import { Section, SectionImperativeAPI } from "./section";
 import { BottomButtons } from "./bottom-buttons";
 import { numQuestionsOnPreviousSections } from "../../utilities/activity-utils";
 import { Page, SectionType } from "../../types";
-import { INavigationOptions } from "@concord-consortium/lara-interactive-api";
+import { IGetInteractiveState, INavigationOptions } from "@concord-consortium/lara-interactive-api";
 import { Logger, LogEventName } from "../../lib/logger";
 import { showReport } from "../../utilities/report-utils";
 
@@ -50,10 +50,10 @@ export class ActivityPageContent extends React.PureComponent <IProps> {
     );
   }
 
-  public requestInteractiveStates() {
+  public requestInteractiveStates(options?: IGetInteractiveState) {
     const promises: Promise<void>[] = [];
     this.props.page.sections.forEach((section: SectionType, idx: number) =>
-      promises.push(...(this.sectionRefs[idx]?.current?.requestInteractiveStates() || [Promise.resolve()]))
+      promises.push(...(this.sectionRefs[idx]?.current?.requestInteractiveStates(options) || [Promise.resolve()]))
     );
     return promises;
   }

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -9,7 +9,7 @@ import { initializePlugin, IPartialEmbeddablePluginContext, validateEmbeddablePl
         } from "../../utilities/plugin-utils";
 import { EmbeddableType, IEmbeddablePlugin } from "../../types";
 import { IInteractiveSupportedFeaturesEvent } from "../../lara-plugin/events";
-import { ICustomMessage, ISupportedFeatures, INavigationOptions } from "@concord-consortium/lara-interactive-api";
+import { ICustomMessage, ISupportedFeatures, INavigationOptions, IGetInteractiveState } from "@concord-consortium/lara-interactive-api";
 
 import "./embeddable.scss";
 
@@ -27,7 +27,7 @@ interface IProps {
 }
 
 export interface EmbeddableImperativeAPI {
-  requestInteractiveState: () => Promise<void>;
+  requestInteractiveState: (options?: IGetInteractiveState) => Promise<void>;
 }
 
 type ISendCustomMessage = (message: ICustomMessage) => void;
@@ -64,7 +64,7 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
   }, [LARA, linkedPluginEmbeddable, embeddable, pluginsLoaded]);
 
   useImperativeHandle(ref, () => ({
-    requestInteractiveState: () => managedInteractiveRef.current?.requestInteractiveState() || Promise.resolve()
+    requestInteractiveState: (options?: IGetInteractiveState) => managedInteractiveRef.current?.requestInteractiveState(options) || Promise.resolve()
   }));
 
   const handleSetSupportedFeatures = useCallback((container: HTMLElement, features: ISupportedFeatures) => {

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -8,7 +8,7 @@ import {
   IGetInteractiveSnapshotResponse, IInitInteractive, ILinkedInteractive, IReportInitInteractive,
   ISupportedFeatures, ServerMessage, IShowModal, ICloseModal, INavigationOptions, ILinkedInteractiveStateResponse,
   IAddLinkedInteractiveStateListenerRequest, IRemoveLinkedInteractiveStateListenerRequest, IDecoratedContentEvent,
-  ITextDecorationInfo, ITextDecorationHandlerInfo, IAttachmentUrlRequest, IAttachmentUrlResponse
+  ITextDecorationInfo, ITextDecorationHandlerInfo, IAttachmentUrlRequest, IAttachmentUrlResponse, IGetInteractiveState
 } from "@concord-consortium/lara-interactive-api";
 import Shutterbug from "shutterbug";
 import { Logger } from "../../../lib/logger";
@@ -20,7 +20,7 @@ import { getReportUrl } from "../../../utilities/report-utils";
 
 const kDefaultHeight = 300;
 
-const kInteractiveStateRequestTimeout = 2000; // ms
+const kInteractiveStateRequestTimeout = 20000; // ms
 
 const getListenerTypes = (textDecorationHandlerInfo: ITextDecorationHandlerInfo): Array<{type: string}> => {
   const { eventListeners } = textDecorationHandlerInfo;
@@ -43,7 +43,7 @@ const createTextDecorationInfo = () => {
 };
 
 export interface IframeRuntimeImperativeAPI {
-  requestInteractiveState: () => Promise<void>;
+  requestInteractiveState: (options?: IGetInteractiveState) => Promise<void>;
 }
 
 interface IProps {
@@ -326,9 +326,9 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
   }, []);
 
   useImperativeHandle(ref, () => ({
-    requestInteractiveState: () => {
+    requestInteractiveState: (options?: IGetInteractiveState) => {
       if (!interactiveStateRequest.promise.current) {
-        phoneRef.current?.post("getInteractiveState");
+        phoneRef.current?.post("getInteractiveState", options);
         interactiveStateRequest.promise.current = new Promise<void>((resolve, reject) => {
           const cleanup = () => {
             interactiveStateRequest.promise.current = undefined;

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -4,7 +4,7 @@ import { IframeRuntime, IframeRuntimeImperativeAPI } from "./iframe-runtime";
 import useResizeObserver from "@react-hook/resize-observer";
 import {
   ICloseModal, INavigationOptions,
-  ICustomMessage, IShowDialog, IShowLightbox, IShowModal, ISupportedFeatures, IAttachmentUrlRequest, IAttachmentUrlResponse
+  ICustomMessage, IShowDialog, IShowLightbox, IShowModal, ISupportedFeatures, IAttachmentUrlRequest, IAttachmentUrlResponse, IGetInteractiveState
 } from "@concord-consortium/lara-interactive-api";
 import { PortalDataContext } from "../../portal-data-context";
 import { IManagedInteractive, IMwInteractive, LibraryInteractiveData, IExportableAnswerMetadata, ILegacyLinkedInteractiveState } from "../../../types";
@@ -33,7 +33,7 @@ interface IProps {
 }
 
 export interface ManagedInteractiveImperativeAPI {
-  requestInteractiveState: () => Promise<void>;
+  requestInteractiveState: (options?: IGetInteractiveState) => Promise<void>;
 }
 
 const kDefaultAspectRatio = 4 / 3;
@@ -259,9 +259,9 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   };
 
   useImperativeHandle(ref, () => ({
-    requestInteractiveState: () => {
+    requestInteractiveState: (options?: IGetInteractiveState) => {
       if (shouldWatchAnswer && iframeRuntimeRef.current) {
-        return iframeRuntimeRef.current.requestInteractiveState();
+        return iframeRuntimeRef.current.requestInteractiveState(options);
       } else {
         // Interactive doesn't save state, so return resolved promise immediately.
         return Promise.resolve();

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -7,7 +7,7 @@ import IconChevronRight from "../../assets/svg-icons/icon-chevron-right.svg";
 import IconChevronLeft from "../../assets/svg-icons/icon-chevron-left.svg";
 import { EmbeddableType, Page, SectionType } from "../../types";
 import { Logger, LogEventName } from "../../lib/logger";
-import { INavigationOptions } from "@concord-consortium/lara-interactive-api";
+import { IGetInteractiveState, INavigationOptions } from "@concord-consortium/lara-interactive-api";
 import useResizeObserver from "@react-hook/resize-observer";
 
 import "./section.scss";
@@ -24,7 +24,7 @@ interface IProps {
 }
 
 export interface SectionImperativeAPI {
-  requestInteractiveStates: () => Promise<void>[];
+  requestInteractiveStates: (options?: IGetInteractiveState) => Promise<void>[];
 }
 
 export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
@@ -59,9 +59,9 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
   }, [screenHeight]);
 
   useImperativeHandle(ref, () => ({
-    requestInteractiveStates: () =>
+    requestInteractiveStates: (options?: IGetInteractiveState) =>
       section.embeddables.map((embeddable: EmbeddableType) =>
-        embeddableRefs.current[embeddable.ref_id]?.current?.requestInteractiveState() || Promise.resolve()
+        embeddableRefs.current[embeddable.ref_id]?.current?.requestInteractiveState(options) || Promise.resolve()
       )
   }));
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -480,7 +480,7 @@ export class App extends React.PureComponent<IProps, IState> {
         });
       };
       // Make sure that interactive state is saved before user can navigate away.
-      const promises = this.activityPageContentRef.current?.requestInteractiveStates() || [Promise.resolve()];
+      const promises = this.activityPageContentRef.current?.requestInteractiveStates({unloading: true}) || [Promise.resolve()];
       Promise.all(promises)
         .then(navigateAway)
         .catch(error => {


### PR DESCRIPTION
This adds the new `unloading` option to the `getInteractiveState` message which lets the interactive know it is being removed due to a page change.  With [this CFM PR](https://github.com/concord-consortium/cloud-file-manager/pull/260) SageModeler/CODAP interactives will now have their final state saved instead of the last state from the autoSave timer.