### PR TITLE
fix: Lab book interactive only displays properly on Tab 1 of the Notebook layout [PT-185055230]

### DIFF
--- a/src/notebook.scss
+++ b/src/notebook.scss
@@ -166,7 +166,10 @@ body.notebook {
         padding: 10px 10px 0 10px;
 
         &.hidden-tab {
-          display: none !important;
+          visibility: hidden;
+          height: 0;
+          margin: 0 !important;
+          padding: 0 !important;
         }
 
         &.tab-contents {
@@ -175,6 +178,7 @@ body.notebook {
 
         .collapsible-header {
           border-radius: 8px;
+          transition: none !important;
 
           div {
             width: auto;


### PR DESCRIPTION
This changes hidden tabs to render with visibility hidden with a height of 0 to ensure the layout with the correct width at startup.

In order to do this the collapsible header transition needs to be disabled in the notebook layout so it doesn't transition in when the section visibility changes when a tab is selected.