### PR TITLE
fix: Removed width for estimated time to complete [PT-184981592]

### DIFF
--- a/src/components/activity-introduction/estimated-time.scss
+++ b/src/components/activity-introduction/estimated-time.scss
@@ -4,7 +4,6 @@
   display: flex;
   align-items: center;
   padding: 10px;
-  width: 550px;
   font-size: pxToRem(18);
   color: $cc-charcoal;
   background-color: $cc-teal-light6;

--- a/src/components/sequence-introduction/sequence-page-content.scss
+++ b/src/components/sequence-introduction/sequence-page-content.scss
@@ -109,7 +109,6 @@
     }
 
     .estimated-time {
-      width: auto;
       margin-bottom: 15px;
     }
   }

--- a/src/data/sample-activity-all-question-interactives-large-font.json
+++ b/src/data/sample-activity-all-question-interactives-large-font.json
@@ -13,7 +13,7 @@
   "show_submit_button": true,
   "student_report_enabled": true,
   "thumbnail_url": "",
-  "time_to_complete": null,
+  "time_to_complete": 60,
   "version": 2,
   "theme_name": null,
   "project": null,

--- a/src/data/sample-activity-all-question-interactives.json
+++ b/src/data/sample-activity-all-question-interactives.json
@@ -13,7 +13,7 @@
   "show_submit_button": true,
   "student_report_enabled": true,
   "thumbnail_url": "",
-  "time_to_complete": null,
+  "time_to_complete": 60,
   "version": 2,
   "theme_name": null,
   "project": null,


### PR DESCRIPTION
This also adds estimated times to complete to two of the sample activities so that the normal vs. large font can be seen.

Note: the estimated time display in the sequence homepage was already set to auto to override the fixed width so that was also removed.