### PR TITLE
fix: Removes null callback parameter for feedback watchers (AP-40)

### DIFF
--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -54,7 +54,7 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
       setAnswers(answersInActivity);
     });
 
-    const unsubscribeQFeedback = watchQuestionLevelFeedback((fbs: QuestionFeedback[]) => {
+    const unsubscribeQFeedback = watchQuestionLevelFeedback(fbs => {
       const questionFeedbackInThisActivity = fbs.filter(f => questionsInActivity.includes(f.questionId));
       setQuestionFeedback(questionFeedbackInThisActivity);
     });

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames";
 import { Section, SectionImperativeAPI } from "./section";
 import { BottomButtons } from "./bottom-buttons";
 import { ActivityLayouts, numQuestionsOnPreviousSections } from "../../utilities/activity-utils";
-import { Activity, Page, QuestionFeedback, SectionType } from "../../types";
+import { Activity, Page, SectionType } from "../../types";
 import { IGetInteractiveState, INavigationOptions } from "@concord-consortium/lara-interactive-api";
 import { QuestionInfoContext } from "../question-info-context";
 import { answersQuestionIdToRefId } from "../../utilities/embeddable-utils";
@@ -81,7 +81,7 @@ export class ActivityPageContent extends React.Component<IProps, IState> {
     const { activity, page } = this.props;
     const { questionMap } = this.context;
     if (activity.id) {
-      this.unsubscribeQuestionLevelFeedback = watchQuestionLevelFeedback((fbs: QuestionFeedback[]) => {
+      this.unsubscribeQuestionLevelFeedback = watchQuestionLevelFeedback(fbs => {
         const qIds: string[] = [];
         fbs.forEach(fb => {
           const eRefId = answersQuestionIdToRefId(fb.questionId);

--- a/src/components/sequence-introduction/sequence-page-content.tsx
+++ b/src/components/sequence-introduction/sequence-page-content.tsx
@@ -30,7 +30,7 @@ export const SequencePageContent: React.FC<IProps> = (props) => {
   sequence.activities.forEach((a: Activity) => totalTime += a.time_to_complete || 0);
 
   useEffect(() => {
-    const unsubscribe = watchActivityLevelFeedback((fbs: ActivityFeedback[]) => {
+    const unsubscribe = watchActivityLevelFeedback(fbs => {
       const ids = fbs.map((fb: ActivityFeedback) => fb.activityId.replace("activity_", ""));
       setActivitiesWithActivityLevelFeedback(ids);
     });
@@ -42,7 +42,7 @@ export const SequencePageContent: React.FC<IProps> = (props) => {
   }, [sequence.activities]);
 
   useEffect(() => {
-    const unsubscribe = watchQuestionLevelFeedback((fbs: QuestionFeedback[]) => {
+    const unsubscribe = watchQuestionLevelFeedback(fbs => {
       const questionIds = fbs.map((fb: QuestionFeedback) => fb.questionId);
       const questionIdsToRefId = questionIds.map(answersQuestionIdToRefId);
       const activityIds: number[] = [];

--- a/src/firebase-db.ts
+++ b/src/firebase-db.ts
@@ -387,14 +387,9 @@ const watchActivityLevelFeedbackDocs = (listener: DocumentsListener) => {
 };
 
 // Watches question level feedback for a single or for all answers
-export const watchQuestionLevelFeedback = (callback: (feedback: QuestionFeedback[] | null) => void, answerId?: string) => {
+export const watchQuestionLevelFeedback = (callback: (fbs: QuestionFeedback[]) => void, answerId?: string) => {
   // Note that watchQuestionLevelFeedbackDocs returns unsubscribe method.
   return watchQuestionLevelFeedbackDocs((feedbackDocs: firebase.firestore.DocumentData[]) => {
-    if (feedbackDocs.length === 0) {
-      callback(null);
-      return;
-    }
-
     if (answerId && feedbackDocs.length > 1) {
       console.warn(
         "Found multiple question feedback objects for the same question. It might be result of early " +
@@ -413,7 +408,7 @@ export const watchQuestionLevelFeedback = (callback: (feedback: QuestionFeedback
 };
 
 // Watches all activity-level feedback for sequence or activity
-export const watchActivityLevelFeedback = (callback: (feedback: ActivityFeedback[] | null) => void) => {
+export const watchActivityLevelFeedback = (callback: (fbs: ActivityFeedback[]) => void) => {
   let feedbackSettings: Record<string, any> | undefined = undefined;
   if (portalData?.type === "authenticated") {
     const query = getFeedbackSettingsQuery();
@@ -426,11 +421,6 @@ export const watchActivityLevelFeedback = (callback: (feedback: ActivityFeedback
 
   // Note that watchActivityLevelFeedbackDocs returns unsubscribe method.
   return watchActivityLevelFeedbackDocs((feedbackDocs: firebase.firestore.DocumentData[]) => {
-    if (feedbackDocs.length === 0) {
-      callback(null);
-      return;
-    }
-
     const allFeedback = feedbackDocs.filter((doc) => !!doc.feedback).map((doc) => {
       const content = doc.feedback;
       const rubricFeedback = doc.rubricFeedback;

--- a/src/utilities/feedback-utils.test.ts
+++ b/src/utilities/feedback-utils.test.ts
@@ -2,8 +2,8 @@ import { Page, ActivityFeedback, QuestionFeedback } from "../types";
 import { pageHasFeedback, subscribeToActivityLevelFeedback, subscribeToQuestionLevelFeedback } from "./feedback-utils";
 
 jest.mock("../firebase-db", () => ({
-  watchActivityLevelFeedback: jest.fn((callback: (feedback: ActivityFeedback | null) => void) => {
-    callback(null);
+  watchActivityLevelFeedback: jest.fn((callback: (fbs: ActivityFeedback[]) => void) => {
+    callback([]);
 
     // simulate the unsubscribe function
     return jest.fn();

--- a/src/utilities/feedback-utils.ts
+++ b/src/utilities/feedback-utils.ts
@@ -1,5 +1,5 @@
 import { watchActivityLevelFeedback, watchQuestionLevelFeedback } from "../firebase-db";
-import { Page, ActivityFeedback, QuestionFeedback, QuestionMap } from "../types";
+import { Page, ActivityFeedback, QuestionMap } from "../types";
 import { answersQuestionIdToRefId } from "./embeddable-utils";
 
 interface ISubscribeActivityLevelFeedback {
@@ -19,8 +19,8 @@ export const subscribeToActivityLevelFeedback = (args: ISubscribeActivityLevelFe
   const { activityId, callback, isSequence } = args;
   const activityIdString = isSequence ? `activity_${activityId}` : `activity-activity_${activityId}`;
 
-  return watchActivityLevelFeedback((feedback: ActivityFeedback[] | null) => {
-    const fb = feedback?.find(f => f.activityId?.toString() === activityIdString) ?? null;
+  return watchActivityLevelFeedback(fbs => {
+    const fb = fbs.find(f => f.activityId?.toString() === activityIdString) ?? null;
     callback(fb);
   });
 };
@@ -28,8 +28,8 @@ export const subscribeToActivityLevelFeedback = (args: ISubscribeActivityLevelFe
 export const subscribeToQuestionLevelFeedback = (args: ISubscribeQuestionLevelFeedback) => {
   const { activityId, callback, isSequence, questionMap } = args;
 
-  return watchQuestionLevelFeedback((fb: QuestionFeedback[] | null) => {
-    const questionIdsToRefId = fb?.map(f => answersQuestionIdToRefId(f.questionId));
+  return watchQuestionLevelFeedback(fbs => {
+    const questionIdsToRefId = fbs.map(f => answersQuestionIdToRefId(f.questionId));
     const pageIds: number[] = [];
     questionIdsToRefId?.forEach((refId: string) => {
       const pageId = questionMap?.[refId]?.pageId;


### PR DESCRIPTION
This changes the null callback parameter to an empty array and updates the callback sites to remove the typing that masked that null was being passed.