### PR TITLE
Skip saving iframe runtime interactive state when there is no change [#181175814]

### DIFF
--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -101,6 +101,8 @@ describe("IframeRuntime component", () => {
     });
     expect(lastPost()).toBe("customMessage");
 
+    expect(mockSetInteractiveState).not.toHaveBeenCalled();
+
     act(() => {
       dispatchMessageFromChild("interactiveState", {});
     });
@@ -117,6 +119,18 @@ describe("IframeRuntime component", () => {
     });
     // "touch" message results in another call
     expect(mockSetInteractiveState).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      dispatchMessageFromChild("interactiveState", {});
+    });
+    // saving the same interactive state doesn't result in another call
+    expect(mockSetInteractiveState).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      dispatchMessageFromChild("interactiveState", {foo: "bar"});
+    });
+    // saving a different interactive state results in another call
+    expect(mockSetInteractiveState).toHaveBeenCalledTimes(3);
 
     act(() => {
       dispatchMessageFromChild("height", 960);
@@ -210,11 +224,11 @@ describe("IframeRuntime component", () => {
 
     const resetButton = testIframe.getByTestId("reset-button");
     expect(resetButton).toBeDefined();
-    expect(mockSetInteractiveState).toHaveBeenCalledTimes(2);
+    expect(mockSetInteractiveState).toHaveBeenCalledTimes(3);
     act(() => {
       fireEvent.click(resetButton);
     });
     expect(global.confirm).toHaveBeenCalledTimes(1);
-    expect(mockSetInteractiveState).toHaveBeenCalledTimes(4);
+    expect(mockSetInteractiveState).toHaveBeenCalledTimes(5);
   });
 });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -113,8 +113,13 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
         // "nochange" and "touch" are special messages supported by LARA. We don't want to save them.
         // newInteractiveState might be undefined if interactive state is requested before any state update.
         if (newInteractiveState !== undefined && newInteractiveState !== "nochange" && newInteractiveState !== "touch") {
-          currentInteractiveState.current = newInteractiveState;
-          setInteractiveStateRef.current(newInteractiveState);
+          // only update interactive state if it's different from the current one to avoid updating the timestamp
+          // used when comparing linked interactive states
+          const interactiveStateChanged = JSON.stringify(currentInteractiveState.current) !== JSON.stringify(newInteractiveState);
+          if (interactiveStateChanged) {
+            currentInteractiveState.current = newInteractiveState;
+            setInteractiveStateRef.current(newInteractiveState);
+          }
         }
         if (currentInteractiveState.current !== undefined && newInteractiveState === "touch") {
           // save the current interactive state with a new timestamp
@@ -394,7 +399,7 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
               title={iframeTitle}
               scrolling="no"
       />
-      {showDeleteDataButton && 
+      {showDeleteDataButton &&
         <button className="button reset" data-cy="reset-button" onClick={handleResetButtonClick} onKeyDown={handleResetButtonClick}>
           Clear &amp; start over
           <ReloadIcon />


### PR DESCRIPTION
This avoids updating the timestamp that is used when comparing linked interactive states.