### PR TITLE
fix: Out of bounds page read in setDocumentTitle [AP-38]

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -184,6 +184,12 @@ export class App extends React.PureComponent<IProps, IState> {
     }
   }
 
+  // note - this is different than the getVisiblePages in activity-utils.ts as it also looks at the author-preview query param
+  private getVisiblePages = (activity: Activity) => {
+    const pagesVisible = queryValue("author-preview") ? activity.pages : activity.pages.filter((page) => !page.is_hidden);
+    return pagesVisible;
+  }
+
   async componentDidMount() {
     try {
       const teacherEditionMode = queryValue("mode")?.toLowerCase() === "teacher-edition";
@@ -312,7 +318,7 @@ export class App extends React.PureComponent<IProps, IState> {
       // If query parameter `showFeedback` is true, take the user to the "feedback page". For sequences, the
       // feedback page is the home page. For activities, the feedback page is the completion page or the home
       // page if no completion page is set.
-      const completionPageIndex = activity.pages.findIndex((p: Page) => p.is_completion);
+      const completionPageIndex = this.getVisiblePages(activity).findIndex((p: Page) => p.is_completion);
       const completionPageNum = completionPageIndex !== -1 ? completionPageIndex + 1 : 0;
       const feedbackPageNum = sequence ? 0 : completionPageNum;
 
@@ -494,7 +500,7 @@ export class App extends React.PureComponent<IProps, IState> {
     // convert option with Ruby snake case to kebab case for css
     const fixedWidthLayout = (sequence?.fixed_width_layout || activity.fixed_width_layout || kDefaultFixedWidthLayout).replace(/_/g, "-");
     const activityClasses = classNames("activity", fullWidth ? "responsive" : `fixed-width-${fixedWidthLayout}`);
-    const pagesVisible = queryValue("author-preview") ? activity.pages : activity.pages.filter((page) => !page.is_hidden);
+    const pagesVisible = this.getVisiblePages(activity);
 
     // create a key so when activities switch within a sequence React knows to update the DOM
     const key = `activity-${activityIndex || 0}`;
@@ -556,7 +562,7 @@ export class App extends React.PureComponent<IProps, IState> {
   }
 
   private renderActivityContent = (activity: Activity, currentPage: number, totalPreviousQuestions: number, fullWidth: boolean) => {
-    const pagesVisible = queryValue("author-preview") ? activity.pages : activity.pages.filter((page) => !page.is_hidden);
+    const pagesVisible = this.getVisiblePages(activity);
     const isSinglePageActivity = activity.layout === ActivityLayouts.SinglePage;
     const isMultiPageActivity = activity.layout === ActivityLayouts.MultiplePages;
     const isNotebookSequenceOverride = this.state.sequence?.layout_override === ActivityLayoutOverrides.Notebook;

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -176,8 +176,10 @@ export const setAppBackgroundImage = (backgroundImageUrl?: string) => {
 };
 
 export const setDocumentTitle = (params: ISetDocumentTitleParams) => {
-  const { activity, pageNumber, sequence, sequenceActivityNum } = params;
+  const { activity, sequence, sequenceActivityNum } = params;
   const setTabTitle = (title: string, pages: Page[]) => {
+    // as a sanity check, ensure the page number is in the range [0, <number of pages>].
+    const pageNumber = Math.max(0, Math.min(params.pageNumber, pages.length));
     document.title = pageNumber === 0
       ? title
       : `Page ${pageNumber} ${pages[pageNumber - 1].name || title}`;


### PR DESCRIPTION
Fixes an error when the showFeedbackPage query parameter is present.  The completion page page number was not being correctly calculated when there were hidden pages and setDocumentTitle was being passed a page number outside the bounds of the page array.

This also adds a sanity check to ensure setDocumentTitle uses a page number within the range of pages to avoid a page crash.