### PR TITLE
Added checks for hide question number in Drawing Tool interactive

### DIFF
--- a/cypress/e2e/hide-question-numbers-interactives.ts
+++ b/cypress/e2e/hide-question-numbers-interactives.ts
@@ -213,7 +213,7 @@ context("Activity hide question numbers checked", () => {
       });
 
       // Page 3: Bottom Row Left - No name no hint
-      cy.log("Page 3: Bottom Row Left - Question #8: No name, no hint");
+      cy.log("Page 3: Bottom Row Left - No name, no hint");
       activityPage.getInteractive().eq(3).find(".has-question-number .header div")
         .should("not.exist")
       activityPage.getInteractive().eq(3).within(($interactive) => {

--- a/cypress/e2e/hide-question-numbers-interactives.ts
+++ b/cypress/e2e/hide-question-numbers-interactives.ts
@@ -1,0 +1,149 @@
+import ActivityPage from "../support/elements/activity-page";
+
+const activityPage = new ActivityPage;
+
+context("Activity hide question numbers checked", () => {
+  before(() => {
+    cy.visit("?activity=sample-activity-hide-question-number");
+    activityPage.getActivityTitle().should("contain", "Test Hide Question Number Setting");
+  });
+  describe("Hide question numbers checked in activity",() => {
+    it.only("Verify the left column has the hide question number setting OFF and the right has it ON.",()=>{
+      activityPage.clickPageItem(0);
+      cy.wait(2000);
+      cy.log("left column question numbers on page 1 shown");
+      activityPage.getInteractive().eq(0).find(".has-question-number .header div").should("exist");
+      activityPage.getInteractive().eq(1).find(".has-question-number .header div").should("exist");
+      activityPage.getInteractive().eq(2).find(".has-question-number .header div").should("exist");
+      activityPage.getInteractive().eq(3).find(".has-question-number .header div").should("exist");
+      cy.log("right column question numbers on page 1 hidden");
+      activityPage.getInteractive().eq(4).find(".has-question-number .header div").should("not.exist");
+      activityPage.getInteractive().eq(5).find(".has-question-number .header div").should("not.exist");
+      activityPage.getInteractive().eq(6).find(".has-question-number .header div").should("not.exist");
+      activityPage.getInteractive().eq(7).find(".has-question-number .header div").should("not.exist");
+
+
+      activityPage.clickPageButton(1);
+      cy.wait(2000);
+      cy.log("left column question numbers on page 2 shown");
+      activityPage.getInteractive().eq(0).find(".has-question-number .header div").should("exist");
+      activityPage.getInteractive().eq(0).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
+      });
+      activityPage.getInteractive().eq(1).find(".has-question-number .header div").should("exist");
+      activityPage.getInteractive().eq(1).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).then((hasHint) => {
+          activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
+        });
+      });
+     activityPage.getInteractive().eq(2).find(".has-question-number .header div").should("exist");
+      activityPage.getInteractive().eq(2).within(($interactive) => {
+      activityPage.hasHintIcon($interactive).then((hasHint) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
+        });
+      });
+      activityPage.getInteractive().eq(3).find(".has-question-number .header div").should("exist");
+      activityPage.getInteractive().eq(3).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
+    });
+    cy.log("right column question numbers on page 2 hidden");
+    activityPage.getInteractive().eq(4).find(".has-question-number .header div").should("not.exist");
+    activityPage.getInteractive().eq(4).within(($interactive) => {
+      activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
+    });
+    activityPage.getInteractive().eq(5).find(".has-question-number .header div").should("not.exist");
+    activityPage.getInteractive().eq(5).within(($interactive) => {
+      activityPage.hasHintIcon($interactive).then((hasHint) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
+      });
+    });
+    activityPage.getInteractive().eq(6).find(".has-question-number .header div").should("not.exist");
+    activityPage.getInteractive().eq(6).within(($interactive) => {
+    activityPage.hasHintIcon($interactive).then((hasHint) => {
+      activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
+      });
+    });
+    activityPage.getInteractive().eq(7).find(".has-question-number .header div").should("not.exist");
+    activityPage.getInteractive().eq(7).within(($interactive) => {
+      activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
+    });
+
+    activityPage.clickPageButton(2);
+      cy.wait(2000);
+      cy.log("verifies left column question numbers on page 3");
+      activityPage.getInteractive().eq(0).find(".has-question-number .header div").should("not.exist");
+      activityPage.getInteractive().eq(0).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
+      });
+      activityPage.getInteractive().eq(1).find(".has-question-number .header div").should("not.exist");
+      activityPage.getInteractive().eq(1).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).then((hasHint) => {
+          activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
+        });
+      });
+     activityPage.getInteractive().eq(2).find(".has-question-number .header div").should("not.exist");
+      activityPage.getInteractive().eq(2).within(($interactive) => {
+      activityPage.hasHintIcon($interactive).then((hasHint) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
+        });
+      });
+      // this isn't working, commenting out for now
+      // Check the first question with the text "This has no name or hint"
+      // cy.contains('legend', 'This has no name or hint')
+      // .should('exist') // Ensure the legend exists
+      // .parent() // Navigate to the parent element
+      // .should('not.have.class', 'has-question-number') // Ensure it doesn't have the question number class
+      // .and('not.have.descendants', '.header'); // Ensure it doesn't contain a header    
+    cy.log("verifies right column question numbers on page 3");
+    activityPage.getInteractive().eq(4).find(".has-question-number .header div").should("not.exist");
+    activityPage.getInteractive().eq(4).within(($interactive) => {
+      activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
+    });
+    activityPage.getInteractive().eq(5).find(".has-question-number .header div").should("not.exist");
+    activityPage.getInteractive().eq(5).within(($interactive) => {
+      activityPage.hasHintIcon($interactive).then((hasHint) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
+      });
+    });
+    activityPage.getInteractive().eq(6).find(".has-question-number .header div").should("not.exist");
+    activityPage.getInteractive().eq(6).within(($interactive) => {
+    activityPage.hasHintIcon($interactive).then((hasHint) => {
+      activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
+      });
+    });
+    // this isn't working, commenting out for now
+    // cy.contains('legend', 'This has no name or hint')
+    //   .eq(1) // Select the second occurrence
+    //   .should('exist')
+    //   .parent()
+    //   .should('not.have.class', 'has-question-number')
+    //   .and('not.have.descendants', '.header');
+    });
+  });
+});
+
+context("Activity hide question numbers unchecked", () => {
+  before(() => {
+    cy.visit("?activity=https%3A%2F%2Fauthoring.lara.staging.concord.org%2Fapi%2Fv1%2Factivities%2F312.json&preview");
+    activityPage.getActivityTitle().should("contain", "Automation Activity For Hide Question Numbers Unchecked");
+  });
+  describe("Hide question numbers unchecked in activity",() => {
+    it("verify question numbers are not hidden in activity",()=>{
+      activityPage.clickPageItem(0);
+      cy.wait(2000);
+      activityPage.getQuestionHeader().should("exist");
+      activityPage.getQuestionHeader().should("contain", "Question #");
+      activityPage.clickPageButton(1);
+      cy.wait(2000);
+      activityPage.getQuestionHeader().should("exist");
+      activityPage.getQuestionHeader().should("contain", "Question #");
+      activityPage.clickPageButton(2);
+      cy.wait(2000);
+      activityPage.getQuestionHeader().should("exist");
+      activityPage.getQuestionHeader().should("contain", "Question #");
+      activityPage.getHintIcon().should("exist");
+      activityPage.clickCompletionPageButton();
+      activityPage.getSummaryTableRow().should("contain", "Question 1");
+    });
+  });
+});

