### PR TITLE
fix: Updated plugin popups to use rem based font sizes [PT-184981622]

### DIFF
--- a/src/components/activity-page/plugins/embeddable-plugin.scss
+++ b/src/components/activity-page/plugins/embeddable-plugin.scss
@@ -42,11 +42,13 @@
 
 .ui-dialog-title {
   font: 700 16px lato, arial, helvetica, sans-serif;
+  font-size: 1rem;
   margin: 0 !important;
 }
 
 .ui-widget-content {
   font-family: lato, arial, helvetica, sans-serif;
+  font-size: 1rem;
   p.response {
     font-size: 1.1rem;
   }


### PR DESCRIPTION
This allows the glossary popup to use the large font setting if enabled.

This is what the glossary popup now looks like in the large font setting:

![image](https://github.com/concord-consortium/activity-player/assets/112938/ba09ddfe-0220-4c1c-b601-729468eee042)
