### PR TITLE
fix: Fixes from read aloud QA (multiple stories)

### DIFF
--- a/src/components/activity-header/header.tsx
+++ b/src/components/activity-header/header.tsx
@@ -33,7 +33,7 @@ export class Header extends React.PureComponent<IProps> {
           <div className="header-center">
             <div className={`title-container ${showSequence && onShowSequence ? "link" : ""}`} onClick={onShowSequence}>
               {showSequence && onShowSequence && <SequenceBackIcon className="sequence-icon" />}
-              <DynamicText>{this.renderContentTitle()}</DynamicText>
+              {showSequence && onShowSequence ? this.renderContentTitle() : <DynamicText>{this.renderContentTitle()}</DynamicText>}
             </div>
           </div>
           <div className="header-right">

--- a/src/components/activity-page/text-box/text-box.tsx
+++ b/src/components/activity-page/text-box/text-box.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { DynamicText } from "@concord-consortium/dynamic-text/component";
+import { DynamicText } from "@concord-consortium/dynamic-text";
 
 import { renderHTML } from "../../../utilities/render-html";
 import { IEmbeddableXhtml } from "../../../types";

--- a/src/components/toggle.scss
+++ b/src/components/toggle.scss
@@ -68,7 +68,6 @@
       transition: all 0.3s;
       border-radius: 50%;
       cursor: pointer;
-      z-index: 1;
     }
 
     &:hover {


### PR DESCRIPTION
- [PT-184631349] Remove read aloud for sequence link
- [PT-184631109] Fix z-index of read aloud toggle to not overlap sidebar content
- [PT-184631417] Fix unregistering of iframed components

Also removed separate require from dynamic-text/component to avoid duplicate code as it also exists in the root dynamic-text module.