### PR TITLE
Fix image inside student sidebar cut off

### DIFF
--- a/src/components/page-sidebar/sidebar-panel.scss
+++ b/src/components/page-sidebar/sidebar-panel.scss
@@ -45,6 +45,11 @@
     max-height: 649px;
     overflow: auto;
     min-height: 100px;
+
+    img {
+      height: auto;
+      max-width: 100%;
+    }
   }
 
   &.visible {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182846991

[#182846991]

Set a maximum width of 100% for images in the sidebar so they can't extend beyond the sidebar's boundaries.