### PR TITLE
Add OAuth support and set teacher logging username using Portal JWT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6730,6 +6730,11 @@
         "raf-schd": "^4.0.2"
       }
     },
+    "@servie/events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@servie/events/-/events-1.0.0.tgz",
+      "integrity": "sha512-sBSO19KzdrJCM3gdx6eIxV8M9Gxfgg6iDQmH5TIAGaUu+X9VDdsINXJOnoiZ1Kx3TrHdH4bt5UVglkjsEGBcvw=="
+    },
     "@sideway/address": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
@@ -7671,6 +7676,11 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.8.tgz",
+      "integrity": "sha512-7axfYN8SW9pWg78NgenHasSproWQee5rzyPVLC9HpaQSDgNArsnKJD88EaMfi4Pl48AyciO3agYCFqpHS1gLpg=="
     },
     "@types/trusted-types": {
       "version": "2.0.2",
@@ -9622,6 +9632,11 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/byte-length/-/byte-length-1.0.2.tgz",
+      "integrity": "sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q=="
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -9945,6 +9960,22 @@
       "requires": {
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
+      }
+    },
+    "client-oauth2": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/client-oauth2/-/client-oauth2-4.3.3.tgz",
+      "integrity": "sha512-k8AvUYJon0vv75ufoVo4nALYb/qwFFicO3I0+39C6xEdflqVtr+f9cy+0ZxAduoVSTfhP5DX2tY2XICAd5hy6Q==",
+      "requires": {
+        "popsicle": "^12.0.5",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
       }
     },
     "cliui": {
@@ -14307,6 +14338,11 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw=="
+    },
     "ipaddr.js": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -16430,8 +16466,15 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "make-error-cause": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-2.3.0.tgz",
+      "integrity": "sha512-etgt+n4LlOkGSJbBTV9VROHA5R7ekIPS4vfh+bCAoJgRrJWdqJCBbpS3osRJ/HrT7R68MzMiY3L3sDJ/Fd8aBg==",
+      "requires": {
+        "make-error": "^1.3.5"
+      }
     },
     "makeerror": {
       "version": "1.0.12",
@@ -17799,6 +17842,70 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "popsicle": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-12.1.0.tgz",
+      "integrity": "sha512-muNC/cIrWhfR6HqqhHazkxjob3eyECBe8uZYSQ/N5vixNAgssacVleerXnE8Are5fspR0a+d2qWaBR1g7RYlmw==",
+      "requires": {
+        "popsicle-content-encoding": "^1.0.0",
+        "popsicle-cookie-jar": "^1.0.0",
+        "popsicle-redirects": "^1.1.0",
+        "popsicle-transport-http": "^1.0.8",
+        "popsicle-transport-xhr": "^2.0.0",
+        "popsicle-user-agent": "^1.0.0",
+        "servie": "^4.3.3",
+        "throwback": "^4.1.0"
+      }
+    },
+    "popsicle-content-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-content-encoding/-/popsicle-content-encoding-1.0.0.tgz",
+      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw=="
+    },
+    "popsicle-cookie-jar": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-cookie-jar/-/popsicle-cookie-jar-1.0.0.tgz",
+      "integrity": "sha512-vrlOGvNVELko0+J8NpGC5lHWDGrk8LQJq9nwAMIVEVBfN1Lib3BLxAaLRGDTuUnvl45j5N9dT2H85PULz6IjjQ==",
+      "requires": {
+        "@types/tough-cookie": "^2.3.5",
+        "tough-cookie": "^3.0.1"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
+    "popsicle-redirects": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/popsicle-redirects/-/popsicle-redirects-1.1.1.tgz",
+      "integrity": "sha512-mC2HrKjdTAWDalOjGxlXw9j6Qxrz/Yd2ui6bPxpi2IQDYWpF4gUAMxbA8EpSWJhLi0PuWKDwTHHPrUPGutAoIA=="
+    },
+    "popsicle-transport-http": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/popsicle-transport-http/-/popsicle-transport-http-1.2.1.tgz",
+      "integrity": "sha512-i5r3IGHkGiBDm1oPFvOfEeSGWR0lQJcsdTqwvvDjXqcTHYJJi4iSi3ecXIttDiTBoBtRAFAE9nF91fspQr63FQ==",
+      "requires": {
+        "make-error-cause": "^2.2.0"
+      }
+    },
+    "popsicle-transport-xhr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-transport-xhr/-/popsicle-transport-xhr-2.0.0.tgz",
+      "integrity": "sha512-5Sbud4Widngf1dodJE5cjEYXkzEUIl8CzyYRYR57t6vpy9a9KPGQX6KBKdPjmBZlR5A06pOBXuJnVr23l27rtA=="
+    },
+    "popsicle-user-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-user-agent/-/popsicle-user-agent-1.0.0.tgz",
+      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA=="
+    },
     "postcss": {
       "version": "8.3.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
@@ -18115,8 +18222,7 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "dev": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -18151,8 +18257,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -19115,6 +19220,16 @@
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
         "send": "0.18.0"
+      }
+    },
+    "servie": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/servie/-/servie-4.3.3.tgz",
+      "integrity": "sha512-b0IrY3b1gVMsWvJppCf19g1p3JSnS0hQi6xu4Hi40CIhf0Lx8pQHcvBL+xunShpmOiQzg1NOia812NAWdSaShw==",
+      "requires": {
+        "@servie/events": "^1.0.0",
+        "byte-length": "^1.0.2",
+        "ts-expect": "^1.1.0"
       }
     },
     "set-blocking": {
@@ -20254,6 +20369,11 @@
         "xtend": "~4.0.1"
       }
     },
