### PR TITLE
Feat: Summary page displays activity-level feedback

### DIFF
--- a/src/components/activity-completion/completion-page-content.scss
+++ b/src/components/activity-completion/completion-page-content.scss
@@ -10,6 +10,13 @@
   padding: 20px;
   width: 100%;
 
+  .banners {
+    width: 100%;
+    .intro-feedback-banner {
+      margin-bottom: 15px;
+    }
+  }
+
   .textButton {
     background: transparent;
     border: none;
@@ -41,8 +48,7 @@
     font-style: italic;
     font-weight: bold;
     line-height: 1;
-    margin: 10px 0 24px;
-    padding: 0;
+    padding: 10px;
 
     &.incomplete {
       background-color: $cc-orange-light2;
@@ -50,14 +56,11 @@
 
     .check {
       fill: $cc-teal-dark1;
-      margin-left: 5px;
+      margin-right: 5px;
 
       &.incomplete {
         fill: $cc-orange-dark1;
       }
-    }
-    .progress-text {
-      padding: 8px 5px 10px;
     }
   }
 
@@ -86,11 +89,12 @@
         pointer-events: none;
       }
     }
+
     .summary-of-work {
       display: flex;
       justify-content: space-between;
       width: 100%;
-      margin: 0 0 30px;
+      margin: 0 0 20px;
       gap: 10px;
 
       h1 {
@@ -102,6 +106,13 @@
         }
       }
     }
