### PR TITLE
fix: Update hide read aloud logic so sequence always overrides [PT-184688393]

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -286,7 +286,13 @@ export class App extends React.PureComponent<IProps, IState> {
       // Show the warning if we are not running on production
       const showWarning = firebaseAppName() !== "report-service-pro";
 
-      const hideReadAloud = sequence?.hide_read_aloud || activity.hide_read_aloud;
+      let hideReadAloud = false;
+      if (sequence) {
+        // sequence always overrides activity level setting
+        hideReadAloud = !!sequence.hide_read_aloud;
+      } else {
+        hideReadAloud = !!activity.hide_read_aloud;
+      }
       if (hideReadAloud) {
         // turn off read-aloud but do not persist the setting
         dynamicTextManager.enableReadAloud({enabled: false, saveSetting: false});


### PR DESCRIPTION
Before the activity in a sequence could hide the read aloud even if the sequence was set to show the read aloud controls.  Now, if there is a sequence only that setting is used.