### PR TITLE
bug: Fixed read aloud toggle not appearing on single page activities [PT-184823019]

### DIFF
--- a/src/components/read-aloud-toggle.tsx
+++ b/src/components/read-aloud-toggle.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useReadAloud } from "./read-aloud-context";
 import { Toggle } from "./toggle";
 
-export const ReadAloudToggle = () => {
+export const ReadAloudToggle = ({style}: {style?: React.CSSProperties}) => {
   const {readAloud, readAloudDisabled, setReadAloud, hideReadAloud} = useReadAloud();
 
   if (hideReadAloud || !setReadAloud) {
@@ -17,6 +17,7 @@ export const ReadAloudToggle = () => {
       disabledMessage="Text to speech not available on this browser."
       isChecked={readAloud}
       onChange={setReadAloud}
+      style={style}
     />
   );
 };

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -1,11 +1,13 @@
 import React from "react";
+
 import { numQuestionsOnPreviousSections, numQuestionsOnPreviousPages } from "../../utilities/activity-utils";
 import { RelatedContent } from "./related-content";
 import { SubmitButton } from "./submit-button";
-
-import "./single-page-content.scss";
 import { Activity, Page } from "../../types";
 import { Section } from "../activity-page/section";
+import { ReadAloudToggle } from "../read-aloud-toggle";
+
+import "./single-page-content.scss";
 
 interface IProps {
   activity: Activity;
@@ -42,6 +44,8 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
 
   return (
     <div className="single-page-content" data-cy="single-page-content">
+      <ReadAloudToggle style={{justifyContent: "flex-end"}} />
+
       {activity.pages.filter((page) => !page.is_hidden).map((page, index: number) => (
         renderPageContent(page, index)
       ))}

--- a/src/components/toggle.tsx
+++ b/src/components/toggle.tsx
@@ -10,6 +10,7 @@ interface IProps {
   disabled?: boolean;
   disabledMessage?: string;
   onChange: (checked: boolean) => void;
+  style?: React.CSSProperties
 }
 
 export const Toggle: React.FC<IProps> = (props) => {
@@ -30,7 +31,7 @@ export const Toggle: React.FC<IProps> = (props) => {
   const className = classNames("toggle", {disabled: props.disabled});
 
   return (
-    <label htmlFor={props.id} className={className} data-cy="toggle">
+    <label htmlFor={props.id} className={className} data-cy="toggle" style={props.style}>
       <div className="label" id={labelId}>
         {props.label}
       </div>


### PR DESCRIPTION
Added read aloud toggle to single page activity content.  Since the toggle needs to be right aligned but may be hidden an enclosing div to align it was not used, instead a style prop was added to left align the toggle itself in this instance.