### PR TITLE
[#183748003]: Fix line-height affecting visibility of text.

### DIFF
--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -173,7 +173,6 @@
     .embeddableWrapper {
       top: 10px;
       align-self: flex-start;
-      line-height: 0;
       &.pinned {
         position: sticky;
       }


### PR DESCRIPTION
Before with line-height on embeddableWrapper set to 0:
<img width="940" alt="Screen Shot 2022-11-16 at 10 52 37 AM" src="https://user-images.githubusercontent.com/89816272/202229401-4250722f-bc73-43ca-b04e-20fbac64d02c.png">
<img width="670" alt="Screen Shot 2022-11-16 at 10 51 51 AM" src="https://user-images.githubusercontent.com/89816272/202229464-dcabf7d3-fa7d-4391-bcb5-6da014d9f28d.png">

After removing line-height set to 0:
<img width="663" alt="Screen Shot 2022-11-16 at 10 52 01 AM" src="https://user-images.githubusercontent.com/89816272/202229612-3794a500-06c7-4c41-8a05-82e9d3527d83.png">
<img width="945" alt="Screen Shot 2022-11-16 at 10 52 10 AM" src="https://user-images.githubusercontent.com/89816272/202229670-af743696-bace-46dd-bced-e73294b38f87.png">

