### PR TITLE
Changed iframe-runtime to use 100% width if the interactive provides a height value [#182216079]

### DIFF
--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -200,7 +200,6 @@ describe("IframeRuntime component", () => {
       dispatchMessageFromChild("height", 960);
     });
     // both width and height are set.  width is 100% due to the interactive posting its height to the iframe
-    // and the aspect ratio being the default
     expect(testIframe.getByTestId("iframe-runtime").children[0]).toHaveAttribute("width", "100%");
     expect(testIframe.getByTestId("iframe-runtime").children[0]).toHaveAttribute("height", "960");
 

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -191,10 +191,18 @@ describe("IframeRuntime component", () => {
     // saving a different interactive state results in another call
     expect(mockSetInteractiveState).toHaveBeenCalledTimes(3);
 
+    expect(testIframe.getByTestId("iframe-runtime").children[0].tagName).toBe("IFRAME");
+    // width is not set as the containerWidth prop is undefined due to window.innerHeight not being set in this test
+    // height is the default of 300px
+    expect(testIframe.getByTestId("iframe-runtime").children[0]).not.toHaveAttribute("width");
+    expect(testIframe.getByTestId("iframe-runtime").children[0]).toHaveAttribute("height", "300");
     act(() => {
       dispatchMessageFromChild("height", 960);
     });
-    // TODO: verify that height was handled properly
+    // both width and height are set.  width is 100% due to the interactive posting its height to the iframe
+    // and the aspect ratio being the default
+    expect(testIframe.getByTestId("iframe-runtime").children[0]).toHaveAttribute("width", "100%");
+    expect(testIframe.getByTestId("iframe-runtime").children[0]).toHaveAttribute("height", "960");
 
     act(() => {
       dispatchMessageFromChild("supportedFeatures", { features: { aspectRatio: 1.5 } });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -404,9 +404,12 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
   // or height from container dimensions and embeddable specifications.
   const height = heightFromInteractive || heightFromSupportedFeatures || proposedHeight || kDefaultHeight;
 
+  // If the interactive sets the height, ignore the container width passed in and use all the available space.
+  const width = heightFromInteractive ? "100%" : containerWidth;
+
   return (
     <div className="iframe-runtime" data-cy="iframe-runtime">
-      <iframe key={`${id}-${reloadCount}`} ref={iframeRef} src={url} id={id} width={containerWidth} height={height} frameBorder={0}
+      <iframe key={`${id}-${reloadCount}`} ref={iframeRef} src={url} id={id} width={width} height={height} frameBorder={0}
               allowFullScreen={true}
               allow="geolocation; microphone; camera"
               title={iframeTitle}

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -179,6 +179,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
     case "MANUAL":
       proposedHeight = divSize?.width / aspectRatio;
       break;
+    case "DEFAULT":
     default:
       if (divSize?.width / aspectRatio > screenHeight.dynamicHeight) {
         proposedHeight = screenHeight.dynamicHeight - kBottomMargin;


### PR DESCRIPTION
Previously the containerWidth prop was used which defaults to 100% but in the "DEFAULT" aspect ratio method may get resized based on the screen size.

This also add an explicit case for the "DEFAULT" aspect ratio in the managed interactive when it computes the proposedHeight and containerWidth.