### PR TITLE
Fix overlapping arrows with text and check for responsive 2 column layout (PT-185354960)

### DIFF
--- a/cypress/e2e/activity-page-font-size-large.test.ts
+++ b/cypress/e2e/activity-page-font-size-large.test.ts
@@ -29,7 +29,7 @@ context("Test the overall app", () => {
       activityPage.getPagesHeader().should('have.css', 'font-size', largeFont.size5);
       activityPage.getPageItemNo().should('have.css', 'font-size', largeFont.size5);
       activityPage.getPageItemLink().should('have.css', 'font-size', largeFont.size5);
-      
+
     });
   });
   describe("Bar Graph",() => {
@@ -51,7 +51,7 @@ context("Test the overall app", () => {
       getInIframe("body", ".runtime--runtime--question-int p").should('have.css', 'font-size', largeFont.size4);
       getInIframe("body", ".runtime--runtime--question-int").find("iframe").its("0.contentDocument.body").find('[data-testid=legend]').should('have.css', 'font-size', largeFont.size4);
       getInIframe("body", ".runtime--runtime--question-int").find("iframe").its("0.contentDocument.body").find('[data-testid=response-textarea]').should('have.css', 'font-size', largeFont.size4);
-      getInIframe("body", ".iframe-runtime--hint--question-int p").should('have.css', 'font-size', largeFont.size3);    
+      getInIframe("body", ".iframe-runtime--hint--question-int p").should('have.css', 'font-size', largeFont.size3);
     });
   });
   describe("Drag & Drop",() => {
@@ -71,8 +71,8 @@ context("Test the overall app", () => {
       cy.wait(5000);
       fontSize.verifyHeaderHintLargeFont("Drawing Tool", "Drawing Tool");
       getInIframe("body", ".base-app--runtime--question-int p").should('have.css', 'font-size', largeFont.size4);
-      getInIframe("body", "[data-test=upload-btn]").should('have.css', 'font-size', largeFont.size6);
-      getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 1).should('have.css', 'font-size', largeFont.size6);
+      getInIframe("body", "[data-test=upload-btn]").should('have.css', 'font-size', largeFont.size4);
+      getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 1).should('have.css', 'font-size', largeFont.size4);
     });
   });
   describe("FIB",() => {
@@ -101,20 +101,20 @@ context("Test the overall app", () => {
       fontSize.verifyHeaderHintLargeFont("Image Question", "Image Question");
       getInIframe("body", ".base-app--runtime--question-int p").eq(0).should('have.css', 'font-size', largeFont.size4);
       getInIframe("body", ".base-app--runtime--question-int p").eq(1).should('have.css', 'font-size', largeFont.size4);
-      getInIframe("body", "[data-test=edit-btn]").should('have.css', 'font-size', largeFont.size6);
+      getInIframe("body", "[data-test=edit-btn]").should('have.css', 'font-size', largeFont.size4);
       getInIframe("body", "[data-test=edit-btn]").click();
       cy.wait(5000);
       getInIframeWithIndex("body", ".runtime--dialogContent--question-int", 2).should("be.visible");
       getInIframeWithIndex("body", ".runtime--dialogRightPanel--question-int div p", 2).eq(0).should('have.css', 'font-size', largeFont.size4);
       getInIframeWithIndex("body", ".runtime--answerPrompt--question-int p", 2).should('have.css', 'font-size', largeFont.size4);
       getInIframeWithIndex("body", ".runtime--dialogRightPanel--question-int textarea", 2).should('have.css', 'font-size', largeFont.size4);
-      getInIframeWithIndex("body", "[data-test=close-dialog-btn]", 2).should('have.css', 'font-size', largeFont.size6);
+      getInIframeWithIndex("body", "[data-test=close-dialog-btn]", 2).should('have.css', 'font-size', largeFont.size4);
       getInIframeWithIndex("body", "[data-test=close-dialog-btn]", 2).click();
       getInIframeWithIndex("body", ".runtime--closeDialogSection--question-int div", 2).should('have.css', 'font-size', largeFont.size4);
       cy.wait(20000);
-      getInIframeWithIndex("body", "[data-test=upload-btn]", 1).should('have.css', 'font-size', largeFont.size6);
+      getInIframeWithIndex("body", "[data-test=upload-btn]", 1).should('have.css', 'font-size', largeFont.size4);
       cy.wait(5000);
-      getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 2).should('have.css', 'font-size', largeFont.size6);
+      getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 2).should('have.css', 'font-size', largeFont.size4);
     });
   });
   describe("Labbook",() => {
@@ -194,7 +194,7 @@ context("Test the overall app", () => {
       cy.wait(2000);
       getInIframe("body", ".runtime--runtime--question-int").find("iframe").its("0.contentDocument.body").find('[data-testid=legend]').should('have.css', 'font-size', largeFont.size4);
       getInIframe("body", ".runtime--runtime--question-int").find("iframe").its("0.contentDocument.body").find('[data-testid=response-textarea]').should('have.css', 'font-size', largeFont.size4);
-          
+
     });
   });
  describe("ScoreBot",() => {

--- a/cypress/e2e/activity-page-font-size-normal.test.ts
+++ b/cypress/e2e/activity-page-font-size-normal.test.ts
@@ -29,7 +29,7 @@ context("Test the overall app", () => {
       activityPage.getPagesHeader().should('have.css', 'font-size', normalFont.size5);
       activityPage.getPageItemNo().should('have.css', 'font-size', normalFont.size5);
       activityPage.getPageItemLink().should('have.css', 'font-size', normalFont.size5);
-      
+
     });
   });
   describe("Bar Graph",() => {
@@ -51,7 +51,7 @@ context("Test the overall app", () => {
       getInIframe("body", ".runtime--runtime--question-int p").should('have.css', 'font-size', normalFont.size4);
       getInIframe("body", ".runtime--runtime--question-int").find("iframe").its("0.contentDocument.body").find('[data-testid=legend]').should('have.css', 'font-size', normalFont.size4);
       getInIframe("body", ".runtime--runtime--question-int").find("iframe").its("0.contentDocument.body").find('[data-testid=response-textarea]').should('have.css', 'font-size', normalFont.size4);
-      getInIframe("body", ".iframe-runtime--hint--question-int p").should('have.css', 'font-size', normalFont.size3);    
+      getInIframe("body", ".iframe-runtime--hint--question-int p").should('have.css', 'font-size', normalFont.size3);
     });
   });
   describe("Drag & Drop",() => {
@@ -71,8 +71,8 @@ context("Test the overall app", () => {
       cy.wait(5000);
       fontSize.verifyHeaderHintNormalFont("Drawing Tool", "Drawing Tool");
       getInIframe("body", ".base-app--runtime--question-int p").should('have.css', 'font-size', normalFont.size4);
-      getInIframe("body", "[data-test=upload-btn]").should('have.css', 'font-size', normalFont.size6);
-      getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 1).should('have.css', 'font-size', normalFont.size6);
+      getInIframe("body", "[data-test=upload-btn]").should('have.css', 'font-size', normalFont.size4);
+      getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 1).should('have.css', 'font-size', normalFont.size4);
     });
   });
   describe("FIB",() => {
@@ -101,20 +101,20 @@ context("Test the overall app", () => {
       fontSize.verifyHeaderHintNormalFont("Image Question", "Image Question");
       getInIframe("body", ".base-app--runtime--question-int p").eq(0).should('have.css', 'font-size', normalFont.size4);
       getInIframe("body", ".base-app--runtime--question-int p").eq(1).should('have.css', 'font-size', normalFont.size4);
-      getInIframe("body", "[data-test=edit-btn]").should('have.css', 'font-size', normalFont.size6);
+      getInIframe("body", "[data-test=edit-btn]").should('have.css', 'font-size', normalFont.size4);
       getInIframe("body", "[data-test=edit-btn]").click();
       cy.wait(5000);
       getInIframeWithIndex("body", ".runtime--dialogContent--question-int", 2).should("be.visible");
       getInIframeWithIndex("body", ".runtime--dialogRightPanel--question-int div p", 2).eq(0).should('have.css', 'font-size', normalFont.size4);
       getInIframeWithIndex("body", ".runtime--answerPrompt--question-int p", 2).should('have.css', 'font-size', normalFont.size4);
       getInIframeWithIndex("body", ".runtime--dialogRightPanel--question-int textarea", 2).should('have.css', 'font-size', normalFont.size4);
-      getInIframeWithIndex("body", "[data-test=close-dialog-btn]", 2).should('have.css', 'font-size', normalFont.size6);
+      getInIframeWithIndex("body", "[data-test=close-dialog-btn]", 2).should('have.css', 'font-size', normalFont.size4);
       getInIframeWithIndex("body", "[data-test=close-dialog-btn]", 2).click();
       getInIframeWithIndex("body", ".runtime--closeDialogSection--question-int div", 2).should('have.css', 'font-size', normalFont.size4);
       cy.wait(20000);
-      getInIframeWithIndex("body", "[data-test=upload-btn]", 1).should('have.css', 'font-size', normalFont.size6);
+      getInIframeWithIndex("body", "[data-test=upload-btn]", 1).should('have.css', 'font-size', normalFont.size4);
       cy.wait(5000);
-      getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 2).should('have.css', 'font-size', normalFont.size6);
+      getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 2).should('have.css', 'font-size', normalFont.size4);
     });
   });
   describe("Labbook",() => {
@@ -194,7 +194,7 @@ context("Test the overall app", () => {
       cy.wait(2000);
       getInIframe("body", ".runtime--runtime--question-int").find("iframe").its("0.contentDocument.body").find('[data-testid=legend]').should('have.css', 'font-size', normalFont.size4);
       getInIframe("body", ".runtime--runtime--question-int").find("iframe").its("0.contentDocument.body").find('[data-testid=response-textarea]').should('have.css', 'font-size', normalFont.size4);
-          
+
     });
   });
  describe("ScoreBot",() => {

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -216,7 +216,7 @@
       align-self: center;
       position: relative;
       white-space: nowrap;
-      width: 30px;
+      width: auto;
     }
   }
 }

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -140,7 +140,7 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
   };
 
   const renderCollapsibleHeader = () => {
-    const collapsibleColumnOnLeft = section.layout === "30-70" || section.layout === "40-60";
+    const collapsibleColumnOnLeft = section.layout === "30-70" || section.layout === "40-60" || section.layout === "responsive-2-columns";
     const headerClass = `collapsible-header ${isSecondaryCollapsed ? "collapsed" : ""} ${collapsibleColumnOnLeft ? left : right}`;
     return (
       <div className={headerClass} data-cy="collapsible-header" tabIndex={0}


### PR DESCRIPTION
This addresses an issue where when the activity font is set to large, the text and collapse/show arrows were colliding.
It was tested in both cases of text being set to normal and large, and there are no regressions if text is set to normal.
Also added a check for responsive 2 column layout -- the column is on the left in that case, and the proper arrows need to be displayed.