### PR TITLE
fix: Large font issues for sidebar icon container [PT-184981622]

### DIFF
--- a/src/components/expandable-content/expandable-container.scss
+++ b/src/components/expandable-content/expandable-container.scss
@@ -40,12 +40,12 @@
 
 .sidebar-hdr {
   cursor: pointer;
-  min-height: 79px;
+  min-height: 4.25rem;
   text-align: center;
-  padding: 8px;
+  padding: 0.5rem;
   position: absolute;
-  width: 85px;
-  left: -85px;
+  width: 4.25rem;
+  left: -4.25rem;
   box-sizing: border-box;
 
   &:hover {


### PR DESCRIPTION
Changed to rem based units from px based units for sidebar container icon so that it changes dynamically with the font size setting.