+
+    .activity-level-feedback-banner {
+      width: 100%;
+      margin-top: 0;
+      margin-bottom: 20px;
+    }
+
     .exit-button {
       flex-basis: 100%;
       text-align: center;

--- a/src/components/activity-introduction/introduction-page-content.tsx
+++ b/src/components/activity-introduction/introduction-page-content.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { ActivitySummary } from "../activity-introduction/activity-summary";
 import { ActivityPageLinks } from "../activity-introduction/activity-page-links";
-import { Activity, TeacherFeedback } from "../../types";
+import { Activity, ActivityFeedback } from "../../types";
 import { watchActivityLevelFeedback } from "../../firebase-db";
 import { IntroPageActivityLevelFeedback } from "../teacher-feedback/intro-page-activity-level-feedback";
 
@@ -9,19 +9,26 @@ import "./introduction-page-content.scss";
 
 interface IProps {
   activity: Activity;
+  isSequence?: boolean;
   onPageChange: (page: number) => void;
 }
 
 export const IntroductionPageContent: React.FC<IProps> = (props) => {
-  const { activity, onPageChange } = props;
+  const { activity, isSequence, onPageChange } = props;
   const hasCompletionPage = activity.pages.find(p => p.is_completion);
-  const [feedback, setFeedback] = useState<TeacherFeedback | null>(null);
+  const [feedback, setFeedback] = useState<ActivityFeedback | null>(null);
 
   useEffect(() => {
-    const unsubscribe = watchActivityLevelFeedback(fb => setFeedback(fb));
+    const unsubscribe = watchActivityLevelFeedback(fbs => {
+      if (fbs?.length) {
+        const activityIdString = isSequence ? `activity_${activity.id}` : `activity-activity_${activity.id}`;
+        const fb = fbs.filter(f => f.activityId === activityIdString);
+        fb.length && setFeedback(fb[0]);
+      }
+    });
 
     return () => unsubscribe();
-  }, []);
+  }, [activity.id, isSequence]);
 
   return (
     <div className="intro-content" data-cy="intro-page-content">

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -1,7 +1,7 @@
 // cf. https://github.com/concord-consortium/question-interactives/blob/master/src/scaffolded-question/components/iframe-runtime.tsx
 import { autorun } from "mobx";
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
-import { IExportableAnswerMetadata, IframePhone, ILegacyLinkedInteractiveState, TeacherFeedback } from "../../../types";
+import { IExportableAnswerMetadata, IframePhone, ILegacyLinkedInteractiveState, QuestionFeedback } from "../../../types";
 import iframePhone from "iframe-phone";
 import {
   ClientMessage, ICustomMessage, IGetFirebaseJwtRequest, IGetInteractiveSnapshotRequest,
@@ -83,7 +83,7 @@ interface IProps {
   setAspectRatio: (aspectRatio: number) => void;
   setHeightFromInteractive: (heightFromInteractive: number) => void;
   hasHeader?: boolean;
-  feedback?: TeacherFeedback | null;
+  feedback?: QuestionFeedback | null;
 }
 
 export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
@@ -474,7 +474,7 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
           <ReloadIcon />
         </button>
       }
-      {feedback && 
+      {feedback &&
         <div className="teacher-feedback">
           <DynamicText>
             <div className="teacher-feedback">

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -620,10 +620,11 @@ export class App extends React.PureComponent<IProps, IState> {
     );
   }
 
-  private renderIntroductionContent = (activity: Activity) => {
+  private renderIntroductionContent = (activity: Activity, isSequence?: boolean) => {
     return (
       <IntroductionPageContent
         activity={activity}
+        isSequence={isSequence}
         onPageChange={this.handleChangePage}
       />
     );

--- a/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
+++ b/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
@@ -4,6 +4,7 @@ import { ActivityLevelFeedbackBanner } from "./activity-level-feedback-banner";
 
 describe("Activity Level Feedback component", () => {
   const mockFeedback = {
+    activityId: "activity_1",
     content: "Great job!",
     timestamp: "2021-08-10T14:00:00Z"
   };

--- a/src/components/teacher-feedback/activity-level-feedback-banner.tsx
+++ b/src/components/teacher-feedback/activity-level-feedback-banner.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { TeacherFeedback } from "../../types";
+import { ActivityFeedback } from "../../types";
 import TeacherFeedbackIcon from "../../assets/svg-icons/teacher-feedback-icon.svg";
 
 import "./activity-level-feedback-banner.scss";
 
 interface IProps {
-  teacherFeedback: TeacherFeedback;
+  teacherFeedback: ActivityFeedback;
 }
 
 export const ActivityLevelFeedbackBanner = ({ teacherFeedback }: IProps) => {

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.test.tsx
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.test.tsx
@@ -4,6 +4,7 @@ import { IntroPageActivityLevelFeedback } from "./intro-page-activity-level-feed
 
 describe("Activity Level Feedback component", () => {
   const mockFeedback = {
+    activityId: "activity_1",
     content: "Great job!",
     timestamp: "2021-08-10T14:00:00Z"
   };

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.tsx
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { DynamicText } from "@concord-consortium/dynamic-text";
-import { TeacherFeedback } from "../../types";
+import { ActivityFeedback } from "../../types";
 import { ActivityLevelFeedbackBanner } from "./activity-level-feedback-banner";
 
 import "./intro-page-activity-level-feedback.scss";
 
 interface IProps {
-  teacherFeedback: TeacherFeedback;
+  teacherFeedback: ActivityFeedback;
 }
 
 export const IntroPageActivityLevelFeedback = ({ teacherFeedback }: IProps) => {

--- a/src/firebase-db.test.ts
+++ b/src/firebase-db.test.ts
@@ -419,7 +419,7 @@ describe("AP run functions", () => {
     it("throws an error if the portal data isn't set", async () => {
       setPortalData(null);
       await expect(async () => {
-        watchQuestionLevelFeedback("test", feedbackCallback);
+        watchQuestionLevelFeedback(feedbackCallback, "test");
       }).rejects.toThrowError("Must set portal data first");
     });
 
@@ -429,7 +429,7 @@ describe("AP run functions", () => {
       });
 
       it("returns no feedback for anonymous users", async () => {
-        expect(watchQuestionLevelFeedback("test", feedbackCallback)).toBeInstanceOf(Function);
+        expect(watchQuestionLevelFeedback(feedbackCallback, "test")).toBeInstanceOf(Function);
         expect(feedbackCallback).toBeCalledTimes(0);
       });
     });

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -318,7 +318,7 @@ const getQuestionLevelFeedbackDocsQuery = (answerId?: string) => {
       .where("contextId", "==", portalData.contextId)
       .where("platformStudentId", "==", portalData.platformUserId.toString());
     if (answerId) {
-      query = query.where("answer_id", "==", answerId);
+      query = query.where("answerId", "==", answerId);
     }
   }
 

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -15,7 +15,7 @@ import { IAnonymousPortalData, IPortalData, isPortalData } from "./portal-types"
 import { getLegacyLinkedRefMap, LegacyLinkedRefMap, refIdToAnswersQuestionId } from "./utilities/embeddable-utils";
 import { IExportableAnswerMetadata, LTIRuntimeAnswerMetadata, AnonymousRuntimeAnswerMetadata,
   IAuthenticatedLearnerPluginState, IAnonymousLearnerPluginState, ILegacyLinkedInteractiveState, IApRun, IBaseApRun,
-  TeacherFeedback } from "./types";
+  QuestionFeedback, ActivityFeedback} from "./types";
 import { queryValueBoolean } from "./utilities/url-query";
 import { RequestTracker } from "./utilities/request-tracker";
 import { ILaraData } from "./components/lara-data-context";
@@ -302,7 +302,7 @@ const getActivityLevelFeedbackDocsQuery = () => {
   return query;
 };
 
-const getQuestionLevelFeedbackDocsQuery = (answerId: string) => {
+const getQuestionLevelFeedbackDocsQuery = (answerId?: string) => {
   if (!portalData) {
     throw new Error("Must set portal data first");
   }
@@ -313,17 +313,19 @@ const getQuestionLevelFeedbackDocsQuery = (answerId: string) => {
 
   if (portalData.type === "authenticated") {
     query = query
-      .where("answerId", "==", answerId)
       .where("platformId", "==", portalData.platformId)
       .where("resourceLinkId", "==", portalData.resourceLinkId)
       .where("contextId", "==", portalData.contextId)
       .where("platformStudentId", "==", portalData.platformUserId.toString());
+    if (answerId) {
+      query = query.where("answer_id", "==", answerId);
+    }
   }
 
   return query;
 };
 
-const watchQuestionLevelFeedbackDocs = (listener: DocumentsListener, answerId: string) => {
+const watchQuestionLevelFeedbackDocs = (listener: DocumentsListener, answerId?: string) => {
   const query = getQuestionLevelFeedbackDocsQuery(answerId);
   if (!query) return () => {/* no-op */};
 
@@ -359,118 +361,52 @@ const watchActivityLevelFeedbackDocs = (listener: DocumentsListener) => {
   });
 };
 
-// Watches ONE question feedback
-export const watchQuestionLevelFeedback = (answerId: string, callback: (feedback: TeacherFeedback | null) => void) => {
+// Watches question level feedback for a single or for all answers
+export const watchQuestionLevelFeedback = (callback: (feedback: QuestionFeedback[] | null) => void, answerId?: string) => {
   // Note that watchQuestionLevelFeedbackDocs returns unsubscribe method.
   return watchQuestionLevelFeedbackDocs((feedbackDocs: firebase.firestore.DocumentData[]) => {
     if (feedbackDocs.length === 0) {
       callback(null);
       return;
     }
-    if (feedbackDocs.length > 1) {
+
+    if (answerId && feedbackDocs.length > 1) {
       console.warn(
-        "Found multiple answer objects for the same question. It might be result of early " +
+        "Found multiple question feedback objects for the same answer. It might be result of early " +
         "ActivityPlayer versions. Your data might be corrupted."
       );
     }
 
-    const feedback = feedbackDocs[0].feedback;
-    const timestamp = feedbackDocs[0].updatedAt.toDate().toLocaleString();
-    callback({content: feedback, timestamp});
-  }, answerId); // limit observer to single answer
+    const feedbacks = feedbackDocs.map((doc) => {
+      const feedback = doc.feedback;
+      const timestamp = doc.updatedAt.toDate().toLocaleString();
+      return {questionId: doc.questionId, content: feedback, timestamp};
+    });
+
+    callback(feedbacks);
+  }, answerId); // limit observer to single answer if specified
 };
 
-// Watches ONE activity feedback
-export const watchActivityLevelFeedback = (callback: (feedback:TeacherFeedback | null) => void) => {
+// Watches all activity-level feedback for sequence or activity
+export const watchActivityLevelFeedback = (callback: (feedback:ActivityFeedback[] | null) => void) => {
   // Note that watchAnswerDocs returns unsubscribe method.
   return watchActivityLevelFeedbackDocs((feedbackDocs: firebase.firestore.DocumentData[]) => {
     if (feedbackDocs.length === 0) {
       callback(null);
       return;
     }
-    if (feedbackDocs.length > 1) {
-      console.warn(
-        "Found multiple activity objects for the same question. It might be result of early " +
-        "ActivityPlayer versions. Your data might be corrupted."
-      );
-    }
 
-    const feedback = feedbackDocs[0].feedback;
-    const timestamp = feedbackDocs[0].updatedAt.toDate().toLocaleString();
-    callback({content: feedback, timestamp});
+    const allFeedback = feedbackDocs.map((doc) => {
+      const feedback = doc.feedback;
+      const timestamp = doc.updatedAt.toDate().toLocaleString();
+      const activityId = doc.activityId;
+      return {activityId, content: feedback, timestamp};
+    });
+
+    callback(allFeedback);
   });
 };
 
-// Watches all activity-level feedback
-export const watchActivityFeedbackForSequence = (callback: (activityIds:string[]) => void) => {
-  // Note that watchAnswerDocs returns unsubscribe method.
-  return watchActivityLevelFeedbackDocs((feedbackDocs: firebase.firestore.DocumentData[]) => {
-    if (feedbackDocs.length === 0) {
-      callback([]);
-      return;
-    }
-    if (feedbackDocs.length > 1) {
-      console.warn(
-        "Found multiple activity objects for the same question. It might be result of early " +
-        "ActivityPlayer versions. Your data might be corrupted."
-      );
-    }
-
-    // remove string prefix from activityId
-    const activityIds = feedbackDocs.map(doc => doc.activityId.replace("activity_", ""));
-    callback(activityIds);
-  });
-};
-
-// Gets all question feedback docs for sequence or activity
-const getAllQuestionLevelFeedbackDocsQuery = () => {
-  if (!portalData) {
-    throw new Error("Must set portal data first");
-  }
-  // Only logged-in students will have feedback.
-  if (portalData.userType !== "learner" || portalData.type === "anonymous") return;
-
-  let query: firebase.firestore.Query = app.firestore().collection(teacherFeedbackPath("question"));
-
-  if (portalData.type === "authenticated") {
-    query = query
-      .where("platformId", "==", portalData.platformId)
-      .where("resourceLinkId", "==", portalData.resourceLinkId)
-      .where("contextId", "==", portalData.contextId)
-      .where("platformStudentId", "==", portalData.platformUserId.toString());
-  }
-
-  return query;
-};
-
-const watchAllQuestionLevelFeedbackDocs = (listener: DocumentsListener) => {
-  const query = getAllQuestionLevelFeedbackDocsQuery();
-  // Note that query.onSnapshot returns unsubscribe method.
-  return query?.onSnapshot((snapshot: firebase.firestore.QuerySnapshot<firebase.firestore.DocumentData>) => {
-    if (!snapshot.empty) {
-      const docs = snapshot.docs.map(doc => doc.data());
-      listener(docs);
-    }
-    else {
-      listener([]);
-    }
-  }, (err) => {
-    throw new Error(err.message);
-  });
-};
-
-// Watches all question-level feedback for sequence or activity
-export const watchAllQuestionLevelFeedback = (callback: (questionIds: string[]) => void) => {
-  // Note that watchQuestionLevelFeedbackDocs returns unsubscribe method.
-  return watchAllQuestionLevelFeedbackDocs((feedbackDocs: firebase.firestore.DocumentData[]) => {
-    if (feedbackDocs.length === 0) {
-      callback([]);
-      return;
-    }
-    const feedbackQuestionIds: string[] = feedbackDocs.map(doc => doc.questionId);
-    callback(feedbackQuestionIds);
-  });
-};
 // use same universal timezone (UTC) as Lara uses for writing created
 export const utcString = () => (new Date()).toUTCString().replace("GMT", "UTC");
 

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -377,13 +377,13 @@ export const watchQuestionLevelFeedback = (callback: (feedback: QuestionFeedback
       );
     }
 
-    const feedbacks = feedbackDocs.map((doc) => {
+    const allFeedback = feedbackDocs.filter(doc => !!doc.feedback).map((doc) => {
       const feedback = doc.feedback;
       const timestamp = doc.updatedAt.toDate().toLocaleString();
       return {questionId: doc.questionId, content: feedback, timestamp};
     });
 
-    callback(feedbacks);
+    callback(allFeedback);
   }, answerId); // limit observer to single answer if specified
 };
 
@@ -396,7 +396,7 @@ export const watchActivityLevelFeedback = (callback: (feedback:ActivityFeedback[
       return;
     }
 
-    const allFeedback = feedbackDocs.map((doc) => {
+    const allFeedback = feedbackDocs.filter(doc => !!doc.feedback).map((doc) => {
       const feedback = doc.feedback;
       const timestamp = doc.updatedAt.toDate().toLocaleString();
       const activityId = doc.activityId;

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,7 +358,15 @@ export interface IAuthenticatedUserApRun extends IBaseApRun {
 
 export type IApRun = IAnonymousApRun | IAuthenticatedUserApRun;
 
-export type TeacherFeedback = {
+export type BaseTeacherFeedback = {
   content: string;
   timestamp: string;
+}
+
+export type ActivityFeedback = BaseTeacherFeedback & {
+  activityId: string;
+};
+
+export type QuestionFeedback = BaseTeacherFeedback & {
+  questionId: string;
 };


### PR DESCRIPTION
This PR also streamlines/gets rid of some functions in `firebase-db.ts` by returning an array of feedbackDocs that include the relevant ids from both the `watchQuestionLevelFeedback` and `watchActivityLevelFeedback` functions, and updates the types of TeacherFeedback. 