### PR TITLE
fix: Changed sequence thumbs to use min-height to avoid cropping images in large fonts [PT-185079448]

### DIFF
--- a/src/components/sequence-introduction/sequence-page-content.scss
+++ b/src/components/sequence-introduction/sequence-page-content.scss
@@ -33,6 +33,8 @@
     .thumb-holder {
       display: flex;
       flex-wrap: wrap;
+      gap: 30px;
+      margin-top: 15px;
 
       .thumb {
         display: flex;
@@ -41,8 +43,7 @@
         flex-grow: 0;
         flex-shrink: 0;
         width: 280px;
-        height: 316px;
-        margin: 15px 30px 15px 0;
+        min-height: 316px;
         padding: 8px 10px 10px;
         border-radius: 8px;
         border: solid 1.5px $cc-charcoal-light1;


### PR DESCRIPTION
Also fixed layout issues by switching to using `gap` instead of margins.

Before:

![image](https://user-images.githubusercontent.com/112938/235751823-74105d2b-5d96-46f6-887e-08abc0af474e.png)

After: 

![image](https://user-images.githubusercontent.com/112938/235751916-8399abf6-5037-4c14-8021-69b3dcfa8d02.png)
