### PR TITLE
Fix some embedded images look disproportionately big

### DIFF
--- a/src/components/activity-page/text-box/text-box.scss
+++ b/src/components/activity-page/text-box/text-box.scss
@@ -10,8 +10,8 @@
     margin: .75em 0;
   }
   img {
-    width: 100%;
     height: auto;
+    max-width: 100%;
   }
 
   .text-name {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182873531

[#182873531]

This change makes it so images embedded in text blocks will conform to any height and width values specified in authoring provided the specified width is not wider than the image's containing column. In that case, the image will be constrained to the width of the column, and its height will be automatically adjusted proportionally.