### PR TITLE
fix: Incorrect page numbers for hidden pages [AP-36]

### DIFF
--- a/src/utilities/activity-utils.test.ts
+++ b/src/utilities/activity-utils.test.ts
@@ -1,5 +1,5 @@
 import { Activity } from "../types";
-import { isQuestion, numQuestionsOnPreviousPages, enableReportButton, getPagePositionFromQueryValue, isSectionHidden, numQuestionsOnPreviousSections, getPageIDFromPosition } from "./activity-utils";
+import { isQuestion, numQuestionsOnPreviousPages, enableReportButton, getPagePositionFromQueryValue, isSectionHidden, numQuestionsOnPreviousSections, getPageIDFromPosition, getPageNumberFromEmbeddable } from "./activity-utils";
 import _activityHidden from "../data/version-2/sample-new-sections-hidden-content.json";
 import _activity from "../data/version-2/sample-new-sections-activity-1.json";
 import { DefaultTestActivity } from "../test-utils/model-for-tests";
@@ -65,5 +65,21 @@ describe("Activity utility functions", () => {
     expect(getPageIDFromPosition(activity, 1)).toBe(1000);
     expect(getPageIDFromPosition(activity, 2)).toBe(2000);
     expect(getPageIDFromPosition(activity, 3)).toBe(3000);
+  });
+  it("ignores hidden pages when getting the page number of an embeddable", () => {
+    const { pages } = activityHidden;
+
+    // make sure the second page is hidden
+    expect(pages[0].is_hidden).toBe(false);
+    expect(pages[1].is_hidden).toBe(true);
+    expect(pages[2].is_hidden).toBe(false);
+
+    // make sure the second page (that is hidden) has an embeddable and that its page number if undefined
+    expect(pages[1].sections[0].embeddables[0]).toBeDefined();
+    expect(getPageNumberFromEmbeddable(activityHidden, pages[1].sections[0].embeddables[0].ref_id)).toBeUndefined();
+
+    // make sure the page number of the third page is 2 since the second page is hidden
+    expect(pages[2].sections[0].embeddables[0]).toBeDefined();
+    expect(getPageNumberFromEmbeddable(activityHidden, pages[2].sections[0].embeddables[0].ref_id)).toBe(2);
   });
 });

--- a/src/utilities/activity-utils.test.ts
+++ b/src/utilities/activity-utils.test.ts
@@ -74,7 +74,7 @@ describe("Activity utility functions", () => {
     expect(pages[1].is_hidden).toBe(true);
     expect(pages[2].is_hidden).toBe(false);
 
-    // make sure the second page (that is hidden) has an embeddable and that its page number if undefined
+    // make sure the second page (that is hidden) has an embeddable and that its page number is undefined
     expect(pages[1].sections[0].embeddables[0]).toBeDefined();
     expect(getPageNumberFromEmbeddable(activityHidden, pages[1].sections[0].embeddables[0].ref_id)).toBeUndefined();
 

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -282,12 +282,17 @@ export const getEmbeddable = (activity: Activity, embeddableRefId: string) => {
 };
 
 export const getPageNumberFromEmbeddable = (activity: Activity, embeddableRefId: string) => {
+  let pageNumber = 0;
   for (let i = 0; i < activity.pages.length; i++) {
     const page = activity.pages[i];
+    if (page.is_hidden) {
+      continue;
+    }
+    pageNumber++;
     for (const section of page.sections) {
       const embeddable = section.embeddables.find((e: EmbeddableType) => e.ref_id === embeddableRefId);
       if (embeddable) {
-        return i + 1;
+        return pageNumber;
       }
     }
   }


### PR DESCRIPTION
This updates the code that returns the page number of an embeddable to ignore hidden pages.