### PR TITLE
Fix interactive reset button functionality.

### DIFF
--- a/cypress/integration/activity-page.test.ts
+++ b/cypress/integration/activity-page.test.ts
@@ -31,18 +31,19 @@ context("Test the overall app", () => {
     });
   });
   describe("Info/Assess (secondary embeddables)",()=>{
-    it("verify collapsible column",()=>{
-      activityPage.getCollapsibleHeader().should("contain", "Hide");
-      activityPage.getCollapsibleHeader().click();
-      activityPage.getCollapsibleHeader().should("have.class", "collapsed").and("contain", "Show");
-      activityPage.getCollapsibleHeader().click();
-      activityPage.getCollapsibleHeader().should("have.not.class", "collapsed").and("contain", "Hide");
-    });
     it("verify textbox",()=>{
       activityPage.getNavPage(3).click();
       cy.wait(1);
       activityPage.getSecondaryEmbeddable("text-box").eq(1).scrollIntoView()
         .should("be.visible").and("contain","Duis vitae ultrices augue, eu fermentum elit.");
+    });
+    it("verify collapsible column",()=>{
+      activityPage.getNavPage(2).click();
+      activityPage.getCollapsibleHeader().should("contain", "Hide");
+      activityPage.getCollapsibleHeader().click();
+      activityPage.getCollapsibleHeader().should("have.class", "collapsed").and("contain", "Show");
+      activityPage.getCollapsibleHeader().click();
+      activityPage.getCollapsibleHeader().should("have.not.class", "collapsed").and("contain", "Hide");
     });
   });
   describe("Required questions",()=>{
@@ -65,7 +66,6 @@ context("Test the overall app", () => {
       activityPage.getCompletionPage().eq(0).click();
       cy.wait(1000);
       activityPage.getNextPageButton().should("have.class", "last-page");
-
     });
   });
   describe("Question Interactives",()=>{

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -210,7 +210,11 @@ describe("IframeRuntime component", () => {
 
     const resetButton = testIframe.getByTestId("reset-button");
     expect(resetButton).toBeDefined();
-    fireEvent.click(resetButton);
+    expect(mockSetInteractiveState).toHaveBeenCalledTimes(2);
+    act(() => {
+      fireEvent.click(resetButton);
+    });
     expect(global.confirm).toHaveBeenCalledTimes(1);
+    expect(mockSetInteractiveState).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/components/activity-page/managed-interactive/lightbox.test.tsx
+++ b/src/components/activity-page/managed-interactive/lightbox.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Lightbox } from "./lightbox";
+import { fireEvent, render } from "@testing-library/react";
+
+describe("Lightbox component", () => {
+  it("renders an image lightbox with a close button", () => {
+    const imageUrl = "https://concord.org/test.png";
+    const stubOnClose = jest.fn();
+    const { getByTestId } = render(
+      <Lightbox type="lightbox" onClose={stubOnClose} isImage={true} url={imageUrl} allowUpscale={true} />
+    );
+    const image = getByTestId("lightbox-image");
+    expect(image).toBeDefined();
+    expect(image).toHaveAttribute("src", imageUrl);
+    const closeButton = getByTestId("lightbox-close");
+    expect(closeButton).toBeDefined();
+    fireEvent.click(closeButton);
+    expect(stubOnClose).toHaveBeenCalledTimes(1);
+  });
+  it("renders an iframe lightbox with a close button", () => {
+    const iframeUrl = "https://concord.org/test.html";
+    const stubOnClose = jest.fn();
+    const { getByTestId } = render(
+      <Lightbox type="lightbox" onClose={stubOnClose} isImage={false} url={iframeUrl} allowUpscale={false} />
+    );
+    const iframe = getByTestId("lightbox-iframe");
+    expect(iframe).toBeDefined();
+    expect(iframe).toHaveAttribute("src", iframeUrl);
+    const closeButton = getByTestId("lightbox-close");
+    expect(closeButton).toBeDefined();
+    fireEvent.click(closeButton);
+    expect(stubOnClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/activity-page/managed-interactive/lightbox.tsx
+++ b/src/components/activity-page/managed-interactive/lightbox.tsx
@@ -83,11 +83,11 @@ export const Lightbox: React.FC<IProps> = (props) => {
   return (
     <ReactModal isOpen={true} appElement={getModalContainer()} onRequestClose={onClose} style={customStyles} >
       <div className="lightbox-content">
-      <div className="lightbox-close-icon" onClick={onClose}>✖</div>
+      <div className="lightbox-close-icon" onClick={onClose} data-testid="lightbox-close">✖</div>
       {
         isImage ?
-        <img ref={imgRef} src={url} onLoad={imgLoaded} style={{ width: imgWidth, height: imgHeight, visibility: imgWidth === undefined ? "hidden" : "visible" }} /> :
-        <iframe src={url} width={iframeSizeOpts.width} height={iframeSizeOpts.height} title="Image lightbox" />
+        <img ref={imgRef} src={url} onLoad={imgLoaded} style={{ width: imgWidth, height: imgHeight, visibility: imgWidth === undefined ? "hidden" : "visible" }} data-testid="lightbox-image" /> :
+        <iframe src={url} width={iframeSizeOpts.width} height={iframeSizeOpts.height} title="Image lightbox" data-testid="lightbox-iframe" />
       }
       </div>
     </ReactModal>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/181169398

[#181169398]

With the work done in https://github.com/concord-consortium/activity-player/pull/332 the reset handler was resetting interactives to the state they had when the page loaded. That would include any work that had been saved in previous sessions. These changes correct that so the interactive is fully reset to its default state, with no saved work at all.