### PR TITLE
feat: Update portal-report to use 4.21.0 [PT-188279220]

### DIFF
--- a/src/utilities/report-utils.ts
+++ b/src/utilities/report-utils.ts
@@ -9,7 +9,7 @@ import { refIdToAnswersQuestionId } from "./embeddable-utils";
 // *** IMPORTANT NOTE ***
 // When you change these URLs you need to edit the portal-report Auth Client in
 // the portals to allow redirects back to the the updated URLs.
-export const kProductionPortalReportUrl = "https://portal-report.concord.org/version/v4.16.0/index.html";
+export const kProductionPortalReportUrl = "https://portal-report.concord.org/version/v4.21.0/index.html";
 export const kDevPortalReportUrl = "https://portal-report.concord.org/branch/master/index.html";
 
 // The default portal report URL is based on the URL:


### PR DESCRIPTION
This is necessary so the students can see the new rubric feedback in 4.21.0 via the Show Work button.