### PR TITLE
fix: remove extra whitespace below activity interactives [AP-113]

### DIFF
--- a/src/components/activity-page/managed-interactive/iframe-runtime.scss
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.scss
@@ -4,6 +4,10 @@
   position: relative;
   iframe {
     border: 0;
+    // display:block removes the ~6px baseline descender gap that an inline
+    // (replaced) element leaves below itself, which otherwise shows as extra
+    // whitespace beneath every interactive.
+    display: block;
 
     &.iframe-runtime-locked {
       pointer-events: none;

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -351,4 +351,47 @@ describe("IframeRuntime component", () => {
     expect(global.confirm).toHaveBeenCalledTimes(1);
     expect(mockSetInteractiveState).toHaveBeenCalledTimes(5);
   });
+
+  const renderIframeRuntime = (overrides: Record<string, any> = {}) => render(
+    <MediaLibraryTester>
+      <DynamicTextTester>
+        <IframeRuntime
+          url={"https://concord.org/"}
+          id={"123-Interactive"}
+          authoredState={null}
+          initialInteractiveState={null}
+          legacyLinkedInteractiveState={null}
+          setInteractiveState={jest.fn()}
+          setAspectRatio={jest.fn()}
+          setHeightFromInteractive={jest.fn()}
+          setSupportedFeatures={jest.fn()}
+          setNewHint={jest.fn()}
+          getFirebaseJWT={jest.fn(() => Promise.resolve("stub"))}
+          getAttachmentUrl={jest.fn(() => Promise.resolve({ url: "https://concord.org/a", requestId: 1 }))}
+          showModal={jest.fn()}
+          closeModal={jest.fn()}
+          setSendCustomMessage={jest.fn()}
+          setNavigation={jest.fn()}
+          log={mockLog}
+          iframeTitle="Interactive content"
+          {...overrides}
+        />
+      </DynamicTextTester>
+    </MediaLibraryTester>
+  );
+
+  it("does not render the buttons wrapper when there is no reset button or feedback", () => {
+    const { container, queryByTestId } = renderIframeRuntime({ showDeleteDataButton: false, feedback: null });
+    jest.runAllTimers();
+    // the wrapper (and its margins) must be omitted so it doesn't add empty whitespace below the iframe
+    expect(container.querySelector(".iframe-runtime-buttons")).toBeNull();
+    expect(queryByTestId("reset-button")).toBeNull();
+  });
+
+  it("renders the buttons wrapper when the reset button is shown", () => {
+    const { container, queryByTestId } = renderIframeRuntime({ showDeleteDataButton: true });
+    jest.runAllTimers();
+    expect(container.querySelector(".iframe-runtime-buttons")).not.toBeNull();
+    expect(queryByTestId("reset-button")).not.toBeNull();
+  });
 });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -525,15 +525,17 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
         title={iframeTitle}
         scrolling="no"
       />
-      <div className="iframe-runtime-buttons">
-        {showDeleteDataButton &&
-          <button className="button reset" data-cy="reset-button" onClick={handleResetButtonClick} onKeyDown={handleResetButtonClick}>
-            Clear &amp; start over
-            <ReloadIcon />
-          </button>
-        }
-        {feedback && <IframeRuntimeFeedback embeddableRefId={id} feedback={feedback} />}
-      </div>
+      {(showDeleteDataButton || feedback) &&
+        <div className="iframe-runtime-buttons">
+          {showDeleteDataButton &&
+            <button className="button reset" data-cy="reset-button" onClick={handleResetButtonClick} onKeyDown={handleResetButtonClick}>
+              Clear &amp; start over
+              <ReloadIcon />
+            </button>
+          }
+          {feedback && <IframeRuntimeFeedback embeddableRefId={id} feedback={feedback} />}
+        </div>
+      }
     </div>
   );
 });


### PR DESCRIPTION
## Summary

Removes two sources of extra vertical whitespace below interactive iframes on activity pages (reported by design).

- **Empty buttons wrapper** — the `.iframe-runtime-buttons` div was always rendered beneath each interactive, even when empty. It only holds the "Clear & start over" reset button (when enabled) and teacher feedback (when present); when neither shows, its margins still added ~30px of dead space. Now it's only rendered when it has content. (It is not a plugin render target — plugins use their own `plugin-container` / `activity-level-plugin-container` — so removing it when empty is safe.)
- **Inline iframe descender gap** — the interactive `<iframe>` defaulted to `display: inline`, so it sat on the text baseline and left a ~6px descender gap below itself. Set to `display: block`.

## Verification (Playwright, against authoring activity 1488)

- Empty-div removal: the buttons wrapper is gone from the DOM when there's no reset button or feedback; its trailing margin space is removed. Still renders correctly when a reset button/feedback is present.
- Descender gap: gap below the iframe goes from **6px → 0px**; `.iframe-runtime` height now equals the iframe height; **no horizontal shift or width change** (iframe is left-aligned, not inline-centered).

## Notes

- Jira: AP-113
- CI may show a failure in `hide-question-numbers-interactives.ts` (`[data-cy=open-hint]` not found). This is a **pre-existing, unrelated flake** inherited from master — an external `branch/master` question-interactive drifted and the test asserts with no retry (`{ timeout: 0 }`). Tracked separately in **AP-114**; not caused by this PR.