+    "throwback": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throwback/-/throwback-4.1.0.tgz",
+      "integrity": "sha512-dLFe8bU8SeH0xeqeKL7BNo8XoPC/o91nz9/ooeplZPiso+DZukhoyZcSz9TFnUNScm+cA9qjU1m1853M6sPOng=="
+    },
     "thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -20319,6 +20439,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "ts-expect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ts-expect/-/ts-expect-1.3.0.tgz",
+      "integrity": "sha512-e4g0EJtAjk64xgnFPD6kTBUtpnMVzDrMb12N1YZV0VvSlhnVT3SGxiYTLdGy8Q5cYHOIC/FAHmZ10eGrAguicQ=="
     },
     "ts-jest": {
       "version": "27.1.0",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "@react-hook/resize-observer": "^1.2.5",
     "buffer": "^6.0.3",
     "classnames": "^2.3.1",
+    "client-oauth2": "^4.3.3",
     "crypto-browserify": "^3.12.0",
     "dompurify": "^2.3.3",
     "firebase": "^9.8.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { App } from "./components/app";
+import { initializeAuthorization } from "./utilities/auth-utils";
 
 import "./index.sass";
 
@@ -8,7 +9,13 @@ import "./index.sass";
 (window as any).React = React;
 (window as any).ReactDOM = ReactDOM;
 
-ReactDOM.render(
-  <App />,
-  document.getElementById("app")
-);
+// Initialize OAuth if `auth-domain` URL parameter is provided.
+const redirecting = initializeAuthorization();
+
+if (!redirecting) {
+  ReactDOM.render(
+    <App />,
+    document.getElementById("app")
+  );
+}
+

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,0 +1,7 @@
+import { getLoggingTeacherUsername } from "./logger";
+
+describe("getLoggingTeacherUsername", () => {
+  it("returns username based on domain UID and domain", () => {
+    expect(getLoggingTeacherUsername(123, "https://learn.concord.org")).toEqual("123@learn.concord.org");
+  });
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -9,6 +9,15 @@ const logManagerUrl: Record<LoggerEnvironment, string> = {
   production: "//cc-log-manager.herokuapp.com/api/logs"
 };
 
+// Returns teacher logging username that is also used by Portal Report / Dashboard and possibly other systems.
+export const getLoggingTeacherUsername = (domainUID: string | number, domain?: string) => {
+  if (!domain) {
+    throw new Error("Can't construct username, missing domain");
+  }
+  // Skip protocol, use hostname only to be consistent with other apps that use this form of ID.
+  return `${domainUID}@${new URL(domain).hostname}`;
+};
+
 export interface LogParams {
   event: string | LogEventName,
   event_value?: any,

--- a/src/utilities/auth-utils.test.ts
+++ b/src/utilities/auth-utils.test.ts
@@ -1,0 +1,116 @@
+import { getBearerToken, initializeAuthorization } from "./auth-utils";
+import queryString from "query-string";
+
+describe("initializeAuthorization", () => {
+  const oldWindowLocation = window.location;
+
+  function getWindowHref() {
+    const calls = (window.location as any).assign.mock.calls;
+    return calls[calls.length - 1][0];
+  }
+
+  beforeAll(() => {
+    // This approach is based on this blog post:
+    // https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/
+    // I added the href set override to catch any code that might be calling
+    // `window.location.href=``
+    delete (window as any).location;
+
+    const oldPropertyDescriptors = Object.getOwnPropertyDescriptors(oldWindowLocation);
+    (window as any).location = Object.defineProperties(
+      {},
+      {
+        ...oldPropertyDescriptors,
+        assign: {
+          configurable: true,
+          value: jest.fn(),
+        },
+        href: {
+          ...oldPropertyDescriptors.href,
+          set: (value) => {throw new Error("must use window.location.assign instead of window.location.href="); }
+        }
+      }
+    );
+  });
+
+  beforeEach(() => {
+    (window.location as any).assign.mockReset();
+  });
+
+  afterAll(() => {
+    // restore `window.location` to the `jsdom` `Location` object
+    window.location = oldWindowLocation;
+  });
+
+  describe("when there is no access_token param", () => {
+    describe("and an auth-domain param", () => {
+      beforeEach(() => {
+        window.history.replaceState({}, "Test", "/?auth-domain=https://portal.concord.org&extraParam=extraValue");
+      });
+
+      it("redirects to portal to authenticate", () => {
+        initializeAuthorization();
+        expect(window.location.assign).toHaveBeenCalledTimes(1);
+        const redirectURL = getWindowHref();
+        const urlParts = queryString.parseUrl(redirectURL);
+        expect(urlParts.url).toEqual("https://portal.concord.org/auth/oauth_authorize");
+        expect(urlParts.query).toMatchObject({
+          client_id: "activity-player",
+          redirect_uri: "https://activity-player.unexisting.url.com/",
+          response_type: "token"
+        });
+      });
+
+      it("saves all query params in session storage under state key", () => {
+        initializeAuthorization();
+        expect(window.location.assign).toHaveBeenCalledTimes(1);
+        const redirectURL = getWindowHref();
+        const urlParts = queryString.parseUrl(redirectURL);
+        const state = urlParts.query.state;
+        const savedParams = sessionStorage.getItem(typeof state !== "string" ? "" : state);
+        expect(savedParams).toEqual("?auth-domain=https://portal.concord.org&extraParam=extraValue");
+      });
+    });
+
+    describe("and no auth-domain param", () => {
+      beforeEach(() => {
+        window.history.replaceState({}, "Test", "/");
+      });
+
+      it("does not redirect", () => {
+        console.log("das", window.location.href, initializeAuthorization());
+        expect(window.location.assign).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe("when there is an access_token and state param", () => {
+    beforeEach(() => {
+      window.history.replaceState({}, "Test", "/#access_token=1234567&state=abcdefg");
+    });
+
+    it("saves the accessToken that can be obtained using getBearerToken helper", () => {
+      expect(getBearerToken()).toEqual(null);
+      initializeAuthorization();
+      expect(getBearerToken()).toEqual("1234567");
+    });
+
+    it("load parameters from session storage, and updates the url", () => {
+      sessionStorage.setItem("abcdefg", "?auth-domain=https://portal.concord.org&extraParam=extraValue");
+      initializeAuthorization();
+      expect(window.location.href).toEqual("https://activity-player.unexisting.url.com/?auth-domain=https://portal.concord.org&extraParam=extraValue");
+    });
+
+    it("does not redirect", () => {
+      initializeAuthorization();
+      expect(window.location.assign).toHaveBeenCalledTimes(0);
+    });
+  });
+});
+
+describe("getBearerToken", () => {
+  it("returns value of token URL param when it's available", () => {
+    window.history.replaceState({}, "Test", "/?token=12345");
+    expect(getBearerToken()).toEqual("12345");
+  });
+});

--- a/src/utilities/auth-utils.ts
+++ b/src/utilities/auth-utils.ts
@@ -1,0 +1,51 @@
+import ClientOAuth2 from "client-oauth2";
+import { hashValue, queryValue } from "./url-query";
+
+// Portal has to have AuthClient configured with this clientId.
+// The AuthClient has to have:
+// - redirect URLs of each branch being tested
+// - "client type" needs to be configured as 'public', to allow browser requests
+const OAUTH_CLIENT_NAME = "activity-player";
+const PORTAL_AUTH_PATH = "/auth/oauth_authorize";
+
+let accessToken: string | null = null;
+
+export const getBearerToken = () => {
+  // `accessToken` variable will be available after OAuth redirect.
+  // However, AP is mostly launched with a short-lived token provided as an URL param.
+  // Both tokens have the same purpose and they let AP obtain Portal JWT.
+  return queryValue("token") || accessToken;
+};
+
+// Returns true if it is redirecting
+export const initializeAuthorization = () => {
+  const state = hashValue("state");
+  accessToken = hashValue("access_token") || null;
+
+  if (accessToken && state) {
+    const savedParamString = sessionStorage.getItem(state);
+    window.history.pushState(null, "Activity Player", savedParamString);
+  }
+  else {
+    const authDomain = queryValue("auth-domain");
+
+    if (authDomain) {
+      const key = Math.random().toString(36).substring(2,15);
+      sessionStorage.setItem(key, window.location.search);
+      authorizeInPortal(authDomain, OAUTH_CLIENT_NAME, key);
+      return true;
+    }
+  }
+  return false;
+};
+
+export const authorizeInPortal = (portalUrl: string, oauthClientName: string, state: string) => {
+  const portalAuth = new ClientOAuth2({
+    clientId: oauthClientName,
+    redirectUri: window.location.origin + window.location.pathname,
+    authorizationUri: `${portalUrl}${PORTAL_AUTH_PATH}`,
+    state
+  });
+  // Redirect
+  window.location.assign(portalAuth.token.getUri());
+};

--- a/src/utilities/url-query.test.ts
+++ b/src/utilities/url-query.test.ts
@@ -1,4 +1,4 @@
-import { deleteQueryValue, setQueryValue } from "./url-query";
+import { deleteQueryValue, setQueryValue, hashValue } from "./url-query";
 
 describe("query string functions", () => {
   const oldWindowLocation = window.location;
@@ -52,6 +52,14 @@ describe("query string functions", () => {
       deleteQueryValue("foo", true);
       expect(window.history.replaceState).not.toHaveBeenCalled();
       expect(window.location.search).toBe("?baz=bam");
+    });
+  });
+
+  describe("hashValue", () => {
+    it("returns value of a hash param", () => {
+      url.href = "https://example.com?foo=bar#baz=bam";
+      expect(hashValue("foo")).toEqual(undefined);
+      expect(hashValue("baz")).toEqual("bam");
     });
   });
 });

--- a/src/utilities/url-query.ts
+++ b/src/utilities/url-query.ts
@@ -51,3 +51,20 @@ export const deleteQueryValue = (prop: string, reload = false) => {
     window.history.replaceState(null, "", "?" + newQueryString);
   }
 };
+
+/**
+ * Simplifies query-string library by only returning `string | undefined`, instead
+ * of `string | string[] | null | undefined`.
+ * @param prop
+ */
+export function hashValue(prop: string): string | undefined {
+  const query = queryString.parse(window.location.hash);
+  const val = query[prop];
+  if (!val) {
+    return undefined;
+  }
+  if (Array.isArray(val)) {
+    throw `May only have one hash parameter for ${prop}. Found: ${val}`;
+  }
+  return val;
+}


### PR DESCRIPTION
[#181821831]

This PR adds OAuth support to Activity Player. Implementation is based on the Portal Report one.

Also, when the Portal JWT can be obtained, but the user type is not "learner", AP will set the logging username to `user_id@portal_domain` (eg 123@learn.concord.org). This matches what LARA used to do, what Dashboard does, and what AP does when launched in Teacher Edition mode straight from Portal.

It'll let researchers match Dashboard log events with ones coming from AP Teacher Edition, even if AP Teacher Edition is opened directly from Dashboard (not from Portal).

@scytacki, note that OAuth path cannot be used by students who launch AP from Portal at the moment without additional changes. Portal JWT API returns a very limited set of information when OAuth token is used to get Portal JWT. 

When students use short-lived token, JWT includes more information. I believe mostly because Portal saves learner data in the AccessGrant here: https://github.com/concord-consortium/rigse/blob/6d75a19f6d1a45c60c0d9681245d5cdedae61449/rails/app/models/external_report.rb#L37-L44
and this doesn't happen in the OAuth path.

When teacher uses OAuth, we don't have much information in JWT too. Not even user_type. But there was "uid" so it was enough for me to construct a logging username and avoid changing Portal. And it doesn't seem like we need anything more now.
