### PR TITLE
fix: don't show rubric when rubric hidden (PT-188780572)

### DIFF
--- a/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
+++ b/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
@@ -2,8 +2,14 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { DynamicTextContext } from "@concord-consortium/dynamic-text";
 import { ActivityLevelFeedbackBanner } from "./activity-level-feedback-banner";
+import { ActivityFeedback } from "../../types";
+
+jest.mock("./rubric", () => ({
+  RubricComponent: () => <div data-testid="mock-rubric" />
+}));
 
 describe("Activity Level Feedback component", () => {
+
   const mockDynamicTextContextValue = {
     registerComponent: jest.fn(),
     unregisterComponent: jest.fn(),
@@ -16,15 +22,45 @@ describe("Activity Level Feedback component", () => {
     timestamp: "2021-08-10T14:00:00Z"
   };
 
-  it("renders component", () => {
+  const renderComponent = (feedback: ActivityFeedback) => {
     render(
       <DynamicTextContext.Provider value={mockDynamicTextContextValue}>
-        <ActivityLevelFeedbackBanner teacherFeedback={mockFeedback} />
+        <ActivityLevelFeedbackBanner teacherFeedback={feedback} />
       </DynamicTextContext.Provider>
     );
+  };
+
+  it("renders component", () => {
+    renderComponent(mockFeedback);
     expect(screen.queryByTestId("activity-level-feedback-banner")).not.toBeNull();
     expect(screen.queryByTestId("activity-level-feedback-content")).not.toBeNull();
     expect(screen.queryByTestId("activity-level-feedback-content")?.querySelector("strong")?.textContent).toBe("Overall Teacher Feedback for This Activity:");
     expect(screen.queryByTestId("activity-level-feedback-content")?.textContent).toContain(mockFeedback.content);
+  });
+  it("renders component with a rubric", () => {
+    const mockFeedbackWithRubric = {
+      ...mockFeedback,
+      feedbackSettings: {
+        rubric: {
+          id: 123,
+          hideRubricFromStudentsInStudentReport: false
+        }
+      }
+    };
+    renderComponent(mockFeedbackWithRubric);
+    expect(screen.queryByTestId("mock-rubric")).not.toBeNull();
+  });
+  it("renders component without a rubric when `hideRubricFromStudentsInStudentReport` is true", () => {
+    const mockFeedbackWithHiddenRubric = {
+      ...mockFeedback,
+      feedbackSettings: {
+        rubric: {
+          id: 123,
+          hideRubricFromStudentsInStudentReport: true
+        }
+      }
+    };
+    renderComponent(mockFeedbackWithHiddenRubric);
+    expect(screen.queryByTestId("mock-rubric")).toBeNull();
   });
 });

--- a/src/components/teacher-feedback/activity-level-feedback-banner.tsx
+++ b/src/components/teacher-feedback/activity-level-feedback-banner.tsx
@@ -12,21 +12,22 @@ interface IProps {
 }
 
 export const ActivityLevelFeedbackBanner = ({ teacherFeedback }: IProps) => {
-  const hasRubric = !!teacherFeedback.feedbackSettings?.rubric;
+  const { rubric } = teacherFeedback.feedbackSettings ?? {};
+  const shouldRenderRubric = !!rubric && !rubric.hideRubricFromStudentsInStudentReport;
   const bannerClass = classNames("activity-level-feedback-banner", {
-    "has-rubric": hasRubric
+    "has-rubric": shouldRenderRubric
   });
 
   return (
     <div className={bannerClass} data-testid="activity-level-feedback-banner">
       <TeacherFeedbackIcon className="teacher-feedback-icon" />
-      {hasRubric && (
+      {shouldRenderRubric && (
         <div className="activity-level-feedback-title">
           <DynamicText><strong>Overall Teacher Feedback for This Activity:</strong></DynamicText>
         </div>
       )}
       <div className="activity-level-feedback-content" data-testid="activity-level-feedback-content">
-        {hasRubric ? (
+        {shouldRenderRubric ? (
           <RubricComponent teacherFeedback={teacherFeedback} />
         ) : (
           <DynamicText><strong>Overall Teacher Feedback for This Activity:</strong> {teacherFeedback.content}</DynamicText>


### PR DESCRIPTION
[#188780572](https://www.pivotaltracker.com/story/show/188780572)

Fixes an issue where rubrics were displayed to students even when the rubrics' "Hide rubric from students" option was checked.