### PR TITLE
feat: Add back read-aloud toggle design in notebook layout [PT-185343168]

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -345,11 +345,6 @@ export class App extends React.PureComponent<IProps, IState> {
         hideReadAloud = !!activity.hide_read_aloud;
       }
 
-      // **** REMOVE THIS activity.layout CHECK BEFORE ANY FINAL MERGE TO MASTER ***
-      if (activity.layout === ActivityLayouts.Notebook) {
-        hideReadAloud = true;
-      }
-
       if (hideReadAloud) {
         // turn off read-aloud but do not persist the setting
         dynamicTextManager.enableReadAloud({ enabled: false, saveSetting: false });

--- a/src/data/sample-activity-notebook.json
+++ b/src/data/sample-activity-notebook.json
@@ -1,7 +1,7 @@
 {
   "background_image": "",
   "defunct": false,
-  "hide_read_aloud": true,
+  "hide_read_aloud": false,
   "description": "",
   "editor_mode": 0,
   "id": 43,

--- a/src/notebook.scss
+++ b/src/notebook.scss
@@ -60,7 +60,7 @@ body.notebook {
 
       display: none;
       &.contains-read-aloud {
-        display: block;
+        display: flex;
       }
     }
 


### PR DESCRIPTION
This removes the forced hiding of the read aloud toggle in the notebook layout that was initially done in the spike.

It also unhides the read aloud toggle in the sample notebook activity for demo/testing.