### PR TITLE
fix(AP-115): apply URL overrides to imperative iframe src assignment

### DIFF
--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -64,6 +64,9 @@ describe("IframeRuntime component", () => {
   afterEach(() => {
     jest.useRealTimers();
     jest.restoreAllMocks();
+    // Override state is a module-level singleton; reset here so it can't leak
+    // into later tests even if a test throws before its own cleanup.
+    resetOverridesForTesting();
   });
 
   it("renders component", async () => {
@@ -411,7 +414,5 @@ describe("IframeRuntime component", () => {
     const iframe = testIframe.getByTestId("iframe-runtime").children[0] as HTMLIFrameElement;
     expect(iframe.getAttribute("src")).toBe(overriddenUrl);
     expect(iframe.getAttribute("src")).not.toBe(rawUrl);
-
-    resetOverridesForTesting();
   });
 });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.test.tsx
@@ -4,6 +4,11 @@ import { act, configure, fireEvent, render } from "@testing-library/react";
 import { ICustomMessage } from "@concord-consortium/lara-interactive-api";
 import { DynamicTextTester } from "../../../test-utils/dynamic-text";
 import { MediaLibraryTester } from "../../../test-utils/media-library";
+import {
+  initializeOverrides,
+  resetOverridesForTesting,
+} from "../../../utilities/url-overrides/state";
+import { RegistryJson } from "../../../utilities/url-overrides/types";
 
 configure({ testIdAttribute: "data-cy" });
 
@@ -350,5 +355,63 @@ describe("IframeRuntime component", () => {
     });
     expect(global.confirm).toHaveBeenCalledTimes(1);
     expect(mockSetInteractiveState).toHaveBeenCalledTimes(5);
+  });
+
+  it("applies an active URL override to the iframe src (AP-115)", async () => {
+    const registry: RegistryJson = {
+      qi: {
+        prefix: "https://models-resources.concord.org/question-interactives/",
+        match: "(branch|version)/[^/]+/",
+        replace: "branch/${value}/",
+      },
+    };
+    resetOverridesForTesting();
+    await initializeOverrides({
+      fetchRegistry: async () => registry,
+      getSearch: () => "?override.qi=toolbar-accessibility",
+    });
+
+    const rawUrl =
+      "https://models-resources.concord.org/question-interactives/branch/master/image-question/index.html";
+    const overriddenUrl =
+      "https://models-resources.concord.org/question-interactives/branch/toolbar-accessibility/image-question/index.html";
+
+    const noop = jest.fn();
+    const testIframe = render(
+      <MediaLibraryTester>
+        <DynamicTextTester>
+          <IframeRuntime
+            url={rawUrl}
+            id={"123-Interactive"}
+            authoredState={null}
+            initialInteractiveState={null}
+            legacyLinkedInteractiveState={null}
+            setInteractiveState={noop}
+            setAspectRatio={noop}
+            setHeightFromInteractive={noop}
+            setSupportedFeatures={noop}
+            setNewHint={noop}
+            getFirebaseJWT={jest.fn(() => Promise.resolve("stub"))}
+            getAttachmentUrl={jest.fn(() => Promise.resolve({ url: "", requestId: 1 }))}
+            showModal={noop}
+            closeModal={noop}
+            setSendCustomMessage={noop}
+            setNavigation={noop}
+            log={noop}
+            iframeTitle="Interactive content"
+          />
+        </DynamicTextTester>
+      </MediaLibraryTester>
+    );
+    // allow the iframe-reload effect (which imperatively sets src) to run
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const iframe = testIframe.getByTestId("iframe-runtime").children[0] as HTMLIFrameElement;
+    expect(iframe.getAttribute("src")).toBe(overriddenUrl);
+    expect(iframe.getAttribute("src")).not.toBe(rawUrl);
+
+    resetOverridesForTesting();
   });
 });

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -424,7 +424,9 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
 
     if (iframeRef.current) {
       // Reload the iframe.
-      iframeRef.current.src = url;
+      // Apply URL overrides here too, to match the JSX src={applyOverrides(url)};
+      // otherwise this imperative assignment clobbers the overridden src with the raw url.
+      iframeRef.current.src = applyOverrides(url);
       // Re-init interactive, this time using a new mode (report or runtime).
       phoneRef.current = new iframePhone.ParentEndpoint(iframeRef.current, initInteractive);
       setSendCustomMessage((message: ICustomMessage) => {


### PR DESCRIPTION
## Problem

URL overrides (e.g. `?override.qi=toolbar-accessibility`) were parsed, compiled, and shown as active in the override banner, but the interactive iframe still loaded the **original** branch URL.

## Root cause

`IframeRuntime` sets the iframe `src` in two places:

- JSX: `src={applyOverrides(url)}` ✅ applies the override
- The iframe-reload effect (deps `[reloadCount, url]`): `iframeRef.current.src = url;` ❌ uses the **raw** url

The effect runs on mount and clobbers the overridden src set by the JSX, so the iframe always loaded the un-overridden URL.

This was verified in the deployed branch by inspecting the live iframe `src`: the override banner showed `override.qi = toolbar-accessibility` while the iframe `src` remained `…/branch/master/…`.

## Fix

Apply `applyOverrides(url)` in the effect's imperative assignment so it matches the JSX:

```diff
-      iframeRef.current.src = url;
+      iframeRef.current.src = applyOverrides(url);
```

## Tests

Added a component test in `iframe-runtime.test.tsx` that renders `IframeRuntime` with an active `override.qi` and asserts the iframe's DOM `src` reflects the override. It fails before the fix (`…/branch/master/…`) and passes after. All managed-interactive and url-overrides suites pass (54 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)