### PR TITLE
Added conversion of production glossary plugin urls [#182392985]

### DIFF
--- a/src/convert-old-lara/convert.test.ts
+++ b/src/convert-old-lara/convert.test.ts
@@ -1,7 +1,9 @@
 import _activity from "../data/sample-activity-multiple-layout-types.json";
 import _sequence from "../data/sample-sequence-with-questions.json";
+import _glossaryActivity from "../data/sample-activity-glossary-plugin.json";
 import { Activity, Sequence } from "../types";
 import { convertLegacyResource } from "./convert";
+import { productionGlossaryUrl } from "./glossary-info";
 
 describe("conversion test", () => {
   it("convert activity", async() => {
@@ -11,6 +13,16 @@ describe("conversion test", () => {
     expect(convertedResource.version).toEqual(2);
     expect(convertedResource.pages[1].sections).toHaveLength(2);
     expect(convertedResource.pages[1].sections[1].embeddables).toHaveLength(5);
+  });
+  it("convert glossary activity", async() => {
+    const glossaryActivity = _glossaryActivity;
+    const convertedResource = await convertLegacyResource(glossaryActivity) as Activity;
+    const originalAuthorData = JSON.parse(glossaryActivity.plugins[0].author_data);
+    const convertedAuthorData = JSON.parse(convertedResource.plugins[0].author_data);
+    expect(originalAuthorData.glossaryResourceId).toBe("upZ83jqTZAZuoQqRAfAb");
+    expect(convertedAuthorData.glossaryResourceId).toBe("this-is-a-fake-CONVERTED-glossary-resource-id");
+    expect(originalAuthorData.s3Url).toBe("https://models-resources.concord.org/glossary-resources/upZ83jqTZAZuoQqRAfAb/glossary.json");
+    expect(convertedAuthorData.s3Url).toBe(`${productionGlossaryUrl}/api/v1/glossaries/37?json_only=true`);
   });
   it("convert sequence", async() => {
     const sequence = _sequence;

--- a/src/convert-old-lara/glossary-info.ts
+++ b/src/convert-old-lara/glossary-info.ts
@@ -1,0 +1,165 @@
+export const productionGlossaryUrl = "https://lara2.concordqa.org";
+
+export const productionGlossaries = [
+  {
+    "id": 8,
+    "name": "Gas Laws 2020",
+    "glossaryResourceId": "NciBizL2HUI7qiv3XdAB",
+  },
+  {
+    "id": 9,
+    "name": "Test Glossary",
+    "glossaryResourceId": "OsuYZYOHoZKMVXMV2ijr",
+  },
+  {
+    "id": 10,
+    "name": "Wild Blueberries Lesson 1 Glossary",
+    "glossaryResourceId": "aSkyVRFkmrnVDqIbxyIN",
+  },
+  {
+    "id": 11,
+    "name": "Wild Blueberries Lesson 2 Glossary",
+    "glossaryResourceId": "lVXWBw9Wa1mTBkIlExXs",
+  },
+  {
+    "id": 12,
+    "name": "Wild Blueberries Lesson 3 Glossary",
+    "glossaryResourceId": "fl8EYoUvUH5GX6D9qVik",
+  },
+  {
+    "id": 13,
+    "name": "Lake Ice-Out Lesson 1 Glossary",
+    "glossaryResourceId": "WKGIe87AR1lBp56SmakN",
+  },
+  {
+    "id": 14,
+    "name": "Lake Ice-Out Lesson 2 Glossary",
+    "glossaryResourceId": "ldArmSwDXRWM1viTO1c7",
+  },
+  {
+    "id": 15,
+    "name": "Lake Ice-Out Lesson 3 Glossary",
+    "glossaryResourceId": "7WaEBOXFakRRoXOUDnDk",
+  },
+  {
+    "id": 16,
+    "name": "The Shape of Change Lesson 1 Glossary",
+    "glossaryResourceId": "8smLeISuOtZ7ICCDgxGt",
+  },
+  {
+    "id": 17,
+    "name": "The Shape of Change Lesson 2 Glossary",
+    "glossaryResourceId": "Mk3yfHrJbBRGDxNnGIS8",
+  },
+  {
+    "id": 18,
+    "name": "Ticks & Lyme Disease Lesson 1 Glossary",
+    "glossaryResourceId": "cIjkFpLdV0bMLgHHHiem",
+  },
+  {
+    "id": 19,
+    "name": "Ticks & Lyme Disease Lesson 2 Glossary",
+    "glossaryResourceId": "SKFnWkgfxXcTJaugMng4",
+  },
+  {
+    "id": 20,
+    "name": "Ticks & Lyme Disease Lesson 3 Glossary",
+    "glossaryResourceId": "JaN86XReZl45mvcliiMY",
+  },
+  {
+    "id": 21,
+    "name": "Ticks & Lyme Disease Lesson 4 Glossary",
+    "glossaryResourceId": "bfR5f6egaMAKaTHWXY0x",
+  },
+  {
+    "id": 22,
+    "name": "Lobster & Black Sea Bass Lesson 1 Glossary",
+    "glossaryResourceId": "yBtnXkC6fIfXZ61zAjUg",
+  },
+  {
+    "id": 23,
+    "name": "Lobster & Black Sea Bass Lesson 2 Glossary",
+    "glossaryResourceId": "wCUHdGfa7JnCuaWRujzF",
+  },
+  {
+    "id": 24,
+    "name": "Lobster & Black Sea Bass Lesson 3 Glossary",
+    "glossaryResourceId": "1VKwXksQNLj7JBjRzbNe",
+  },
+  {
+    "id": 25,
+    "name": "Diffusion, osmosis, and active transport",
+    "glossaryResourceId": "CBpP9TUgUGuUdDhliQNn",
+  },
+  {
+    "id": 26,
+    "name": "Bug Test Activity Glossary",
+    "glossaryResourceId": "LvcQrzVvnl1Bm8sRKtHw",
+  },
+  {
+    "id": 27,
+    "name": "Kiley's Sample Glossary",
+    "glossaryResourceId": "uGyUKyevEzJldnyYx4I0",
+  },
+  {
+    "id": 28,
+    "name": "V2PluginTestGlossary",
+    "glossaryResourceId": "3Bn1CgFVH2oIpjV6242q",
+ },
+  {
+    "id": 29,
+    "name": "ER Glossary",
+    "glossaryResourceId": "zE3QYVz8xJxomOQVvEbc",
+  },
+  {
+    "id": 30,
+    "name": "test glossary",
+    "glossaryResourceId": "D9afwcpQ834e3XvKoak3",
+  },
+  {
+    "id": 31,
+    "name": "Test",
+    "glossaryResourceId": "FLC50FXJVHBLjSMBkQks",
+  },
+  {
+    "id": 32,
+    "name": "DNA to Proteins",
+    "glossaryResourceId": "hcV6fLyzTbRtB4KYFhxE",
+  },
+  {
+    "id": 33,
+    "name": "Test Glossary 1",
+    "glossaryResourceId": "iWA7lhVgJX2ZyLoG7HXa",
+  },
+  {
+    "id": 34,
+    "name": "TestGlossaryPlugin",
+    "glossaryResourceId": "H7yFsp4riXPRT8bRXd2J",
+  },
+  {
+    "id": 35,
+    "name": "heat and temperature",
+    "glossaryResourceId": "Laz2d1NFDQTQ5uxvSNQd",
+  },
+  {
+    "id": 36,
+    "name": "PC Lesson 1 MA",
+    "glossaryResourceId": "862154P6gx3V6oKtJRZw",
+  },
+  {
+    "id": 37,
+    "name": "PrecipitatingChange-AK-NE",
+    "glossaryResourceId": "upZ83jqTZAZuoQqRAfAb"
+  },
+  {
+    "id": 39,
+    "name": "WATERS",
+    "glossaryResourceId": "oRKDulC2nuAoBjeIaAIh"
+  }
+];
+
+
+export const productionGlossaryIdMap: Record<string, number> = {};
+productionGlossaries.forEach(item => {
+  productionGlossaryIdMap[item.glossaryResourceId] = item.id;
+});

--- a/src/data/sample-activity-glossary-plugin.json
+++ b/src/data/sample-activity-glossary-plugin.json
@@ -174,7 +174,7 @@
   "plugins": [
     {
       "description": null,
-      "author_data": "{\"version\":\"1.0\",\"glossaryResourceId\":\"ISnn8j8r2veEFjPCx3XH\",\"s3Url\":\"https://token-service-files.s3.amazonaws.com/glossary-plugin/ISnn8j8r2veEFjPCx3XH/glossary.json\"}",
+      "author_data": "{\"version\":\"1.0\",\"glossaryResourceId\":\"upZ83jqTZAZuoQqRAfAb\",\"s3Url\":\"https://models-resources.concord.org/glossary-resources/upZ83jqTZAZuoQqRAfAb/glossary.json\"}",
       "approved_script_label": "glossary",
       "component_label": "glossary",
       "approved_script": {


### PR DESCRIPTION
This change converts the s3Url in the glossary plugin data to use the new glossary api endpoint for matching production glossaries.