### PR TITLE
fix: Updated plugin rendering to use notebook font [PT-185471695]

### DIFF
--- a/src/components/activity-page/plugins/embeddable-plugin.scss
+++ b/src/components/activity-page/plugins/embeddable-plugin.scss
@@ -10,7 +10,8 @@
 }
 
 #modal {
-  font: 400 100% lato, arial, helvetica, sans-serif;
+  font-weight: 400;
+  font-size: 1rem;
 }
 
 .ui-dialog {
@@ -41,13 +42,12 @@
 }
 
 .ui-dialog-title {
-  font: 700 16px lato, arial, helvetica, sans-serif;
+  font-weight: 700;
   font-size: 1rem;
   margin: 0 !important;
 }
 
 .ui-widget-content {
-  font-family: lato, arial, helvetica, sans-serif;
   font-size: 1rem;
   p.response {
     font-size: 1.1rem;

--- a/src/notebook.scss
+++ b/src/notebook.scss
@@ -5,14 +5,20 @@ $notebook_font_size: 1rem;  // this uses the new font size setting, forced to "l
 
 $notebookHeaderZIndex: 99;
 
+$font_family: $notebook_font_family, 'Lato', arial, helvetica, sans-serif;
+
 body.notebook {
 
-  font-family: 'Andika', 'Lato', arial, helvetica, sans-serif;
+  font-family: $font_family;
   font-size: $notebook_font_size;
+
+  .ui-widget, textarea {
+    font-family: $font_family !important;
+  }
 
   button, .button {
     height: auto;
-    font-family: $notebook_font_family;
+    font-family: $font_family;
   }
 
   .sequence-nav {
@@ -37,7 +43,7 @@ body.notebook {
         font-size: $notebook_font_size;
         width: auto;
         border-radius: 8px;
-        font-family: 'Andika', 'Lato', arial, helvetica, sans-serif;
+        font-family: $font_family;
         gap: 5px;
         justify-content: center;
         align-items: center;


### PR DESCRIPTION
This removes the last of the specific Lato overrides in AP and refactors the font family in the notebook.scss to use a sass variable.