### PR TITLE
fix: Missing $ in string interpolation when generating question headers [PT-185302905]

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -366,7 +366,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   const iframeUrl = activeDialog?.url || (embeddable.url_fragment ? url + embeddable.url_fragment : url);
   const hasQuestionNumber = questionNumber ? "runtime-container has-question-number" : "runtime-container";
 
-  const questionPrefix = props.showQuestionPrefix ? `Question #{questionNumber}:` : "";
+  const questionPrefix = props.showQuestionPrefix ? `Question #${questionNumber}:` : "";
 
   const interactiveIframeRuntime =
     loadingAnswer || loadingLegacyLinkedInteractiveState ?


### PR DESCRIPTION
This was introduced in the notebook spike and wasn't seen until the forcing of the activity layout to the notebook was removed in the notebook feature branch.