### PR TITLE
fix: Border radius for iframes with no question header [PT-185395490]

### DIFF
--- a/src/notebook.scss
+++ b/src/notebook.scss
@@ -74,6 +74,9 @@ body.notebook {
       }
       .runtime-container.has-question-number {
         border: 0;
+        iframe {
+          border-radius: 0 0 10px 10px;
+        }
       }
       iframe {
         border-radius: 10px;


### PR DESCRIPTION
This keeps the original bottom border radius when the question has a header and sets the default border radius to be on all four corners.