### PR TITLE
Fix tabs and notebook header z-index issues. (PT-185395585)

### DIFF
--- a/src/notebook.scss
+++ b/src/notebook.scss
@@ -189,7 +189,7 @@ body.notebook {
           border: solid 2px  $cc-orange-dark1;
           border-bottom: solid 2px $cc-orange-dark1;
           background-color: $cc-orange-dark1;
-          z-index: 100 !important;
+          z-index: $notebookHeaderZIndex - 1 !important;
         }
 
         &.selected {
@@ -197,7 +197,7 @@ body.notebook {
         }
 
         &:hover {
-          z-index: 200 !important;
+          z-index: $notebookHeaderZIndex !important;
         }
       }
     }
@@ -253,5 +253,11 @@ body.notebook {
     font-size: $notebook_font_size;
     background-color: $cc-teal-dark1;
     border-radius: 10px 10px;
+  }
+
+  .expandable-container {
+    position: absolute;
+    top: 120px;
+    right: 0px;
   }
 }


### PR DESCRIPTION
This PR changes the section tabs to have the same z-index as the notebook header (99) so that they don't appear over the sharing plugin, which has a z-index of 100.

It also adds an absolute position to the expandable-container div, because otherwise the stacking order was interfering with the correct application of the z-indices. 