### PR TITLE
[#182952356]: Default Aspect Ratio option limits interactive height to viewport.

### DIFF
--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -119,10 +119,11 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
   const singlePageLayout = activityLayout === ActivityLayouts.SinglePage;
   const isFullWidthLayout = sectionLayout === "full-width" || singlePageLayout;
 
-  let hasMaxAspectRatio;
+  let hasMaxAspectRatio = false;
+
   if (embeddable.type === "ManagedInteractive" && !embeddable.inherit_aspect_ratio_method) {
     hasMaxAspectRatio = embeddable.custom_aspect_ratio_method === "MAX";
-  } else {
+  } else if (embeddable.type !== "ManagedInteractive") {
     hasMaxAspectRatio = embeddable.aspect_ratio_method === "MAX";
   }
 

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -118,7 +118,14 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
 
   const singlePageLayout = activityLayout === ActivityLayouts.SinglePage;
   const isFullWidthLayout = sectionLayout === "full-width" || singlePageLayout;
-  const singleWithMaxAspectRatio = isFullWidthLayout && (embeddable.type === "ManagedInteractive" ? embeddable.custom_aspect_ratio_method === "MAX" : embeddable.aspect_ratio_method === "MAX");
+
+  let hasMaxAspectRatio;
+  if (embeddable.type === "ManagedInteractive" && !embeddable.inherit_aspect_ratio_method) {
+    hasMaxAspectRatio = embeddable.custom_aspect_ratio_method === "MAX";
+  } else {
+    hasMaxAspectRatio = embeddable.aspect_ratio_method === "MAX";
+  }
+
   const embeddableClasses = classNames("embeddable",
                                         isFullWidthLayout
                                           ? "full-width"
@@ -129,7 +136,7 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
                                               : "secondary",
                                         {"half-width":  embeddable.is_half_width && !singlePageLayout},
                                         {"hidden": embeddable.is_hidden},
-                                        {"max-aspect-ratio": singleWithMaxAspectRatio}
+                                        {"max-aspect-ratio": isFullWidthLayout && hasMaxAspectRatio}
                                       );
 
   return (

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -125,7 +125,7 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
     hasMaxAspectRatio = embeddable.custom_aspect_ratio_method === "MAX";
   } else if (embeddable.type === "ManagedInteractive" && embeddable.inherit_aspect_ratio_method) {
     hasMaxAspectRatio = embeddable.library_interactive?.data.aspect_ratio_method === "MAX";
-  } else{
+  } else {
     hasMaxAspectRatio = embeddable.aspect_ratio_method === "MAX";
   }
 

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -123,7 +123,9 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
 
   if (embeddable.type === "ManagedInteractive" && !embeddable.inherit_aspect_ratio_method) {
     hasMaxAspectRatio = embeddable.custom_aspect_ratio_method === "MAX";
-  } else if (embeddable.type !== "ManagedInteractive") {
+  } else if (embeddable.type === "ManagedInteractive" && embeddable.inherit_aspect_ratio_method) {
+    hasMaxAspectRatio = embeddable.library_interactive?.data.aspect_ratio_method === "MAX";
+  } else{
     hasMaxAspectRatio = embeddable.aspect_ratio_method === "MAX";
   }
 

--- a/src/components/activity-page/embeddable.tsx
+++ b/src/components/activity-page/embeddable.tsx
@@ -115,8 +115,10 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
   if (qComponent === undefined) {
     return null;
   }
+
   const singlePageLayout = activityLayout === ActivityLayouts.SinglePage;
   const isFullWidthLayout = sectionLayout === "full-width" || singlePageLayout;
+  const singleWithMaxAspectRatio = isFullWidthLayout && (embeddable.type === "ManagedInteractive" ? embeddable.custom_aspect_ratio_method === "MAX" : embeddable.aspect_ratio_method === "MAX");
   const embeddableClasses = classNames("embeddable",
                                         isFullWidthLayout
                                           ? "full-width"
@@ -126,7 +128,8 @@ export const Embeddable: React.ForwardRefExoticComponent<IProps> = forwardRef((p
                                               ? "secondary stacked"
                                               : "secondary",
                                         {"half-width":  embeddable.is_half_width && !singlePageLayout},
-                                        {"hidden": embeddable.is_hidden}
+                                        {"hidden": embeddable.is_hidden},
+                                        {"max-aspect-ratio": singleWithMaxAspectRatio}
                                       );
 
   return (

--- a/src/components/activity-page/managed-interactive/iframe-runtime.scss
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.scss
@@ -1,7 +1,6 @@
 @import "../../vars.scss";
 
 .iframe-runtime {
-  width: 100%;
   button.button {
     align-items: center;
     display: flex;

--- a/src/components/activity-page/managed-interactive/iframe-runtime.scss
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.scss
@@ -1,6 +1,7 @@
 @import "../../vars.scss";
 
 .iframe-runtime {
+  width: 100%;
   button.button {
     align-items: center;
     display: flex;

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -69,6 +69,9 @@ describe("IframeRuntime component", () => {
     const mockGetAttachmentUrl = jest.fn(() => Promise.resolve({ url: mockAttachmentUrl, requestId: 1 }));
     const mockShowModal = jest.fn();
     const mockCloseModal = jest.fn();
+    const mockSetAspectRatio = jest.fn();
+    const mockSetHeightFromInteractive = jest.fn();
+
     type CustomMsgSender = (msg: ICustomMessage) => void;
     let mockSendCustomMessage: CustomMsgSender;
     const mockSetSendCustomMessage = jest.fn((sendMsg: CustomMsgSender) => {
@@ -82,6 +85,8 @@ describe("IframeRuntime component", () => {
         initialInteractiveState={{testing: true}}
         legacyLinkedInteractiveState={null}
         setInteractiveState={mockSetInteractiveState}
+        setAspectRatio={mockSetAspectRatio}
+        setHeightFromInteractive={mockSetHeightFromInteractive}
         setSupportedFeatures={mockSetSupportedFeatures}
         setNewHint={mockSetNewHint}
         getFirebaseJWT={mockGetFirebaseJWT}

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -204,16 +204,8 @@ describe("IframeRuntime component", () => {
     expect(mockSetInteractiveState).toHaveBeenCalledTimes(3);
 
     expect(testIframe.getByTestId("iframe-runtime").children[0].tagName).toBe("IFRAME");
-    // width is not set as the containerWidth prop is undefined due to window.innerHeight not being set in this test
     // height is the default of 300px
-    expect(testIframe.getByTestId("iframe-runtime").children[0]).not.toHaveAttribute("width");
     expect(testIframe.getByTestId("iframe-runtime").children[0]).toHaveAttribute("height", "300");
-    act(() => {
-      dispatchMessageFromChild("height", 960);
-    });
-    // both width and height are set.  width is 100% due to the interactive posting its height to the iframe
-    expect(testIframe.getByTestId("iframe-runtime").children[0]).toHaveAttribute("width", "100%");
-    expect(testIframe.getByTestId("iframe-runtime").children[0]).toHaveAttribute("height", "960");
 
     act(() => {
       dispatchMessageFromChild("supportedFeatures", { features: { aspectRatio: 1.5 } });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -412,9 +412,6 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
 
   // If the interactive sets the height, ignore the container width passed in and use all the available space.
   const width = heightFromInteractive ? "100%" : containerWidth;
-  // const width = height * (4 / 3);
-
-  console.log("height", height, "width", width);
 
   return (
     <div className="iframe-runtime" style={{width}} data-cy="iframe-runtime">

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -414,7 +414,7 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
   const width = heightFromInteractive ? "100%" : containerWidth;
 
   return (
-    <div className="iframe-runtime" style={{width}} data-cy="iframe-runtime">
+    <div className="iframe-runtime" data-cy="iframe-runtime">
       <iframe key={`${id}-${reloadCount}`} ref={iframeRef} src={url} id={id} width={width} height={height} frameBorder={0}
               allowFullScreen={true}
               allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write"

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -73,18 +73,17 @@ interface IProps {
   portalData?: IPortalData;
   answerMetadata?: IExportableAnswerMetadata;
   interactiveInfo?: IInteractiveInfo;
-  aspectRatioMethod?: "MAX" | "MANUAL" | "DEFAULT";
   showDeleteDataButton?: boolean;
+  setAspectRatio: (aspectRatio: number) => void;
+  setHeightFromInteractive: (heightFromInteractive: number) => void;
 }
 
 export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
   const { url, id, authoredState, initialInteractiveState, legacyLinkedInteractiveState, setInteractiveState, linkedInteractives, report,
     proposedHeight, containerWidth, setNewHint, getFirebaseJWT, getAttachmentUrl, showModal, closeModal, setSupportedFeatures,
-    setSendCustomMessage, setNavigation, iframeTitle, portalData, answerMetadata, interactiveInfo, aspectRatioMethod,
-    showDeleteDataButton } = props;
+    setSendCustomMessage, setNavigation, iframeTitle, portalData, answerMetadata, interactiveInfo,
+    showDeleteDataButton, setAspectRatio, setHeightFromInteractive } = props;
 
-  const [ heightFromInteractive, setHeightFromInteractive ] = useState(0);
-  const [ ARFromSupportedFeatures, setARFromSupportedFeatures ] = useState(0);
   const [reloadCount, setReloadCount] = useState<number>(0);
   const iframePhoneTimeout = useRef<number|undefined>(undefined);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -105,6 +104,7 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
       if (!phone) {
         return;
       }
+
       // Just to add some type checking to phone post (ServerMessage).
       const post = (type: ServerMessage, data: any) => phone.post(type, data);
       const addListener = (type: ClientMessage, handler: any) => phone.addListener(type, handler);
@@ -135,7 +135,7 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
       addListener("supportedFeatures", (info: any) => {
         const features: ISupportedFeatures = info.features;
         if (features.aspectRatio) {
-          setARFromSupportedFeatures(features.aspectRatio);
+          setAspectRatio(features.aspectRatio);
         }
         if (iframeRef.current) {
           setSupportedFeatures(iframeRef.current, features);
@@ -399,23 +399,12 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
       setReloadCount(reloadCount + 1);
     }
   };
-  const heightFromSupportedFeatures = aspectRatioMethod === "MAX"
-                                        ? proposedHeight
-                                        : ARFromSupportedFeatures && containerWidth && typeof(containerWidth) === "number"
-                                            ? containerWidth / ARFromSupportedFeatures
-                                            : 0;
 
-  // There are several options for specifying the iframe height. Check if we have height specified by interactive (from IframePhone
-  // "height" listener), height based on aspect ratio specified by interactive (from IframePhone "supportedFeatures" listener),
-  // or height from container dimensions and embeddable specifications.
-  const height = heightFromInteractive || heightFromSupportedFeatures || proposedHeight || kDefaultHeight;
-
-  // If the interactive sets the height, ignore the container width passed in and use all the available space.
-  const width = heightFromInteractive ? "100%" : containerWidth;
+  const height = proposedHeight || kDefaultHeight;
 
   return (
     <div className="iframe-runtime" data-cy="iframe-runtime">
-      <iframe key={`${id}-${reloadCount}`} ref={iframeRef} src={url} id={id} width={width} height={height} frameBorder={0}
+      <iframe key={`${id}-${reloadCount}`} ref={iframeRef} src={url} id={id} width={containerWidth} height={height} frameBorder={0}
               allowFullScreen={true}
               allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write"
               title={iframeTitle}

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -399,7 +399,6 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
       setReloadCount(reloadCount + 1);
     }
   };
-
   const heightFromSupportedFeatures = aspectRatioMethod === "MAX"
                                         ? proposedHeight
                                         : ARFromSupportedFeatures && containerWidth && typeof(containerWidth) === "number"
@@ -411,16 +410,14 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
   // or height from container dimensions and embeddable specifications.
   const height = heightFromInteractive || heightFromSupportedFeatures || proposedHeight || kDefaultHeight;
 
-  console.log("heightFromInteractive", heightFromInteractive);
-  console.log("heightFromSupportedFeatures", heightFromSupportedFeatures);
-  console.log("height", height);
-
   // If the interactive sets the height, ignore the container width passed in and use all the available space.
   const width = heightFromInteractive ? "100%" : containerWidth;
-  console.log("width", width);
+  // const width = height * (4 / 3);
+
+  console.log("height", height, "width", width);
 
   return (
-    <div className="iframe-runtime" data-cy="iframe-runtime">
+    <div className="iframe-runtime" style={{width}} data-cy="iframe-runtime">
       <iframe key={`${id}-${reloadCount}`} ref={iframeRef} src={url} id={id} width={width} height={height} frameBorder={0}
               allowFullScreen={true}
               allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write"

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -401,10 +401,11 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
   };
 
   const height = proposedHeight || kDefaultHeight;
+  const width = containerWidth || "100%";
 
   return (
     <div className="iframe-runtime" data-cy="iframe-runtime">
-      <iframe key={`${id}-${reloadCount}`} ref={iframeRef} src={url} id={id} width={containerWidth} height={height} frameBorder={0}
+      <iframe key={`${id}-${reloadCount}`} ref={iframeRef} src={url} id={id} width={width} height={height} frameBorder={0}
               allowFullScreen={true}
               allow="geolocation; microphone; camera; bluetooth; clipboard-read; clipboard-write"
               title={iframeTitle}

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -411,8 +411,13 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
   // or height from container dimensions and embeddable specifications.
   const height = heightFromInteractive || heightFromSupportedFeatures || proposedHeight || kDefaultHeight;
 
+  console.log("heightFromInteractive", heightFromInteractive);
+  console.log("heightFromSupportedFeatures", heightFromSupportedFeatures);
+  console.log("height", height);
+
   // If the interactive sets the height, ignore the container width passed in and use all the available space.
   const width = heightFromInteractive ? "100%" : containerWidth;
+  console.log("width", width);
 
   return (
     <div className="iframe-runtime" data-cy="iframe-runtime">

--- a/src/components/activity-page/managed-interactive/managed-interactive.scss
+++ b/src/components/activity-page/managed-interactive/managed-interactive.scss
@@ -1,9 +1,11 @@
 @import "../../vars.scss";
 
 .managed-interactive {
-  width: 100%;
-  &.has-question-number {
-    border: 1px solid $cc-charcoal-light1;
+  // width: 100%;
+  .sub-container {
+    &.has-question-number {
+      border: 1px solid $cc-charcoal-light1;
+    }
   }
 }
 

--- a/src/components/activity-page/managed-interactive/managed-interactive.scss
+++ b/src/components/activity-page/managed-interactive/managed-interactive.scss
@@ -1,7 +1,7 @@
 @import "../../vars.scss";
 
 .managed-interactive {
-
+  width: 100%;
   &.has-question-number {
     border: 1px solid $cc-charcoal-light1;
   }

--- a/src/components/activity-page/managed-interactive/managed-interactive.scss
+++ b/src/components/activity-page/managed-interactive/managed-interactive.scss
@@ -1,8 +1,7 @@
 @import "../../vars.scss";
 
 .managed-interactive {
-  // width: 100%;
-  .sub-container {
+  .runtime-container {
     &.has-question-number {
       border: 1px solid $cc-charcoal-light1;
     }

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -224,12 +224,12 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
       break;
     case "DEFAULT":
     default:
-      if (divSize?.width / aspectRatio > screenHeight.dynamicHeight) {
+      if (divSize?.width / kDefaultAspectRatio > screenHeight.dynamicHeight) {
         proposedHeight = (screenHeight.dynamicHeight * .98) - unusableHeight;
       } else {
-        proposedHeight = (divSize?.width / aspectRatio) - unusableHeight;
+        proposedHeight = (divSize?.width / kDefaultAspectRatio) - unusableHeight;
       }
-      containerWidth = proposedHeight * aspectRatio;
+      containerWidth = proposedHeight * kDefaultAspectRatio;
   }
 
   const [showHint, setShowHint] = useState(false);

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -202,7 +202,10 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
       break;
     case "DEFAULT":
     default:
-      if (divSize?.width / aspectRatio > screenHeight.dynamicHeight) {
+      console.log("divSize.width", divSize.width);
+      console.log("aspectRatio", aspectRatio);
+      console.log("divSize.width / aspectRatio > (screenHeight.dynamicHeight * .95)", divSize?.width / aspectRatio > (screenHeight.dynamicHeight * .95));
+      if (divSize?.width / aspectRatio > (screenHeight.dynamicHeight * .95)) {
         proposedHeight = screenHeight.dynamicHeight - kBottomMargin;
         containerWidth = (proposedHeight * aspectRatio);
       } else {

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -225,15 +225,11 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
     case "DEFAULT":
     default:
       if (divSize?.width / aspectRatio > screenHeight.dynamicHeight) {
-        console.log("I am in first if statement here");
         proposedHeight = (screenHeight.dynamicHeight * .98) - unusableHeight;
       } else {
-        console.log("I am in else statement");
         proposedHeight = (divSize?.width / aspectRatio) - unusableHeight;
       }
-      console.log("proposedHeight", proposedHeight);
       containerWidth = proposedHeight * aspectRatio;
-      console.log("containerWidth", containerWidth);
   }
 
   const [showHint, setShowHint] = useState(false);
@@ -352,7 +348,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   // with this fragment if necessary. ActivityPlayer doesn't have knowledge about URL format and provided url_fragment
   // to perform this merge automatically.
   const iframeUrl = activeDialog?.url || (embeddable.url_fragment ? url + embeddable.url_fragment : url);
-  const hasQuestionNumber = questionNumber ? "sub-container has-question-number" : "sub-container";
+  const hasQuestionNumber = questionNumber ? "runtime-container has-question-number" : "runtime-container";
 
   const interactiveIframeRuntime =
     loadingAnswer || loadingLegacyLinkedInteractiveState ?

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -144,7 +144,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   let nativeWidth: number;
   let aspectRatio: number;
 
-  if (embeddable.type === "ManagedInteractive") {
+  if (embeddable.type === "ManagedInteractive"  && !embeddable.inherit_aspect_ratio_method) {
     nativeHeight = embeddable.custom_native_height || 0;
     nativeWidth = embeddable.custom_native_width || 0;
   } else {

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -144,9 +144,9 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   let nativeWidth: number;
   let aspectRatio: number;
 
-  if (embeddable.type === "ManagedInteractive"  && !embeddable.inherit_aspect_ratio_method) {
-    nativeHeight = embeddable.custom_native_height || 0;
-    nativeWidth = embeddable.custom_native_width || 0;
+  if (embeddable.type === "ManagedInteractive") {
+    nativeHeight = (embeddable.inherit_native_height ? embeddableData?.native_height : embeddable.custom_native_height) || 0;
+    nativeWidth = (embeddable.inherit_native_width ? embeddableData?.native_width : embeddable.custom_native_width) || 0;
   } else {
     nativeHeight = embeddableData?.native_height || 0;
     nativeWidth = embeddableData?.native_width || 0;

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -156,22 +156,27 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   // cf. https://www.npmjs.com/package/@react-hook/resize-observer
   const useSize = (target: any) => {
     const [size, setSize] = React.useState();
+
     React.useLayoutEffect(() => {
       setSize(target.current.getBoundingClientRect());
     }, [target]);
+
     useResizeObserver(target, (entry: any) => setSize(entry.contentRect));
     return size;
+
   };
 
   // use this to get height when aspect ratio method is "MAX"
   const [screenHeight, getDimension] = useState({
     dynamicHeight: window.innerHeight
   });
+
   const setDimension = () => {
     getDimension({
       dynamicHeight: window.innerHeight
     });
   };
+
   useEffect(() => {
     window.addEventListener("resize", setDimension);
     return(() => {
@@ -189,6 +194,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   };
 
   const divTarget = React.useRef(null);
+  // const divSize = divTarget.current?.
   const divSize: any = useSize(divTarget);
   let containerWidth: number | string = "100%";
 
@@ -202,16 +208,8 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
       break;
     case "DEFAULT":
     default:
-      console.log("divSize.width", divSize.width);
-      console.log("aspectRatio", aspectRatio);
-      console.log("divSize.width / aspectRatio > (screenHeight.dynamicHeight * .95)", divSize?.width / aspectRatio > (screenHeight.dynamicHeight * .95));
-      if (divSize?.width / aspectRatio > (screenHeight.dynamicHeight * .95)) {
-        proposedHeight = screenHeight.dynamicHeight - kBottomMargin;
-        containerWidth = (proposedHeight * aspectRatio);
-      } else {
-        proposedHeight = divSize?.width / kDefaultAspectRatio;
-      }
-      break;
+        proposedHeight = (divSize?.width / aspectRatio) - kBottomMargin;
+        containerWidth = divSize?.width;
   }
 
   const [showHint, setShowHint] = useState(false);

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -145,8 +145,8 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   let aspectRatio: number;
 
   if (embeddable.type === "ManagedInteractive") {
-    nativeHeight = embeddable.inherit_native_height ? embeddableData?.native_height || 0 : embeddable.custom_native_height || 0;
-    nativeWidth = embeddable.inherit_native_width ? embeddableData?.native_width || 0 : embeddable.custom_native_width || 0;
+    nativeHeight = (embeddable.inherit_native_height ? embeddableData?.native_height : embeddable.custom_native_height) || 0;
+    nativeWidth = (embeddable.inherit_native_width ? embeddableData?.native_width : embeddable.custom_native_width) || 0;
   } else {
     nativeHeight = embeddableData?.native_height || 0;
     nativeWidth = embeddableData?.native_width || 0;

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -8,7 +8,7 @@
   margin: 10px;
   position: relative;
   &.responsive {
-    width: calc(100% - 20px);
+    width: 100%;
   }
 
   &.full-width {

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -160,7 +160,7 @@
       top: 10px;
       align-self: flex-start;
       line-height: 0;
-      width: 100%;
+      // width: 100%;
       &.pinned {
         position: sticky;
       }

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -155,9 +155,7 @@
     position: relative;
     height: auto;
     &.max-aspect-ratio {
-      .embeddableWrapper {
-        display: flex;
-        flex-direction: column;
+      .embeddable.primary {
         height: 98vh;
         .embeddable.primary, .embeddable-sub-two, .managed-interactive, .runtime-container, .iframe-runtime {
           display: flex;
@@ -176,7 +174,6 @@
       top: 10px;
       align-self: flex-start;
       line-height: 0;
-      // width: 100%;
       &.pinned {
         position: sticky;
       }

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -8,7 +8,7 @@
   margin: 10px;
   position: relative;
   &.responsive {
-    width: 100%;
+    width: calc(100% - 20px);
   }
 
   &.full-width {
@@ -119,7 +119,7 @@
 
     .column.primary {
       right: 0;
-      width: 100%;
+      width: calc(100% - 365px - 50px);
       margin-right: 20px;
     }
     .column.secondary {
@@ -160,6 +160,7 @@
       top: 10px;
       align-self: flex-start;
       line-height: 0;
+      width: 100%;
       &.pinned {
         position: sticky;
       }

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -135,7 +135,7 @@
 
     .column.primary {
       right: 0;
-      width: calc(100% - 365px - 50px);
+      width: 100%;
       margin-right: 20px;
     }
     .column.secondary {

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -14,6 +14,22 @@
   &.full-width {
     .embeddable.full-width {
       grid-column: span 10;
+      &.max-aspect-ratio {
+        display: flex;
+        flex-direction: column;
+        height: 98vh;
+        .embeddable.primary, .embeddable-sub-two, .managed-interactive, .runtime-container, .iframe-runtime {
+          display: flex;
+          flex-direction: column;
+          flex: 1;
+        }
+        .embeddable-sub-two {
+          height: 100%;
+        }
+        iframe {
+          flex: 1;
+        }
+      }
       &.half-width {
         grid-column: span 5;
       }
@@ -143,7 +159,7 @@
         display: flex;
         flex-direction: column;
         height: 98vh;
-        .embeddable.primary, .embeddable-sub-two, .managed-interactive, .iframe-runtime {
+        .embeddable.primary, .embeddable-sub-two, .managed-interactive, .runtime-container, .iframe-runtime {
           display: flex;
           flex-direction: column;
           flex: 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export interface IframePhone {
 }
 
 export interface LibraryInteractiveData {
-  aspect_ratio_method?: "DEFAULT" | null;
+  aspect_ratio_method?: "DEFAULT" | "MANUAL" | "MAX" | null;
   authoring_guidance?: string;
   base_url: string;
   url?: string;


### PR DESCRIPTION
This PR makes several fixes to support different aspects of interactive sizing. In working on this story it became clear that the "Manual" and "Default" options weren't always working properly. In the first case it was because custom_native_width and custom_native_height weren't overwriting the interactive's native_width and native_height. In the latter case there were a number of issues that have been addressed.

To see the differences this PR makes I think it is helpful to run [this activity](https://authoring.concord.org/activities/9620) both in activity player and in this branch on localhost and compare them against one another.
