### PR TITLE
Fixed interactiveAvailable message passing with sharing plugin [#182921431]

### DIFF
--- a/src/lara-plugin/plugins/embeddable-runtime-context.spec.ts
+++ b/src/lara-plugin/plugins/embeddable-runtime-context.spec.ts
@@ -94,12 +94,26 @@ describe("Embeddable runtime context helper", () => {
       const runtimeContext = generateEmbeddableRuntimeContext(embeddableContext);
       const handler = jest.fn();
       runtimeContext.onInteractiveAvailable(handler);
+
       // Different container => different interactive. Handler should not be called.
       emitInteractiveAvailable({ container: document.createElement("div"), available: false });
       expect(handler).toHaveBeenCalledTimes(0);
-      const event = { container: embeddableContext.container, available: true };
-      emitInteractiveAvailable(event);
-      expect(handler).toHaveBeenCalledWith(event);
+
+      // event called directly on container should cause handler to be called
+      const containerEvent = { container: embeddableContext.container, available: true };
+      emitInteractiveAvailable(containerEvent);
+      expect(handler).toHaveBeenCalledWith(containerEvent);
+
+      // reset mock
+      handler.mockReset();
+      expect(handler).toHaveBeenCalledTimes(0);
+
+      // event called on parent of container should cause handler to be called (to enable wrapper plugins)
+      const parentContainer = document.createElement("div");
+      parentContainer.appendChild(embeddableContext.container);
+      const parentContainerEvent = { container: parentContainer, available: true };
+      emitInteractiveAvailable(parentContainerEvent);
+      expect(handler).toHaveBeenCalledWith(parentContainerEvent);
     });
   });
 
@@ -108,12 +122,26 @@ describe("Embeddable runtime context helper", () => {
       const runtimeContext = generateEmbeddableRuntimeContext(embeddableContext);
       const handler = jest.fn();
       runtimeContext.onInteractiveSupportedFeatures(handler);
+
       // Different container => different interactive. Handler should not be called.
       emitInteractiveSupportedFeatures({ container: document.createElement("div"), supportedFeatures: {} });
       expect(handler).toHaveBeenCalledTimes(0);
+
+      // event called directly on container should cause handler to be called
       const event = { container: embeddableContext.container, supportedFeatures: {} };
       emitInteractiveSupportedFeatures(event);
       expect(handler).toHaveBeenCalledWith(event);
+
+      // reset mock
+      handler.mockReset();
+      expect(handler).toHaveBeenCalledTimes(0);
+
+      // event called on parent of container should cause handler to be called (to enable wrapper plugins)
+      const parentContainer = document.createElement("div");
+      parentContainer.appendChild(embeddableContext.container);
+      const parentContainerEvent = { container: parentContainer, supportedFeatures: {} };
+      emitInteractiveSupportedFeatures(parentContainerEvent);
+      expect(handler).toHaveBeenCalledWith(parentContainerEvent);
     });
   });
 

--- a/src/lara-plugin/plugins/embeddable-runtime-context.ts
+++ b/src/lara-plugin/plugins/embeddable-runtime-context.ts
@@ -32,6 +32,18 @@ const setAnswerSharedWithClass = (shared: boolean, embeddable: EmbeddableBase) =
   });
 };
 
+// returns true if the contextContainer is equal or is contained in eventContainer
+// this is needed as click to play on an embeddable using the sharing plugin generates interativeAvailable
+// events with the eventContainer set to the sharing plugin wrapper but the runtime context is generated
+// using the wrapped interactive's container
+const inContainerTree = (eventContainer: HTMLElement, contextContainer: HTMLElement): boolean => {
+  let treeWalker: HTMLElement | null = contextContainer;
+  while (treeWalker && (eventContainer !== treeWalker)) {
+    treeWalker = treeWalker.parentElement;
+  }
+  return eventContainer === treeWalker;
+};
+
 export const generateEmbeddableRuntimeContext = (context: IEmbeddableContextOptions): IEmbeddableRuntimeContext => {
   return {
     container: context.container,
@@ -41,7 +53,7 @@ export const generateEmbeddableRuntimeContext = (context: IEmbeddableContextOpti
     onInteractiveAvailable: (handler: IInteractiveAvailableEventHandler) => {
       // Add generic listener and filter events to limit them just to this given embeddable.
       onInteractiveAvailable((event: IInteractiveAvailableEvent) => {
-        if (event.container === context.container) {
+        if (inContainerTree(event.container, context.container)) {
           handler(event);
         }
       });
@@ -49,7 +61,7 @@ export const generateEmbeddableRuntimeContext = (context: IEmbeddableContextOpti
     onInteractiveSupportedFeatures: (handler: IInteractiveSupportedFeaturesEventHandler) => {
       // Add generic listener and filter events to limit them just to this given embeddable.
       onInteractiveSupportedFeatures((event: IInteractiveSupportedFeaturesEvent) => {
-        if (event.container === context.container) {
+        if (inContainerTree(event.container, context.container)) {
           handler(event);
         }
       });


### PR DESCRIPTION
The issue was that the interactiveAvailable message being sent when click to play was clicked was not being routed to the wrapped embeddable the sharing plugin was wrapping.  There was a check to see if the message was generated by the container of the wrapped embeddable and this has been changed to be that plus any parent container.