### PR TITLE
fix: Activity summary title alignment [PT-185079432]

### DIFF
--- a/src/components/activity-introduction/activity-summary.scss
+++ b/src/components/activity-introduction/activity-summary.scss
@@ -8,6 +8,7 @@
     display: flex;
     width: 100%;
     justify-content: space-between;
+    align-items: center;
 
     img {
       height: 80px;


### PR DESCRIPTION
Added `align-items: center` to `.activity-title` to ensure the thumbnail image vertically aligns with the activity title text when in large font mode.