### PR TITLE
fix: Hide question numbers QA issues [PT-186748231]

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -24,6 +24,7 @@ import { Logger, LogEventName } from "../../../lib/logger";
 import { handleGetAttachmentUrl } from "@concord-consortium/interactive-api-host";
 import { LaraDataContext } from "../../lara-data-context";
 import { ClickToPlay } from "./click-to-play";
+import { ActivityLayouts, hasPluginReferencingEmbeddable } from "../../../utilities/activity-utils";
 
 import "./managed-interactive.scss";
 
@@ -72,6 +73,11 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   const [heightFromInteractive, setHeightFromInteractive] = useState(0);
 
   const embeddableRefId = props.embeddable.ref_id;
+
+  const hasPlugin = useMemo(() => {
+    return !!laraData.activity && hasPluginReferencingEmbeddable(laraData.activity, embeddableRefId);
+  }, [laraData.activity, embeddableRefId]);
+
   useEffect(() => {
     if (shouldWatchAnswer) {
       return watchAnswer(embeddableRefId, (wrappedAnswer) => {
@@ -374,7 +380,9 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   const trimmedQuestionName = questionName.trim();
   const hasQuestionName = trimmedQuestionName.length > 0;
   const questionPrefix = props.showQuestionPrefix && !props.hideQuestionNumbers ? `Question #${questionNumber}${hasQuestionName ? ": " : ""}` : "";
-  const hideQuestionHeader = props.hideQuestionNumbers && !hasQuestionName;
+
+  const isNotebookLayout = laraData.activity?.layout === ActivityLayouts.Notebook;
+  const hideQuestionHeader = props.hideQuestionNumbers && !hasQuestionName && !hint && !isNotebookLayout && !hasPlugin;
 
   const interactiveIframeRuntime =
     loadingAnswer || loadingLegacyLinkedInteractiveState ?

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -593,6 +593,7 @@ export class App extends React.PureComponent<IProps, IState> {
         activity={activity}
         teacherEditionMode={this.state.teacherEditionMode}
         pluginsLoaded={this.state.pluginsLoaded}
+        hideQuestionNumbers={this.state.hideQuestionNumbers}
       />
     );
   }

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -13,10 +13,11 @@ interface IProps {
   activity: Activity;
   teacherEditionMode?: boolean;
   pluginsLoaded: boolean;
+  hideQuestionNumbers?: boolean;
 }
 
 export const SinglePageContent: React.FC<IProps> = (props) => {
-  const { activity, teacherEditionMode, pluginsLoaded } = props;
+  const { activity, teacherEditionMode, pluginsLoaded, hideQuestionNumbers } = props;
   const renderPageContent = (page: Page, index: number) => {
     // Even though this renders as a single page, the authored JSON still has pages
     const totalPreviousQuestions = numQuestionsOnPreviousPages(page.position, activity);
@@ -34,6 +35,7 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
                 teacherEditionMode={teacherEditionMode}
                 pluginsLoaded={pluginsLoaded}
                 page={page}
+                hideQuestionNumbers={hideQuestionNumbers}
               />
             );
           })

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -253,3 +253,17 @@ export const getSequenceActivityId = (sequence: Sequence, activityIndex: number 
 
   return undefined;
 };
+
+export const hasPluginReferencingEmbeddable = (activity: Activity, embeddableRefId: string): boolean => {
+  return activity.pages.reduce<boolean>((acc, page) => {
+    return page.sections.reduce<boolean>((acc2, section) => {
+      return section.embeddables.reduce<boolean>((acc3, embeddable) => {
+        if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.embeddable_ref_id === embeddableRefId) {
+          acc3 = true;
+        }
+        return acc3;
+      }, acc2);
+    }, acc);
+  }, false);
+};
+


### PR DESCRIPTION
- Added back showing header even when question numbers are disabled and the question has no name when the activity is in notebook layout, the question has a hint or the question has a plugin.
- Fixed question numbers not being hidden in the single page layout