### PR TITLE
fix: summary table feedback margin (PT-188859980)

### DIFF
--- a/src/components/activity-completion/summary-table.scss
+++ b/src/components/activity-completion/summary-table.scss
@@ -69,6 +69,13 @@
         flex: 1;
         font-weight: normal;
       }
+      .question-feedback {
+        margin-top: 6px;
+
+        &.no-prompt {
+          margin-top: 0;
+        }
+      }
     }
   }
   th {

--- a/src/components/activity-completion/summary-table.tsx
+++ b/src/components/activity-completion/summary-table.tsx
@@ -60,8 +60,11 @@ export const SummaryTable: React.FC<IProps> = (props) => {
                     </button>
                   </div>
                   <div className="question-prompt" data-testid="question-prompt">
-                    <DynamicText><em>{questionPrompt}</em></DynamicText>
-                    {question.feedback && <SummaryPageQuestionFeedback teacherFeedback={question.feedback} />}
+                    {questionPrompt && <DynamicText><em>{questionPrompt}</em></DynamicText>}
+                    {question.feedback && (
+                      <div className={questionPrompt ? "question-feedback" : "question-feedback no-prompt"}>
+                        <SummaryPageQuestionFeedback teacherFeedback={question.feedback} />
+                      </div>)}
                   </div>
                 </div>
               </td>

--- a/src/components/teacher-feedback/summary-page-question-feedback.scss
+++ b/src/components/teacher-feedback/summary-page-question-feedback.scss
@@ -7,7 +7,7 @@
   display: flex;
   font-size: pxToRem(18);
   gap: 9px;
-  margin: 6px -5px -5px 0;
+  margin: -5px -5px -5px 0;
   padding: 7px 6px;
 
   .teacher-feedback-icon {


### PR DESCRIPTION
[#188859980](https://www.pivotaltracker.com/story/show/188859980)

Ensures that when a question has no prompt, there is no top margin to question-level feedback in the summary table.