### PR TITLE
test: harden flaky hint-icon check with retry [AP-114]

### DIFF
--- a/cypress/support/elements/activity-page.js
+++ b/cypress/support/elements/activity-page.js
@@ -143,8 +143,13 @@ class ActivityPage {
   getHintText() {
     return this.getInteractive().find('.hint.question-txt');
   }
+  // Returns the hint icon (if any) within the given interactive. The icon is rendered by the
+  // externally-hosted interactive only after its iframe loads, so we rely on Cypress's normal
+  // retry (no { timeout: 0 }) to let ".should('exist')" call sites wait for it to appear.
+  // ".should('not.exist')" call sites still pass immediately when the icon is absent, so they
+  // are not slowed down.
   hasHintIcon(interactive) {
-    return cy.wrap(interactive).find('[data-cy=open-hint]', { timeout: 0 });
+    return cy.wrap(interactive).find('[data-cy=open-hint]');
   }
   verifyHiddenQuestionNumberInteractive() {
     return cy.get('[data-cy="managed-interactive"]').should('not.exist');


### PR DESCRIPTION
## Summary

Fixes the intermittent failure in `cypress/e2e/hide-question-numbers-interactives.ts`:

> Expected to find element: `[data-cy=open-hint]`, but never found it.

## Root cause

The hint "?" icon (`data-cy="open-hint"`) is rendered by an externally-hosted question-interactive (loaded from `branch/master`) only **after** its iframe loads. The `hasHintIcon()` helper queried with `{ timeout: 0 }`, which disables Cypress's auto-retry — so the `.should("exist")` checks ran once, immediately after a fixed `cy.wait(2000)`, and failed whenever the icon hadn't rendered yet (slower CI/network). The markup itself is correct; this is purely a timing race.

## Fix

Remove `{ timeout: 0 }` from `hasHintIcon` so the `.should("exist")` checks retry until the icon appears. The `.should("not.exist")` checks still pass immediately when the icon is absent, so they aren't slowed down.

## Verification

- Ran the spec locally against the dev server — passes.
- Inspected the activity in-browser previously: when given time, all hint icons render and match the test's expectations exactly, confirming it was a timing race rather than a markup change.

Jira: AP-114