### PR TITLE
build: Disable ScoreBot Cypress tests

### DIFF
--- a/cypress/e2e/activity-page-font-size-large.test.ts
+++ b/cypress/e2e/activity-page-font-size-large.test.ts
@@ -110,6 +110,10 @@ context("Test the overall app", () => {
       getInIframe("body", ".base-app--runtime--question-int p").eq(1).should('have.css', 'font-size', largeFont.size4);
       getInIframe("body", "[data-test=edit-btn]").should('have.css', 'font-size', largeFont.size4);
       getInIframe("body", "[data-test=edit-btn]").click();
+      /*
+
+      DISABLED DUE TO ERROR ON GITHUB - WORKS FINE LOCALLY.  SHOULD BE FIXED WHEN AP IS WORKED ON NEXT.
+
       cy.wait(5000);
       getInIframeWithIndex("body", ".drawing-tool-dialog--dialogContent--question-int", 2).should("be.visible");
       getInIframeWithIndex("body", ".drawing-tool-dialog--dialogRightPanel--question-int div p", 2).eq(0).should('have.css', 'font-size', largeFont.size4);
@@ -122,6 +126,7 @@ context("Test the overall app", () => {
       getInIframeWithIndex("body", "[data-test=upload-btn]", 1).should('have.css', 'font-size', largeFont.size4);
       cy.wait(5000);
       getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 2).should('have.css', 'font-size', largeFont.size4);
+      */
     });
   });
   describe("Labbook",() => {
@@ -209,7 +214,11 @@ context("Test the overall app", () => {
 
     });
   });
- describe("ScoreBot",() => {
+  /*
+
+  DISABLED DUE TO SCOREBOT NO LONGER SENDING AN API RESPONSE.  SHOULD BE RE-ENABLED IF SCOREBOT IS FIXED.
+
+  describe("ScoreBot",() => {
     it("verify large font size in scorebot interactive",()=>{
       beforeTest();
       activityPage.clickPageItem(12);
@@ -282,4 +291,5 @@ context("Test the overall app", () => {
       activityPage.getExitTextButton().should('have.css', 'font-size', largeFont.size6);
     });
   });
+*/
 });

--- a/cypress/e2e/activity-page-font-size-normal.test.ts
+++ b/cypress/e2e/activity-page-font-size-normal.test.ts
@@ -109,6 +109,10 @@ context("Test the overall app", () => {
       getInIframe("body", ".base-app--runtime--question-int p").eq(1).should('have.css', 'font-size', normalFont.size4);
       getInIframe("body", "[data-test=edit-btn]").should('have.css', 'font-size', normalFont.size4);
       getInIframe("body", "[data-test=edit-btn]").click();
+      /*
+
+      DISABLED DUE TO ERROR ON GITHUB - WORKS FINE LOCALLY.  SHOULD BE FIXED WHEN AP IS WORKED ON NEXT.
+
       cy.wait(5000);
       getInIframeWithIndex("body", ".drawing-tool-dialog--dialogContent--question-int", 2).should("be.visible");
       getInIframeWithIndex("body", ".drawing-tool-dialog--dialogContent--question-int div p", 2).eq(0).should('have.css', 'font-size', normalFont.size4);
@@ -121,6 +125,7 @@ context("Test the overall app", () => {
       getInIframeWithIndex("body", "[data-test=upload-btn]", 1).should('have.css', 'font-size', normalFont.size4);
       cy.wait(5000);
       getInIframeWithIndex("body", "[data-testid=snapshot-btn]", 2).should('have.css', 'font-size', normalFont.size4);
+      */
     });
   });
   describe("Labbook",() => {
@@ -208,7 +213,11 @@ context("Test the overall app", () => {
 
     });
   });
- describe("ScoreBot",() => {
+  /*
+
+  DISABLED DUE TO SCOREBOT NO LONGER SENDING AN API RESPONSE. SHOULD BE RE-ENABLED IF SCOREBOT IS FIXED.
+
+  describe("ScoreBot",() => {
     it("verify normal font size in scorebot interactive",()=>{
       beforeTest();
       activityPage.clickPageItem(12);
@@ -281,4 +290,5 @@ context("Test the overall app", () => {
       activityPage.getExitTextButton().should('have.css', 'font-size', normalFont.size6);
     });
   });
+  */
 });

--- a/cypress/e2e/activity-page-read-aloud.test.ts
+++ b/cypress/e2e/activity-page-read-aloud.test.ts
@@ -118,7 +118,11 @@ context("Test the overall app", () => {
       getInIframe("body", ".runtime--runtime--question-int p").eq(0).parent().parent().click().should('have.css', 'background-color', readAlound.backgroundColor);
     });
   });
- describe("ScoreBot",() => {
+  /*
+
+  DISABLED DUE TO SCOREBOT NO LONGER SENDING AN API RESPONSE. SHOULD BE RE-ENABLED IF SCOREBOT IS FIXED.
+
+  describe("ScoreBot",() => {
     it("verify read aloud in scorebot interactive",()=>{
       beforeTest();
       activityPage.clickPageItem(11);
@@ -163,4 +167,5 @@ context("Test the overall app", () => {
       activityPage.getTextBlockContent().children().click().should('have.css', 'background-color', readAlound.backgroundColor);
     });
   });
+  */
 });


### PR DESCRIPTION
The ScoreBot tests are broken because the ScoreBot api endpoint is not sending correct responses.  These tests should be fixed if and when ScoreBot is fixed.

The Image Question tests are broken on GitHub but run fine locally.  This is probably due to the GitHub Actions platform updating some dependency.  These tests should be fixed the next time AP is worked on.