### PR TITLE
feat: support for `showFeedback` param (PT-188732128)

### DIFF
--- a/cypress/e2e/load-activities.test.ts
+++ b/cypress/e2e/load-activities.test.ts
@@ -31,5 +31,12 @@ context("Loading activities", () => {
       activityPage.getSecondaryEmbeddable("text-box").eq(1).scrollIntoView()
         .should("be.visible").and("contain","Duis vitae ultrices augue, eu fermentum elit.");
     });
+
+    it("can load the completion page when `showFeedback` query param is set", () => {
+      cy.visit("?activity=sample-activity-1&preview");
+      cy.get("[data-cy=completion-page-content]").should("not.exist");
+      cy.visit("?activity=sample-activity-1&showFeedback&preview");
+      cy.get("[data-cy=completion-page-content]").should("be.visible");
+    });
   });
 });

--- a/cypress/e2e/sequence-page.test.ts
+++ b/cypress/e2e/sequence-page.test.ts
@@ -51,6 +51,10 @@ context("Test sequences", () => {
       cy.get("[data-cy=custom-select-header]").should("contain", "3: Sample Sequence Activity 3");
       cy.get("[data-cy=activity-summary]").should("exist");
       cy.get("[data-cy=activity-summary]").should("contain", "Sample Sequence Activity 3");
+
+      cy.log("should always load the sequence intro page when query param `showFeedback` is set");
+      cy.visit("?sequence=sample-sequence&preview&sequenceActivity=activity_1&showFeedback");
+      cy.url().should("contain", "sequenceActivity=0");
     });
   });
 });


### PR DESCRIPTION
[#188732128](https://www.pivotaltracker.com/story/show/188732128)

When the `showFeedback` URL query param is set:

- Activities with completion page will automatically load the completion page
- Activities without the completion page will automatically load the home page
- Sequences will automatically load the sequence home page