### PR TITLE
Fixes to layout and arrows when using collapsible 70-30 or 60-40 layout. (PT-185354960)

### DIFF
--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -43,7 +43,7 @@
     .column.primary {
       grid-column: span 6;
       &.expand {
-        grid-column: span 9;
+        grid-column: span 10;
       }
     }
     .column.secondary {
@@ -53,7 +53,7 @@
         flex-direction: column;
       }
       &.collapsed {
-        grid-column: span 1;
+        grid-column: none;
       }
     }
   }
@@ -82,7 +82,7 @@
     .column.primary {
       grid-column: span 7;
       &.expand {
-        grid-column: span 9;
+        grid-column: span 10;
       }
     }
     .column.secondary {
@@ -92,7 +92,7 @@
         flex-direction: column;
       }
       &.collapsed {
-        grid-column: span 1;
+        grid-column: none;
       }
     }
   }

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -27,6 +27,9 @@ export interface SectionImperativeAPI {
   requestInteractiveStates: (options?: IGetInteractiveState) => Promise<void>[];
 }
 
+const right = "right";
+const left = "left";
+
 export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
   const { activityLayout, page, section, questionNumberStart } = props;
   const [isSecondaryCollapsed, setIsSecondaryCollapsed] = useState(false);
@@ -136,29 +139,29 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
   };
 
   const renderCollapsibleHeader = () => {
-    const rightOrientation = section.layout.includes("l");
-    const headerClass = `collapsible-header ${isSecondaryCollapsed ? "collapsed" : ""} ${rightOrientation ? "right" : ""}`;
+    const collapsibleColumnOnLeft = section.layout === "30-70" || section.layout === "40-60";
+    const headerClass = `collapsible-header ${isSecondaryCollapsed ? "collapsed" : ""} ${collapsibleColumnOnLeft ? left : right}`;
     return (
       <div className={headerClass} data-cy="collapsible-header" tabIndex={0}
             onClick={handleCollapseHeader} onKeyDown={handleCollapseHeader} >
         {isSecondaryCollapsed
           ? <React.Fragment>
-              {renderCollapseArrow(rightOrientation)}
+              {renderCollapseArrow(collapsibleColumnOnLeft ? right : left)}
               <div>Show</div>
             </React.Fragment>
           : <React.Fragment>
-              {rightOrientation && <div>Hide</div>}
-              {renderCollapseArrow(!rightOrientation)}
-              {!rightOrientation && <div>Hide</div>}
+              {!collapsibleColumnOnLeft && <div>Hide</div>}
+              {renderCollapseArrow(collapsibleColumnOnLeft ? left : right)}
+              {collapsibleColumnOnLeft && <div>Hide</div>}
             </React.Fragment>
         }
       </div>
     );
   };
 
-  const renderCollapseArrow = (leftArrow: boolean) => {
+  const renderCollapseArrow = (arrowType: "left" | "right" ) => {
     return (
-      leftArrow
+      arrowType === left
         ? <IconChevronLeft
           width={32}
           height={32}


### PR DESCRIPTION
This PR fixes two issues:

- When the collapsible header was on the right side of the layout, the wrong arrows were showing for Show and Hide modes.
- When the collapsible header was on the right side of the layout, the collapsed column was taking up too much space.