### PR TITLE
fix: gather teacher feedback

### DIFF
--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -313,6 +313,7 @@ const getQuestionLevelFeedbackDocsQuery = (answerId: string) => {
 
   if (portalData.type === "authenticated") {
     query = query
+      .where("answerId", "==", answerId)
       .where("platformId", "==", portalData.platformId)
       .where("resourceLinkId", "==", portalData.resourceLinkId)
       .where("contextId", "==", portalData.contextId)


### PR DESCRIPTION
The `answerId` is actually required in `getQuestionLevelFeedbackDocsQuery`. Otherwise, feedback for any question in an activity will be applied to all questions in that activity.