### PR TITLE
Handle activities and sequences with defunct flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_EC2_METADATA_DISABLED: true

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -210,9 +210,6 @@ export class App extends React.PureComponent<IProps, IState> {
                                    ? sequence.activities[activityIndex]
                                    : await getActivityDefinition(activityPath);
 
-      // tslint:disable-next-line:no-console
-      console.log("activity", sequence, activity);
-
       const showSequenceIntro = sequence != null && sequenceActivityNum < 1;
 
       // page 0 is introduction, inner pages start from 1 and match page.position in exported activity if numeric
@@ -235,7 +232,7 @@ export class App extends React.PureComponent<IProps, IState> {
       // Show a warning about obsolute features if activity/sequences is marked as defunct
       const showDefunctBanner = activity.defunct || (sequence?.defunct);
       // Show the warning if we are not running on production
-      const showWarning = false;
+      const showWarning = firebaseAppName() !== "report-service-pro";
 
       newState = {...newState, activity, activityIndex, currentPage, showThemeButtons, showDefunctBanner, showWarning, showSequenceIntro, sequence, teacherEditionMode, sequenceActivity};
       setDocumentTitle({activity, pageNumber: currentPage, sequence, sequenceActivityNum});
@@ -287,8 +284,6 @@ export class App extends React.PureComponent<IProps, IState> {
   }
 
   render() {
-    // tslint:disable-next-line
-    console.log("state", this.state);
     return (
       <LaraGlobalContext.Provider value={this.LARA}>
         <PortalDataContext.Provider value={this.state.portalData}>

--- a/src/components/defunct-banner.scss
+++ b/src/components/defunct-banner.scss
@@ -1,0 +1,14 @@
+@import "./vars.scss";
+
+.defunct-banner {
+  align-items: center;
+  background-color: $cc-gold;
+  color: black;
+  display: flex;
+  flex-direction: row;
+  font-size: 18px;
+  justify-content: center;
+  margin: -40px -40px 10px;
+  padding: 20px;
+  width: calc(100% + 80px);
+}

--- a/src/components/defunct-banner.scss
+++ b/src/components/defunct-banner.scss
@@ -1,14 +1,23 @@
 @import "./vars.scss";
 
 .defunct-banner {
-  align-items: center;
   background-color: $cc-gold;
   color: black;
-  display: flex;
-  flex-direction: row;
   font-size: 18px;
-  justify-content: center;
   margin: -40px -40px 10px;
   padding: 20px;
+  text-align: center;
   width: calc(100% + 80px);
+
+  a {
+    &:link, &:visited {
+      color: black;
+    }
+    &:hover {
+      color: $cc-teal-dark1;
+    }
+    &:active {
+      color: $cc-teal-dark2;
+    }
+  }
 }

--- a/src/components/defunct-banner.tsx
+++ b/src/components/defunct-banner.tsx
@@ -5,7 +5,7 @@ import "./defunct-banner.scss";
 export const DefunctBanner: React.FC = () => {
   return (
     <div className="defunct-banner">
-      WARNING: This resource contains obsolete features that may no longer work.
+      WARNING: This resource contains obsolete features that are no longer supported. Questions? Please email <a href="mailto:webmaster@concord.org">webmaster@concord.org</a>.
     </div>
   );
 };

--- a/src/components/defunct-banner.tsx
+++ b/src/components/defunct-banner.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+import "./defunct-banner.scss";
+
+export const DefunctBanner: React.FC = () => {
+  return (
+    <div className="defunct-banner">
+      WARNING: This resource contains obsolete features that may no longer work.
+    </div>
+  );
+};

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -21,6 +21,7 @@ $cc-orange-light3: #ffcea1;
 $cc-orange-light4: #ffe6d0;
 $cc-orange-light5: #fff2e7;
 $cc-orange-light6: #fff9f3;
+$cc-gold: #fdc32d;
 $light-font-color: #eeeeee;
 $medium-font-color: #444444;
 $font-color: #373737;

--- a/src/convert-old-lara/convert.ts
+++ b/src/convert-old-lara/convert.ts
@@ -229,7 +229,8 @@ function convertActivityResource (legacyResource: any) {
     "plugins": convertGlossaryPlugins(legacyResource.plugins),
     "type": "LightweightActivity",
     "export_site": legacyResource.export_site,
-    "pages": newPagesResource(legacyResource.pages)
+    "pages": newPagesResource(legacyResource.pages),
+    "defunct": legacyResource.defunct
   };
   return newActivityResource;
 }
@@ -256,7 +257,8 @@ const newSequenceResource = (sequenceResource: any) => {
       "title": sequenceResource.title,
       "type": sequenceResource.type,
       "export_site": sequenceResource.export_site,
-      "activities": getSequenceActivities(sequenceResource.activities)
+      "activities": getSequenceActivities(sequenceResource.activities),
+      "defunct": sequenceResource.defunct
     }
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,7 +179,8 @@ export interface Activity {
   export_site?: string | null;
   pages: Page[];
   position?: number | null;
-  fixed_width_layout?: "ipad_friendly" | "1100px"
+  fixed_width_layout?: "ipad_friendly" | "1100px";
+  defunct?: boolean;
 }
 
 export interface Sequence {
@@ -195,7 +196,8 @@ export interface Sequence {
   activities: Activity[];
   type: string;
   export_site: string | null;
-  fixed_width_layout?: "ipad_friendly" | "1100px"
+  fixed_width_layout?: "ipad_friendly" | "1100px";
+  defunct?: boolean;
 }
 
 export interface IReportState {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182465001

[#182465001]

When an activity or sequence has its `defunct` property set to `true`, display a banner at the top of every page warning that it contains obsolete elements.

The `defunct` property is added in [this LARA PR](https://github.com/concord-consortium/lara/pull/971).

This is how the banner looks in the browser:

![image](https://user-images.githubusercontent.com/367459/176044083-e35da28c-b047-4dcf-973c-84f5f55362c4.png)
