### PR TITLE
Added page change  notifications [#181511767]

### DIFF
--- a/src/components/activity-page/activity-page-content.test.tsx
+++ b/src/components/activity-page/activity-page-content.test.tsx
@@ -4,13 +4,14 @@ import { configure, render } from "@testing-library/react";
 import { DefaultTestPage } from "../../test-utils/model-for-tests";
 
 describe("Activity Page Content component", () => {
+  const stubFunction = () => {
+    // do nothing.
+  };
+  const page = { ...DefaultTestPage, layout: "l-responsive" };
+  configure({ testIdAttribute: "data-cy" });
+
   it("renders component", () => {
-    const stubFunction = () => {
-      // do nothing.
-    };
-    const page = { ...DefaultTestPage, layout: "l-responsive" };
-    configure({ testIdAttribute: "data-cy" });
-    const { getByTestId } = render(<ActivityPageContent
+    const { getByTestId, queryAllByTestId } = render(<ActivityPageContent
       enableReportButton={false}
       activityLayout={0}
       page={page}
@@ -20,5 +21,42 @@ describe("Activity Page Content component", () => {
       pluginsLoaded={true}
     />);
     expect(getByTestId("page-content")).toBeDefined();
+
+    const notifications = queryAllByTestId("page-change-notification");
+    expect(notifications.length).toBe(0);
+  });
+
+  describe("with page change notification", () => {
+    it("renders page change started notification", () => {
+      const { getAllByTestId } = render(<ActivityPageContent
+        enableReportButton={false}
+        activityLayout={0}
+        page={page}
+        pageNumber={5}
+        totalPreviousQuestions={5}
+        setNavigation={stubFunction}
+        pluginsLoaded={true}
+        pageChangeNotification={{state: "started"}}
+      />);
+      const notifications = getAllByTestId("page-change-notification");
+      expect(notifications.length).toBe(2);
+      expect(notifications[0].textContent).toBe("Please wait, your work is being saved...");
+    });
+
+    it("renders page change errored notification", () => {
+      const { getAllByTestId } = render(<ActivityPageContent
+        enableReportButton={false}
+        activityLayout={0}
+        page={page}
+        pageNumber={5}
+        totalPreviousQuestions={5}
+        setNavigation={stubFunction}
+        pluginsLoaded={true}
+        pageChangeNotification={{state: "errored", message: "Test error message!"}}
+      />);
+      const notifications = getAllByTestId("page-change-notification");
+      expect(notifications.length).toBe(2);
+      expect(notifications[0].textContent).toBe("Test error message!");
+    });
   });
 });

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -6,6 +6,7 @@ import { Page, SectionType } from "../../types";
 import { IGetInteractiveState, INavigationOptions } from "@concord-consortium/lara-interactive-api";
 import { Logger, LogEventName } from "../../lib/logger";
 import { showReport } from "../../utilities/report-utils";
+import { IPageChangeNotification, PageChangeNotification } from "./page-change-notification";
 
 import "./activity-page-content.scss";
 
@@ -18,6 +19,7 @@ interface IProps {
   totalPreviousQuestions: number;
   setNavigation: (refId: string, options: INavigationOptions) => void;
   pluginsLoaded: boolean;
+  pageChangeNotification?: IPageChangeNotification;
 }
 
 export class ActivityPageContent extends React.PureComponent <IProps> {
@@ -25,6 +27,10 @@ export class ActivityPageContent extends React.PureComponent <IProps> {
 
   public constructor(props: IProps) {
     super(props);
+  }
+
+  renderPageChangeNotification() {
+    return <PageChangeNotification pageChangeNotification={this.props.pageChangeNotification} />;
   }
 
   render() {
@@ -37,6 +43,7 @@ export class ActivityPageContent extends React.PureComponent <IProps> {
     return (
       <>
         {page.is_hidden && this.renderHiddenWarningBanner()}
+        {this.renderPageChangeNotification()}
         <div className={`page-content full ${isResponsiveLayout ? "responsive" : ""}`} data-cy="page-content">
           <div className="name">{ pageTitle }</div>
           {this.renderSections(sections, totalPreviousQuestions)}
@@ -46,6 +53,7 @@ export class ActivityPageContent extends React.PureComponent <IProps> {
             />
           }
         </div>
+        {this.renderPageChangeNotification()}
       </>
     );
   }

--- a/src/components/activity-page/page-change-notification.scss
+++ b/src/components/activity-page/page-change-notification.scss
@@ -1,0 +1,18 @@
+@import "../vars.scss";
+
+.page-change-notification {
+  background-color: $cc-orange-light1;
+  color: $cc-charcoal;
+  padding: 18px;
+  font-family: Lato;
+  font-size: 20px;
+  font-weight: bold;
+  font-stretch: normal;
+  font-style: italic;
+  text-align: center;
+}
+
+.page-change-notification-errored {
+  background-color: $activity-red;
+  color: $cc-charcoal-light3;
+}

--- a/src/components/activity-page/page-change-notification.test.tsx
+++ b/src/components/activity-page/page-change-notification.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { PageChangeNotification } from "./page-change-notification";
+import { shallow } from "enzyme";
+
+describe("Page Change Notification component", () => {
+  it("renders nothing when prop is undefined", () => {
+    const wrapper = shallow(<PageChangeNotification pageChangeNotification={undefined} />);
+    expect(wrapper.type()).toBe(null);
+  });
+
+  it("renders a message when in the started state", () => {
+    const wrapper = shallow(<PageChangeNotification pageChangeNotification={{state: "started"}} />);
+    expect(wrapper.text()).toBe("Please wait, your work is being saved...");
+    expect(wrapper.hasClass("page-change-notification")).toBe(true);
+    expect(wrapper.hasClass("page-change-notification-errored")).toBe(false);
+  });
+
+  it("renders a message when in the error state", () => {
+    const wrapper = shallow(<PageChangeNotification pageChangeNotification={{state: "errored", message: "Test error message!"}} />);
+    expect(wrapper.text()).toBe("Test error message!");
+    expect(wrapper.hasClass("page-change-notification")).toBe(true);
+    expect(wrapper.hasClass("page-change-notification-errored")).toBe(true);
+  });
+});

--- a/src/components/activity-page/page-change-notification.tsx
+++ b/src/components/activity-page/page-change-notification.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import "./page-change-notification.scss";
+
+export const PageChangeNotificationStartTimeout = 500;
+export const PageChangeNotificationErrorTimeout = 3000;
+
+interface IPageChangeNotificationStarted {
+  state: "started";
+}
+interface IPageChangeNotificationErrored {
+  state: "errored";
+  message: string;
+}
+export type IPageChangeNotification = IPageChangeNotificationStarted | IPageChangeNotificationErrored;
+
+interface IProps {
+  pageChangeNotification: IPageChangeNotification | undefined;
+}
+
+export class PageChangeNotification extends React.PureComponent<IProps> {
+  render() {
+    if (this.props.pageChangeNotification) {
+      switch (this.props.pageChangeNotification.state) {
+        case "started":
+          return (
+            <div className="page-change-notification" data-cy="page-change-notification">
+              Please wait, your work is being saved...
+            </div>
+          );
+
+        case "errored":
+          return (
+            <div className="page-change-notification page-change-notification-errored" data-cy="page-change-notification">
+              {this.props.pageChangeNotification.message}
+            </div>
+          );
+      }
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
The page change notification displays a please wait message after 500ms on a page change along with an error with a 3000ms delay.  Previously no please wait message was shown and any error was shown in a Javascript alert.