### PR TITLE
feat: Only require header for sharing plugin [PT-187807322]

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -24,7 +24,7 @@ import { Logger, LogEventName } from "../../../lib/logger";
 import { handleGetAttachmentUrl } from "@concord-consortium/interactive-api-host";
 import { LaraDataContext } from "../../lara-data-context";
 import { ClickToPlay } from "./click-to-play";
-import { ActivityLayouts, hasPluginReferencingEmbeddable } from "../../../utilities/activity-utils";
+import { ActivityLayouts, hasPluginThatRequiresHeader } from "../../../utilities/activity-utils";
 
 import "./managed-interactive.scss";
 
@@ -74,8 +74,8 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
 
   const embeddableRefId = props.embeddable.ref_id;
 
-  const hasPlugin = useMemo(() => {
-    return !!laraData.activity && hasPluginReferencingEmbeddable(laraData.activity, embeddableRefId);
+  const hasPluginRequiringHeader = useMemo(() => {
+    return !!laraData.activity && hasPluginThatRequiresHeader(laraData.activity, embeddableRefId);
   }, [laraData.activity, embeddableRefId]);
 
   useEffect(() => {
@@ -381,7 +381,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   const questionPrefix = props.showQuestionPrefix && !props.hideQuestionNumbers && questionNumber ? `Question #${questionNumber}${hasQuestionName ? ": " : ""}` : "";
 
   const isNotebookLayout = laraData.activity?.layout === ActivityLayouts.Notebook;
-  const hideQuestionHeader = (props.hideQuestionNumbers || !hasQuestionNumber) && !hasQuestionName && !hint && !isNotebookLayout && !hasPlugin;
+  const hideQuestionHeader = (props.hideQuestionNumbers || !hasQuestionNumber) && !hasQuestionName && !hint && !isNotebookLayout && !hasPluginRequiringHeader;
 
   const isInteractive = embeddable.type === "MwInteractive";
   const isManagedInteractive = embeddable.type === "ManagedInteractive";

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -254,11 +254,12 @@ export const getSequenceActivityId = (sequence: Sequence, activityIndex: number 
   return undefined;
 };
 
-export const hasPluginReferencingEmbeddable = (activity: Activity, embeddableRefId: string): boolean => {
+const pluginsRequiringHeader = ["laraSharing"];
+export const hasPluginThatRequiresHeader = (activity: Activity, embeddableRefId: string): boolean => {
   return activity.pages.reduce<boolean>((acc, page) => {
     return page.sections.reduce<boolean>((acc2, section) => {
       return section.embeddables.reduce<boolean>((acc3, embeddable) => {
-        if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.embeddable_ref_id === embeddableRefId) {
+        if (embeddable.type === "Embeddable::EmbeddablePlugin" && embeddable.embeddable_ref_id === embeddableRefId && pluginsRequiringHeader.includes(embeddable.plugin?.approved_script_label ?? "")) {
           acc3 = true;
         }
         return acc3;
@@ -266,4 +267,3 @@ export const hasPluginReferencingEmbeddable = (activity: Activity, embeddableRef
     }, acc);
   }, false);
 };
-


### PR DESCRIPTION
This updates the code that decides if the header is shown not check if any plugin is associated with the question but only if the sharing plugin is associated.

The code is setup in such a way so that other plugins can be included in that list in the future.