--- a/cypress/e2e/hide-question-numbers-interactives.ts
+++ b/cypress/e2e/hide-question-numbers-interactives.ts
@@ -12,6 +12,10 @@ context("Activity hide question numbers checked", () => {
       // Visit Page 1 of activity
       activityPage.clickPageItem(0);
       cy.wait(2000);
+      // Check that "Library Interactives" exists within the page 1 content
+      activityPage.getPageContent()
+      .should("exist")
+      .and("contain.text", "Library Interactives");
 
       // Page 1: Top Left - Question #1: Name and no hint
       cy.log("Page 1: Top Left - Question #1: Name and no hint");
@@ -61,7 +65,7 @@ context("Activity hide question numbers checked", () => {
       // Page 1: Row 3 Right - No name and hint
       cy.log("Page 1: Row 3 Right - No name and hint");
       activityPage.getInteractive().eq(6).find(".has-question-number .header div")
-        .should("not.exist")
+        .should("not.exist");
       activityPage.getInteractive().eq(6).within(($interactive) => {
         activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
@@ -78,7 +82,7 @@ context("Activity hide question numbers checked", () => {
       // Page 1: Bottom Right - No header, no hint
       cy.log("Page 1: Bottom Right: No header, no hint");
       activityPage.getInteractive().eq(7).find(".has-question-number .header div")
-        .should("not.exist") // Check for no header
+        .should("not.exist"); // Check for no header
       activityPage.getInteractive().eq(7).within(($interactive) => {
         activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
@@ -86,6 +90,10 @@ context("Activity hide question numbers checked", () => {
       // Visit Page 2 of activity
       activityPage.clickPageButton(1);
       cy.wait(2000);
+      activityPage.getPageContent()
+      .should("exist")
+      .and("contain.text", "Interactives That Save State");
+
       // Page 2: Top Left - Question #5: Name and no hint
       cy.log("Page 2: Top Left - Question #5: Name and no hint");
       activityPage.getInteractive().eq(0).find(".has-question-number .header div")
@@ -134,7 +142,7 @@ context("Activity hide question numbers checked", () => {
       // Page 2: Row 3 Right - No name and hint
       cy.log("Page 2: Row 3 Right - No name and hint");
       activityPage.getInteractive().eq(6).find(".has-question-number .header div")
-        .should("not.exist")
+        .should("not.exist");
       activityPage.getInteractive().eq(6).within(($interactive) => {
         activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
@@ -151,14 +159,18 @@ context("Activity hide question numbers checked", () => {
       // Page 2: Bottom Right - No header, no hint
       cy.log("Page 2: Bottom Right: No header, no hint");
       activityPage.getInteractive().eq(7).find(".has-question-number .header div")
-        .should("not.exist") // Check for no header
+        .should("not.exist"); // Check for no header
       activityPage.getInteractive().eq(7).within(($interactive) => {
         activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
-    // Visit Page 3 of activity
-    activityPage.clickPageButton(2);
+      // Visit Page 3 of activity
+      activityPage.clickPageButton(2);
       cy.wait(2000);
+      activityPage.getPageContent()
+        .should("exist")
+        .and("contain.text", "Interactives That DO NOT Save State");
+
       // Page 3: Top Left - Name and no hint
       cy.log("Page 3: Top Left - Name and no hint");
       activityPage.getInteractive().eq(0).find(".header div")
@@ -207,7 +219,7 @@ context("Activity hide question numbers checked", () => {
       // Page 3: Row 3 Right - No name and hint
       cy.log("Page 3: Row 3 Right - No name and hint");
       activityPage.getInteractive().eq(6).find(".has-question-number .header div")
-        .should("not.exist") // No name expected
+        .should("not.exist"); // No name expected
       activityPage.getInteractive().eq(6).within(($interactive) => {
         activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
@@ -215,7 +227,7 @@ context("Activity hide question numbers checked", () => {
       // Page 3: Bottom Row Left - No name no hint
       cy.log("Page 3: Bottom Row Left - No name, no hint");
       activityPage.getInteractive().eq(3).find(".has-question-number .header div")
-        .should("not.exist")
+        .should("not.exist"); // No name expected
       activityPage.getInteractive().eq(3).within(($interactive) => {
         activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
@@ -223,10 +235,10 @@ context("Activity hide question numbers checked", () => {
       // Page 2: Bottom Right - No header, no hint
       cy.log("Page 3: Bottom Right: No header, no hint");
       activityPage.getInteractive().eq(3).find(".has-question-number .header div")
-        .should("not.exist")
+        .should("not.exist"); // No name expected
       activityPage.getInteractive().eq(3).within(($interactive) => {
         activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
     });
   });
-  });
+});

--- a/cypress/e2e/hide-question-numbers-interactives.ts
+++ b/cypress/e2e/hide-question-numbers-interactives.ts
@@ -8,142 +8,225 @@ context("Activity hide question numbers checked", () => {
     activityPage.getActivityTitle().should("contain", "Test Hide Question Number Setting");
   });
   describe("Hide question numbers checked in activity",() => {
-    it.only("Verify the left column has the hide question number setting OFF and the right has it ON.",()=>{
+    it("Verifies combinations of hide question number option, name, and hint",()=>{
+      // Visit Page 1 of activity
       activityPage.clickPageItem(0);
       cy.wait(2000);
-      cy.log("left column question numbers on page 1 shown");
-      activityPage.getInteractive().eq(0).find(".has-question-number .header div").should("exist");
-      activityPage.getInteractive().eq(1).find(".has-question-number .header div").should("exist");
-      activityPage.getInteractive().eq(2).find(".has-question-number .header div").should("exist");
-      activityPage.getInteractive().eq(3).find(".has-question-number .header div").should("exist");
-      cy.log("right column question numbers on page 1 hidden");
-      activityPage.getInteractive().eq(4).find(".has-question-number .header div").should("not.exist");
-      activityPage.getInteractive().eq(5).find(".has-question-number .header div").should("not.exist");
-      activityPage.getInteractive().eq(6).find(".has-question-number .header div").should("not.exist");
-      activityPage.getInteractive().eq(7).find(".has-question-number .header div").should("not.exist");
 
+      // Page 1: Top Left - Question #1: Name and no hint
+      cy.log("Page 1: Top Left - Question #1: Name and no hint");
+      activityPage.getInteractive().eq(0).find(".has-question-number .header div")
+        .should("exist")
+        .and("have.text", "Question #1: Name and no hint"); // Check for specific text "Question #1: Name and no hint"
+      activityPage.getInteractive().eq(0).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
 
+      // Page 1: Top Right - Name and no hint
+      cy.log("Page 1: Top Right - Name and no hint");
+      activityPage.getInteractive().eq(4).find(".header div")
+        .should("exist")
+        .and("have.text", "Name and no hint"); // Check for specific text "Name and no hint"
+      activityPage.getInteractive().eq(4).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
+
+      // Page 1: Row 2 Left - Question #2: Name and hint
+      cy.log("Page 1: Row 2 Left - Question #2: Name and hint");
+      activityPage.getInteractive().eq(1).find(".has-question-number .header div")
+        .should("exist")
+        .and("contain.text", "Question #2: Name and hint"); // Check for "Question #2" and name
+      activityPage.getInteractive().eq(1).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 1: Row 2 Right - Name and hint
+      cy.log("Page 1: Row 2 Right - Name and hint");
+      activityPage.getInteractive().eq(5).find(".header div")
+        .should("exist")
+        .and("contain.text", "Name and hint"); // Check for specific text "Name and hint"
+      activityPage.getInteractive().eq(5).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 1: Row 3 Left - Question #3: No name and hint
+      cy.log("Page 1: Row 3 Left - Question #3: No name and hint");
+      activityPage.getInteractive().eq(2).find(".has-question-number .header div")
+        .should("exist")
+        .and("contain.text", "Question #3"); // Check for Header with question number
+      activityPage.getInteractive().eq(2).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 1: Row 3 Right - No name and hint
+      cy.log("Page 1: Row 3 Right - No name and hint");
+      activityPage.getInteractive().eq(6).find(".has-question-number .header div")
+        .should("not.exist")
+      activityPage.getInteractive().eq(6).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 1: Bottom Row Left - Question #4: No name, no hint
+      cy.log("Page 1: Bottom Row Left - Question #4: No name, no hint");
+      activityPage.getInteractive().eq(3).find(".has-question-number .header div")
+        .should("exist")
+        .and("contain.text", "Question #4"); // Check for question # without name
+      activityPage.getInteractive().eq(3).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
+
+      // Page 1: Bottom Right - No header, no hint
+      cy.log("Page 1: Bottom Right: No header, no hint");
+      activityPage.getInteractive().eq(7).find(".has-question-number .header div")
+        .should("not.exist") // Check for no header
+      activityPage.getInteractive().eq(7).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
+
+      // Visit Page 2 of activity
       activityPage.clickPageButton(1);
       cy.wait(2000);
-      cy.log("left column question numbers on page 2 shown");
-      activityPage.getInteractive().eq(0).find(".has-question-number .header div").should("exist");
+      // Page 2: Top Left - Question #5: Name and no hint
+      cy.log("Page 2: Top Left - Question #5: Name and no hint");
+      activityPage.getInteractive().eq(0).find(".has-question-number .header div")
+        .should("exist")
+        .and("have.text", "Question #5: Name and no hint"); // Check for specific text "Question #5: Name and no hint"
       activityPage.getInteractive().eq(0).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
       });
-      activityPage.getInteractive().eq(1).find(".has-question-number .header div").should("exist");
-      activityPage.getInteractive().eq(1).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).then((hasHint) => {
-          activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
-        });
-      });
-     activityPage.getInteractive().eq(2).find(".has-question-number .header div").should("exist");
-      activityPage.getInteractive().eq(2).within(($interactive) => {
-      activityPage.hasHintIcon($interactive).then((hasHint) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
-        });
-      });
-      activityPage.getInteractive().eq(3).find(".has-question-number .header div").should("exist");
-      activityPage.getInteractive().eq(3).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
-    });
-    cy.log("right column question numbers on page 2 hidden");
-    activityPage.getInteractive().eq(4).find(".has-question-number .header div").should("not.exist");
-    activityPage.getInteractive().eq(4).within(($interactive) => {
-      activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
-    });
-    activityPage.getInteractive().eq(5).find(".has-question-number .header div").should("not.exist");
-    activityPage.getInteractive().eq(5).within(($interactive) => {
-      activityPage.hasHintIcon($interactive).then((hasHint) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
-      });
-    });
-    activityPage.getInteractive().eq(6).find(".has-question-number .header div").should("not.exist");
-    activityPage.getInteractive().eq(6).within(($interactive) => {
-    activityPage.hasHintIcon($interactive).then((hasHint) => {
-      activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
-      });
-    });
-    activityPage.getInteractive().eq(7).find(".has-question-number .header div").should("not.exist");
-    activityPage.getInteractive().eq(7).within(($interactive) => {
-      activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
-    });
 
+      // Page 2: Top Right - Name and no hint
+      cy.log("Page 2: Top Right - Name and no hint");
+      activityPage.getInteractive().eq(4).find(".header div")
+        .should("exist")
+        .and("have.text", "Name and no hint"); // Check for specific text "Name and no hint"
+      activityPage.getInteractive().eq(4).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
+
+      // Page 2: Row 2 Left - Question #6: Name and hint
+      cy.log("Page 2: Row 2 Left - Question #6: Name and hint");
+      activityPage.getInteractive().eq(1).find(".has-question-number .header div")
+        .should("exist")
+        .and("contain.text", "Question #6: Name and hint"); // Check for "Question #2" and name
+      activityPage.getInteractive().eq(1).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 2: Row 2 Right - Name and hint
+      cy.log("Page 2: Row 2 Right - Name and hint");
+      activityPage.getInteractive().eq(5).find(".header div")
+        .should("exist")
+        .and("contain.text", "Name and hint"); // Check for specific text "Name and hint"
+      activityPage.getInteractive().eq(5).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 2: Row 3 Left - Question #7: No name and hint
+      cy.log("Page 2: Row 3 Left - Question #7: No name and hint");
+      activityPage.getInteractive().eq(2).find(".has-question-number .header div")
+        .should("exist")
+        .and("contain.text", "Question #7"); // Check for Header with question number
+      activityPage.getInteractive().eq(2).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 2: Row 3 Right - No name and hint
+      cy.log("Page 2: Row 3 Right - No name and hint");
+      activityPage.getInteractive().eq(6).find(".has-question-number .header div")
+        .should("not.exist")
+      activityPage.getInteractive().eq(6).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 2: Bottom Row Left - Question #8: No name, no hint
+      cy.log("Page 2: Bottom Row Left - Question #8: No name, no hint");
+      activityPage.getInteractive().eq(3).find(".has-question-number .header div")
+        .should("exist")
+        .and("contain.text", "Question #8"); // Check for question # without name
+      activityPage.getInteractive().eq(3).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
+
+      // Page 2: Bottom Right - No header, no hint
+      cy.log("Page 2: Bottom Right: No header, no hint");
+      activityPage.getInteractive().eq(7).find(".has-question-number .header div")
+        .should("not.exist") // Check for no header
+      activityPage.getInteractive().eq(7).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
+
+    // Visit Page 3 of activity
     activityPage.clickPageButton(2);
       cy.wait(2000);
-      cy.log("verifies left column question numbers on page 3");
-      activityPage.getInteractive().eq(0).find(".has-question-number .header div").should("not.exist");
+      // Page 3: Top Left - Name and no hint
+      cy.log("Page 3: Top Left - Name and no hint");
+      activityPage.getInteractive().eq(0).find(".header div")
+      .should("exist")
+      .and("have.text", "Name and no hint"); // Check for specific text "Name and no hint"
       activityPage.getInteractive().eq(0).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
       });
-      activityPage.getInteractive().eq(1).find(".has-question-number .header div").should("not.exist");
-      activityPage.getInteractive().eq(1).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).then((hasHint) => {
-          activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
-        });
-      });
-     activityPage.getInteractive().eq(2).find(".has-question-number .header div").should("not.exist");
-      activityPage.getInteractive().eq(2).within(($interactive) => {
-      activityPage.hasHintIcon($interactive).then((hasHint) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
-        });
-      });
-      // this isn't working, commenting out for now
-      // Check the first question with the text "This has no name or hint"
-      // cy.contains('legend', 'This has no name or hint')
-      // .should('exist') // Ensure the legend exists
-      // .parent() // Navigate to the parent element
-      // .should('not.have.class', 'has-question-number') // Ensure it doesn't have the question number class
-      // .and('not.have.descendants', '.header'); // Ensure it doesn't contain a header    
-    cy.log("verifies right column question numbers on page 3");
-    activityPage.getInteractive().eq(4).find(".has-question-number .header div").should("not.exist");
-    activityPage.getInteractive().eq(4).within(($interactive) => {
-      activityPage.hasHintIcon($interactive).should('not.exist'); // Verify no hint icon exists
-    });
-    activityPage.getInteractive().eq(5).find(".has-question-number .header div").should("not.exist");
-    activityPage.getInteractive().eq(5).within(($interactive) => {
-      activityPage.hasHintIcon($interactive).then((hasHint) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
-      });
-    });
-    activityPage.getInteractive().eq(6).find(".has-question-number .header div").should("not.exist");
-    activityPage.getInteractive().eq(6).within(($interactive) => {
-    activityPage.hasHintIcon($interactive).then((hasHint) => {
-      activityPage.hasHintIcon($interactive).should('exist'); // Verify the hint icon exists
-      });
-    });
-    // this isn't working, commenting out for now
-    // cy.contains('legend', 'This has no name or hint')
-    //   .eq(1) // Select the second occurrence
-    //   .should('exist')
-    //   .parent()
-    //   .should('not.have.class', 'has-question-number')
-    //   .and('not.have.descendants', '.header');
-    });
-  });
-});
 
-context("Activity hide question numbers unchecked", () => {
-  before(() => {
-    cy.visit("?activity=https%3A%2F%2Fauthoring.lara.staging.concord.org%2Fapi%2Fv1%2Factivities%2F312.json&preview");
-    activityPage.getActivityTitle().should("contain", "Automation Activity For Hide Question Numbers Unchecked");
-  });
-  describe("Hide question numbers unchecked in activity",() => {
-    it("verify question numbers are not hidden in activity",()=>{
-      activityPage.clickPageItem(0);
-      cy.wait(2000);
-      activityPage.getQuestionHeader().should("exist");
-      activityPage.getQuestionHeader().should("contain", "Question #");
-      activityPage.clickPageButton(1);
-      cy.wait(2000);
-      activityPage.getQuestionHeader().should("exist");
-      activityPage.getQuestionHeader().should("contain", "Question #");
-      activityPage.clickPageButton(2);
-      cy.wait(2000);
-      activityPage.getQuestionHeader().should("exist");
-      activityPage.getQuestionHeader().should("contain", "Question #");
-      activityPage.getHintIcon().should("exist");
-      activityPage.clickCompletionPageButton();
-      activityPage.getSummaryTableRow().should("contain", "Question 1");
+      // Page 3: Top Right - Name and no hint
+      cy.log("Page 3: Top Right - Name and no hint");
+      activityPage.getInteractive().eq(4).find(".header div")
+        .should("exist")
+        .and("have.text", "Name and no hint"); // Check for specific text "Name and no hint"
+      activityPage.getInteractive().eq(4).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
+
+      // Page 3: Row 2 Left - Name and hint
+      cy.log("Page 3: Row 2 Left - Name and hint");
+      activityPage.getInteractive().eq(1).find(".header div")
+      .should("exist")
+      .and("have.text", "Name and hint"); // Check for specific text "Name and hint"
+      activityPage.getInteractive().eq(1).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 3: Row 2 Right - Name and hint
+      cy.log("Page 3: Row 2 Right - Name and hint");
+      activityPage.getInteractive().eq(5).find(".header div")
+        .should("exist")
+        .and("contain.text", "Name and hint"); // Check for specific text "Name and hint"
+      activityPage.getInteractive().eq(5).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 3: Row 3 Left - No name and hint
+      cy.log("Page 2: Row 3 Left - No name and hint");
+      activityPage.getInteractive().eq(2).find(".header div")
+      .should("exist")
+      .and("not.have.text"); // Check for no text
+      activityPage.getInteractive().eq(2).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 3: Row 3 Right - No name and hint
+      cy.log("Page 3: Row 3 Right - No name and hint");
+      activityPage.getInteractive().eq(6).find(".has-question-number .header div")
+        .should("not.exist") // No name expected
+      activityPage.getInteractive().eq(6).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+      });
+
+      // Page 3: Bottom Row Left - No name no hint
+      cy.log("Page 3: Bottom Row Left - Question #8: No name, no hint");
+      activityPage.getInteractive().eq(3).find(".has-question-number .header div")
+        .should("not.exist")
+      activityPage.getInteractive().eq(3).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
+
+      // Page 2: Bottom Right - No header, no hint
+      cy.log("Page 3: Bottom Right: No header, no hint");
+      activityPage.getInteractive().eq(3).find(".has-question-number .header div")
+        .should("not.exist")
+      activityPage.getInteractive().eq(3).within(($interactive) => {
+        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+      });
     });
   });
-});
+  });

--- a/cypress/e2e/hide-question-numbers-interactives.ts
+++ b/cypress/e2e/hide-question-numbers-interactives.ts
@@ -19,7 +19,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("have.text", "Question #1: Name and no hint"); // Check for specific text "Question #1: Name and no hint"
       activityPage.getInteractive().eq(0).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 1: Top Right - Name and no hint
@@ -28,7 +28,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("have.text", "Name and no hint"); // Check for specific text "Name and no hint"
       activityPage.getInteractive().eq(4).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 1: Row 2 Left - Question #2: Name and hint
@@ -37,7 +37,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Question #2: Name and hint"); // Check for "Question #2" and name
       activityPage.getInteractive().eq(1).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 1: Row 2 Right - Name and hint
@@ -46,7 +46,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Name and hint"); // Check for specific text "Name and hint"
       activityPage.getInteractive().eq(5).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 1: Row 3 Left - Question #3: No name and hint
@@ -55,7 +55,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Question #3"); // Check for Header with question number
       activityPage.getInteractive().eq(2).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 1: Row 3 Right - No name and hint
@@ -63,7 +63,7 @@ context("Activity hide question numbers checked", () => {
       activityPage.getInteractive().eq(6).find(".has-question-number .header div")
         .should("not.exist")
       activityPage.getInteractive().eq(6).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 1: Bottom Row Left - Question #4: No name, no hint
@@ -72,7 +72,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Question #4"); // Check for question # without name
       activityPage.getInteractive().eq(3).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 1: Bottom Right - No header, no hint
@@ -80,7 +80,7 @@ context("Activity hide question numbers checked", () => {
       activityPage.getInteractive().eq(7).find(".has-question-number .header div")
         .should("not.exist") // Check for no header
       activityPage.getInteractive().eq(7).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Visit Page 2 of activity
@@ -92,7 +92,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("have.text", "Question #5: Name and no hint"); // Check for specific text "Question #5: Name and no hint"
       activityPage.getInteractive().eq(0).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 2: Top Right - Name and no hint
@@ -101,7 +101,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("have.text", "Name and no hint"); // Check for specific text "Name and no hint"
       activityPage.getInteractive().eq(4).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 2: Row 2 Left - Question #6: Name and hint
@@ -110,7 +110,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Question #6: Name and hint"); // Check for "Question #2" and name
       activityPage.getInteractive().eq(1).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 2: Row 2 Right - Name and hint
@@ -119,7 +119,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Name and hint"); // Check for specific text "Name and hint"
       activityPage.getInteractive().eq(5).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 2: Row 3 Left - Question #7: No name and hint
@@ -128,7 +128,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Question #7"); // Check for Header with question number
       activityPage.getInteractive().eq(2).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 2: Row 3 Right - No name and hint
@@ -136,7 +136,7 @@ context("Activity hide question numbers checked", () => {
       activityPage.getInteractive().eq(6).find(".has-question-number .header div")
         .should("not.exist")
       activityPage.getInteractive().eq(6).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 2: Bottom Row Left - Question #8: No name, no hint
@@ -145,7 +145,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Question #8"); // Check for question # without name
       activityPage.getInteractive().eq(3).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 2: Bottom Right - No header, no hint
@@ -153,7 +153,7 @@ context("Activity hide question numbers checked", () => {
       activityPage.getInteractive().eq(7).find(".has-question-number .header div")
         .should("not.exist") // Check for no header
       activityPage.getInteractive().eq(7).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
     // Visit Page 3 of activity
@@ -165,7 +165,7 @@ context("Activity hide question numbers checked", () => {
       .should("exist")
       .and("have.text", "Name and no hint"); // Check for specific text "Name and no hint"
       activityPage.getInteractive().eq(0).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 3: Top Right - Name and no hint
@@ -174,7 +174,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("have.text", "Name and no hint"); // Check for specific text "Name and no hint"
       activityPage.getInteractive().eq(4).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 3: Row 2 Left - Name and hint
@@ -183,7 +183,7 @@ context("Activity hide question numbers checked", () => {
       .should("exist")
       .and("have.text", "Name and hint"); // Check for specific text "Name and hint"
       activityPage.getInteractive().eq(1).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 3: Row 2 Right - Name and hint
@@ -192,7 +192,7 @@ context("Activity hide question numbers checked", () => {
         .should("exist")
         .and("contain.text", "Name and hint"); // Check for specific text "Name and hint"
       activityPage.getInteractive().eq(5).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 3: Row 3 Left - No name and hint
@@ -201,7 +201,7 @@ context("Activity hide question numbers checked", () => {
       .should("exist")
       .and("not.have.text"); // Check for no text
       activityPage.getInteractive().eq(2).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 3: Row 3 Right - No name and hint
@@ -209,7 +209,7 @@ context("Activity hide question numbers checked", () => {
       activityPage.getInteractive().eq(6).find(".has-question-number .header div")
         .should("not.exist") // No name expected
       activityPage.getInteractive().eq(6).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('exist'); // Hint icon expected
+        activityPage.hasHintIcon($interactive).should("exist"); // Hint icon expected
       });
 
       // Page 3: Bottom Row Left - No name no hint
@@ -217,7 +217,7 @@ context("Activity hide question numbers checked", () => {
       activityPage.getInteractive().eq(3).find(".has-question-number .header div")
         .should("not.exist")
       activityPage.getInteractive().eq(3).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
 
       // Page 2: Bottom Right - No header, no hint
@@ -225,7 +225,7 @@ context("Activity hide question numbers checked", () => {
       activityPage.getInteractive().eq(3).find(".has-question-number .header div")
         .should("not.exist")
       activityPage.getInteractive().eq(3).within(($interactive) => {
-        activityPage.hasHintIcon($interactive).should('not.exist'); // No hint icon expected
+        activityPage.hasHintIcon($interactive).should("not.exist"); // No hint icon expected
       });
     });
   });

--- a/cypress/e2e/hide-question-numbers.test.ts
+++ b/cypress/e2e/hide-question-numbers.test.ts
@@ -1,6 +1,4 @@
 import ActivityPage from "../support/elements/activity-page";
-import { getInIframe, getInIframeWithIndex } from "../support/elements/iframe";
-
 
 const activityPage = new ActivityPage;
 
@@ -13,7 +11,7 @@ context("Activity hide question numbers checked", () => {
     it("verify question numbers are hidden in activity",()=>{
       activityPage.clickPageItem(0);
       cy.wait(2000);
-      activityPage.getInteractive().find('.has-question-number .header div').should("not.exist");
+      activityPage.getInteractive().find(".has-question-number .header div").should("not.exist");
       activityPage.clickPageButton(1);
       cy.wait(2000);
       activityPage.getQuestionHeader().should("exist");
@@ -26,15 +24,15 @@ context("Activity hide question numbers checked", () => {
       activityPage.clickPageButton(3);
       cy.wait(2000);
       activityPage.getRuntimeContainer()
-        .should('exist') // Check the container exists
-        .and('not.have.class', 'has-question-number'); // Verify it doesn't have the question number class 
+        .should("exist") // Check the container exists
+        .and("not.have.class", "has-question-number"); // Verify it doesn't have the question number class 
       activityPage.clickPageButton(4);
       activityPage.getRuntimeContainer()
-        .should('exist')
-        .and('have.class', 'has-question-number'); // Check it has the question number class
+        .should("exist")
+        .and("have.class", "has-question-number"); // Check it has the question number class
       activityPage.getQuestionHeader()
-        .should('contain', 'Drawing Tool Name') // Check for the presence of "Drawing Tool Name"
-        .and('not.contain', 'Question #'); // Ensure it does not contain "Question #"
+        .should("contain", "Drawing Tool Name") // Check for the presence of "Drawing Tool Name"
+        .and("not.contain", "Question #"); // Ensure it does not contain "Question #"
       // check completion page
       activityPage.clickCompletionPageButton();
       activityPage.getSummaryTableRow().should("contain", "Question 1");
@@ -80,7 +78,7 @@ context("Sequence hide question numbers checked", () => {
       activityPage.getActivityTitle().should("contain", "Automation Activity For Hide Question Numbers Checked");
       activityPage.clickPageItem(0);
       cy.wait(2000);
-      activityPage.getInteractive().find('.has-question-number .header div').should("not.exist");
+      activityPage.getInteractive().find(".has-question-number .header div").should("not.exist");
       activityPage.clickPageButton(1);
       cy.wait(2000);
       activityPage.getQuestionHeader().should("exist");
@@ -91,7 +89,7 @@ context("Sequence hide question numbers checked", () => {
       activityPage.getActivityTitle().should("contain", "Automation Activity For Hide Question Numbers Unchecked");
       activityPage.clickPageItem(0);
       cy.wait(2000);
-      activityPage.getInteractive().find('.has-question-number .header div').should("not.exist");
+      activityPage.getInteractive().find(".has-question-number .header div").should("not.exist");
       activityPage.clickPageButton(1);
       cy.wait(2000);
       activityPage.getQuestionHeader().should("exist");

--- a/cypress/e2e/hide-question-numbers.test.ts
+++ b/cypress/e2e/hide-question-numbers.test.ts
@@ -1,4 +1,6 @@
 import ActivityPage from "../support/elements/activity-page";
+import { getInIframe, getInIframeWithIndex } from "../support/elements/iframe";
+
 
 const activityPage = new ActivityPage;
 
@@ -21,6 +23,19 @@ context("Activity hide question numbers checked", () => {
       activityPage.getQuestionHeader().should("exist");
       activityPage.getQuestionHeader().should("not.contain", "Question #");
       activityPage.getHintIcon().should("exist");
+      activityPage.clickPageButton(3);
+      cy.wait(2000);
+      activityPage.getRuntimeContainer()
+        .should('exist') // Check the container exists
+        .and('not.have.class', 'has-question-number'); // Verify it doesn't have the question number class 
+      activityPage.clickPageButton(4);
+      activityPage.getRuntimeContainer()
+        .should('exist')
+        .and('have.class', 'has-question-number'); // Check it has the question number class
+      activityPage.getQuestionHeader()
+        .should('contain', 'Drawing Tool Name') // Check for the presence of "Drawing Tool Name"
+        .and('not.contain', 'Question #'); // Ensure it does not contain "Question #"
+      // check completion page
       activityPage.clickCompletionPageButton();
       activityPage.getSummaryTableRow().should("contain", "Question 1");
     });

--- a/cypress/e2e/hide-question-numbers.test.ts
+++ b/cypress/e2e/hide-question-numbers.test.ts
@@ -4,7 +4,7 @@ const activityPage = new ActivityPage;
 
 context("Activity hide question numbers checked", () => {
   before(() => {
-    cy.visit("?activity=https%3A%2F%2Fauthoring.lara.staging.concord.org%2Fapi%2Fv1%2Factivities%2F311.json&preview");
+    cy.visit("?activity=https%3A%2F%2Fauthoring.lara.staging.concord.org%2Fapi%2Fv1%2Factivities%2F311.json");
     activityPage.getActivityTitle().should("contain", "Automation Activity For Hide Question Numbers Checked");
   });
   describe("Hide question numbers checked in activity",() => {

--- a/cypress/support/elements/activity-page.js
+++ b/cypress/support/elements/activity-page.js
@@ -143,8 +143,11 @@ class ActivityPage {
   getHintText() {
     return this.getInteractive().find('.hint.question-txt');
   }
+  hasHintIcon(interactive) {
+    return cy.wrap(interactive).find('[data-cy=open-hint]', { timeout: 0 });
+  }
   verifyHiddenQuestionNumberInteractive() {
-    cy.get('[data-cy="managed-interactive"]').should('not.exist');
+    return cy.get('[data-cy="managed-interactive"]').should('not.exist');
   }
 
   //Alert Dialog

--- a/cypress/support/elements/activity-page.js
+++ b/cypress/support/elements/activity-page.js
@@ -131,6 +131,9 @@ class ActivityPage {
   verifyQuestionHeader(header) {
     this.getQuestionHeader().should("contain", header);
   }
+  getRuntimeContainer() {
+    return cy.get('.runtime-container');
+  }
   getHintIcon() {
     return this.getInteractive().find('[data-cy=open-hint]');
   }
@@ -139,6 +142,9 @@ class ActivityPage {
   }
   getHintText() {
     return this.getInteractive().find('.hint.question-txt');
+  }
+  verifyHiddenQuestionNumberInteractive() {
+    cy.get('[data-cy="managed-interactive"]').should('not.exist');
   }
 
   //Alert Dialog


### PR DESCRIPTION
[PT-188437590](https://www.pivotaltracker.com/story/show/188437590)

This PR automates the following behavior:

If an iFrame interactive does not have a Name or Hint, the system should:
1. Hide the question number when there is a name in the iFrame interactive.
2. If a library interactive does not have a Name or Hint, do not display the blue header but still display the gray border around the iFrame.

### Next Steps

Would it make sense to extend these checks to the Class Dashboard? I think I could explore getting the Hide Question Numbers feature to work there. My approach would be:

1. Adding the Hide Question Numbers test activity to the test sequence for the `portal-report` repository. This would be covered in [PT-#188523305](https://www.pivotaltracker.com/n/projects/2441249/stories/188523305)
2. Writing a Cypress test to ensure the question numbers are hidden in the Class Dashboard: This is outlined in [PT-#188523305](https://www.pivotaltracker.com/n/projects/2441249/stories/188523305)
3. I also thought we could use a `data-cy` statement around the run container div in the file `managed-interactive.tsx`, but it looks like I'd probably want to merge that code into `main` and then pull locally and make sure the tests work. So if we want that, let me know and I can do it. The code would look something like this:
```
  <div ref={divTarget} className="managed-interactive" data-cy="managed-interactive">
    <div 
      className={className} 
      style={{ width: containerWidth }}
      data-cy="runtime-container" // Add the data-cy attribute here
    >
```

Then there would be a helper function that looks like this:

```
verifyRuntimeContainerDoesNotExist() {
  cy.get('[data-cy="runtime-container"]').should('not.exist');
}
```