### PR TITLE
feat(AP-112): keyboard-operable hint trigger via accordion pattern

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
@@ -33,9 +33,17 @@ describe("ManagedInteractiveHeader hint trigger", () => {
     expect(trigger?.tagName).toBe("BUTTON");
   });
 
-  it("gives the icon-only trigger an accessible name via aria-label", () => {
-    const { trigger } = renderHeader();
-    expect(trigger?.getAttribute("aria-label")).toBeTruthy();
+  it("gives the trigger a stable, question-contextual accessible name", () => {
+    // The name stays stable across open/closed state; aria-expanded conveys state.
+    const collapsed = renderHeader({ showHint: false }).trigger;
+    expect(collapsed?.getAttribute("aria-label")).toBe("Hint for My question");
+    const expanded = renderHeader({ showHint: true }).trigger;
+    expect(expanded?.getAttribute("aria-label")).toBe("Hint for My question");
+  });
+
+  it("falls back to a generic hint label when there is no question name", () => {
+    const { trigger } = renderHeader({ questionName: "" });
+    expect(trigger?.getAttribute("aria-label")).toBe("Show hint");
   });
 
   it("reflects the collapsed state with aria-expanded='false'", () => {

--- a/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render } from "@testing-library/react";
+import React from "react";
+import { ManagedInteractiveHeader } from "./managed-interactive-header";
+import { DynamicTextTester } from "../../../test-utils/dynamic-text";
+
+const hintPanelId = "hint-panel-314-ManagedInteractive";
+
+const baseProps = {
+  questionNumber: 1,
+  questionName: "My question",
+  hint: "<p>this is a hint</p>",
+  showHint: false,
+  hintPanelId,
+  onToggleHint: jest.fn(),
+  hideHeader: false,
+};
+
+const renderHeader = (props: Partial<typeof baseProps> = {}) => {
+  const merged = { ...baseProps, ...props };
+  const { container } = render(
+    <DynamicTextTester>
+      <ManagedInteractiveHeader {...merged} />
+    </DynamicTextTester>
+  );
+  const trigger = container.querySelector<HTMLElement>("[data-cy='open-hint']");
+  return { container, trigger };
+};
+
+describe("ManagedInteractiveHeader hint trigger", () => {
+  it("renders the hint trigger as a native button element", () => {
+    const { trigger } = renderHeader();
+    expect(trigger).not.toBeNull();
+    expect(trigger?.tagName).toBe("BUTTON");
+  });
+
+  it("gives the icon-only trigger an accessible name via aria-label", () => {
+    const { trigger } = renderHeader();
+    expect(trigger?.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("reflects the collapsed state with aria-expanded='false'", () => {
+    const { trigger } = renderHeader({ showHint: false });
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("reflects the expanded state with aria-expanded='true'", () => {
+    const { trigger } = renderHeader({ showHint: true });
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("links the trigger to the hint panel with aria-controls", () => {
+    const { trigger } = renderHeader();
+    expect(trigger?.getAttribute("aria-controls")).toBe(hintPanelId);
+  });
+
+  it("calls onToggleHint when the trigger is activated", () => {
+    const onToggleHint = jest.fn();
+    const { trigger } = renderHeader({ onToggleHint });
+    fireEvent.click(trigger!);
+    expect(onToggleHint).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render a trigger when there is no hint", () => {
+    const { trigger } = renderHeader({ hint: "" });
+    expect(trigger).toBeNull();
+  });
+});

--- a/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
@@ -46,6 +46,11 @@ describe("ManagedInteractiveHeader hint trigger", () => {
     expect(trigger?.getAttribute("aria-label")).toBe("Show hint");
   });
 
+  it("trims surrounding whitespace from the question name in the accessible name", () => {
+    const { trigger } = renderHeader({ questionName: "  My question  " });
+    expect(trigger?.getAttribute("aria-label")).toBe("Hint for My question");
+  });
+
   it("reflects the collapsed state with aria-expanded='false'", () => {
     const { trigger } = renderHeader({ showHint: false });
     expect(trigger?.getAttribute("aria-expanded")).toBe("false");

--- a/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
@@ -15,11 +15,13 @@ interface IProps {
 export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, questionName, hint, showHint, hintPanelId, onToggleHint, hideHeader }) => {
   if (hideHeader) return null;
 
+  const trimmedQuestionName = questionName.trim();
+
   return (
     <div className="header">
       <DynamicText>
         {questionNumber && `Question #${questionNumber}`}
-        {questionName.trim().length > 0 && questionNumber && ": "}
+        {trimmedQuestionName.length > 0 && questionNumber && ": "}
         {questionName}
       </DynamicText>
       {hint && (
@@ -28,7 +30,7 @@ export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, que
           className="question-container"
           onClick={onToggleHint}
           data-cy="open-hint"
-          aria-label={questionName.trim() ? `Hint for ${questionName}` : "Show hint"}
+          aria-label={trimmedQuestionName ? `Hint for ${trimmedQuestionName}` : "Show hint"}
           aria-expanded={showHint}
           aria-controls={hintPanelId}
         >

--- a/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
@@ -28,7 +28,7 @@ export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, que
           className="question-container"
           onClick={onToggleHint}
           data-cy="open-hint"
-          aria-label={showHint ? "Hide hint" : "Show hint"}
+          aria-label={questionName.trim() ? `Hint for ${questionName}` : "Show hint"}
           aria-expanded={showHint}
           aria-controls={hintPanelId}
         >

--- a/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
@@ -6,11 +6,13 @@ interface IProps {
   questionNumber?: number;
   questionName: string;
   hint: string;
+  showHint: boolean;
+  hintPanelId: string;
   onToggleHint: () => void;
   hideHeader: boolean;
 }
 
-export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, questionName, hint, onToggleHint, hideHeader }) => {
+export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, questionName, hint, showHint, hintPanelId, onToggleHint, hideHeader }) => {
   if (hideHeader) return null;
 
   return (
@@ -21,14 +23,17 @@ export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, que
         {questionName}
       </DynamicText>
       {hint && (
-        <div
+        <button
+          type="button"
           className="question-container"
           onClick={onToggleHint}
           data-cy="open-hint"
-          tabIndex={0}
+          aria-label={showHint ? "Hide hint" : "Show hint"}
+          aria-expanded={showHint}
+          aria-controls={hintPanelId}
         >
           <IconQuestion className="question" height={22} width={22} />
-        </div>
+        </button>
       )}
     </div>
   );

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
@@ -1,0 +1,30 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { ManagedInteractiveHint } from "./managed-interactive-hint";
+import { DynamicTextTester } from "../../../test-utils/dynamic-text";
+
+const panelId = "hint-panel-314-ManagedInteractive";
+
+const renderHint = (props: Partial<React.ComponentProps<typeof ManagedInteractiveHint>> = {}) => {
+  const { container } = render(
+    <DynamicTextTester>
+      <ManagedInteractiveHint
+        hint="<p>this is a hint</p>"
+        showHint={true}
+        panelId={panelId}
+        onToggleHint={jest.fn()}
+        {...props}
+      />
+    </DynamicTextTester>
+  );
+  return { container };
+};
+
+describe("ManagedInteractiveHint panel", () => {
+  it("gives the panel the provided id so the trigger's aria-controls can reference it", () => {
+    const { container } = renderHint();
+    const panel = container.querySelector(`#${panelId}`);
+    expect(panel).not.toBeNull();
+    expect(panel?.classList.contains("hint-container")).toBe(true);
+  });
+});

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
@@ -27,4 +27,11 @@ describe("ManagedInteractiveHint panel", () => {
     expect(panel).not.toBeNull();
     expect(panel?.classList.contains("hint-container")).toBe(true);
   });
+
+  it("preserves the panel id even when showHint is false so aria-controls stays valid", () => {
+    const { container } = renderHint({ showHint: false });
+    const panel = container.querySelector(`#${panelId}`);
+    expect(panel).not.toBeNull();
+    expect(panel?.classList.contains("collapsed")).toBe(true);
+  });
 });

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.tsx
@@ -6,14 +6,15 @@ import IconArrowUp from "../../../assets/svg-icons/icon-arrow-up.svg";
 interface IProps {
   hint: string;
   showHint: boolean;
+  panelId: string;
   onToggleHint: () => void;
 }
 
-export const ManagedInteractiveHint: React.FC<IProps> = ({hint, showHint, onToggleHint}) => {
+export const ManagedInteractiveHint: React.FC<IProps> = ({hint, showHint, panelId, onToggleHint}) => {
   if (!hint) return null;
 
   return (
-    <div className={`hint-container ${showHint ? "" : "collapsed"}`}>
+    <div id={panelId} className={`hint-container ${showHint ? "" : "collapsed"}`}>
       <DynamicText>
         <div className="hint question-txt" data-cy="hint">
           {renderHTML(hint)}

--- a/src/components/activity-page/managed-interactive/managed-interactive.scss
+++ b/src/components/activity-page/managed-interactive/managed-interactive.scss
@@ -15,6 +15,8 @@
   height: 26px;
   width: 26px;
   margin: 5px;
+  padding: 0;
+  border: none;
   border-radius: 50%;
   background-color: white;
   cursor: pointer;

--- a/src/components/activity-page/managed-interactive/managed-interactive.scss
+++ b/src/components/activity-page/managed-interactive/managed-interactive.scss
@@ -21,6 +21,11 @@
   background-color: white;
   cursor: pointer;
 
+  &:focus-visible {
+    outline: 2px solid $cc-button-focus-ring;
+    outline-offset: 2px;
+  }
+
   .question {
     fill: $cc-charcoal;
   }

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -15,7 +15,6 @@ import { IManagedInteractive, IMwInteractive, IExportableAnswerMetadata, ILegacy
 import { createOrUpdateAnswer, watchAnswer, getLegacyLinkedInteractiveInfo, getAnswer, watchQuestionLevelFeedback } from "../../../firebase-db";
 import { handleGetFirebaseJWT } from "../../../portal-utils";
 import { getAnswerWithMetadata, getInteractiveInfo, hasLegacyLinkedInteractive, IInteractiveInfo, isQuestion, refIdToAnswersQuestionId } from "../../../utilities/embeddable-utils";
-import { accessibilityClick } from "../../../utilities/accessibility-helper";
 import { safeJsonParseIfString } from "../../../utilities/safe-json-parse";
 import { Lightbox } from "./lightbox";
 import { Logger, LogEventName } from "../../../lib/logger";
@@ -253,13 +252,11 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
     setShowHint(false);
   };
   const handleShowHint = () => {
-    if (accessibilityClick(event)) {
-      Logger.log({
-        event: LogEventName.toggle_hint,
-        parameters: { show_hint: !showHint, hint }
-      });
-      setShowHint(!showHint);
-    }
+    Logger.log({
+      event: LogEventName.toggle_hint,
+      parameters: { show_hint: !showHint, hint }
+    });
+    setShowHint(!showHint);
   };
 
   const handleCloseDialog = () => {
@@ -362,6 +359,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   const hasQuestionName = questionName.trim().length > 0;
   const isNotebookLayout = laraData.activity?.layout === ActivityLayouts.Notebook;
   const hideQuestionHeader = (props.hideQuestionNumbers || !hasQuestionNumber) && !hasQuestionName && !hint && !isNotebookLayout && !hasPluginRequiringHeader;
+  const hintPanelId = `hint-panel-${embeddableRefId}`;
 
   const isInteractive = embeddable.type === "MwInteractive";
   const isManagedInteractive = embeddable.type === "ManagedInteractive";
@@ -411,12 +409,15 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
         questionNumber={props.hideQuestionNumbers ? undefined : questionNumber}
         questionName={questionName}
         hint={hint}
+        showHint={showHint}
+        hintPanelId={hintPanelId}
         onToggleHint={handleShowHint}
         hideHeader={hideQuestionHeader}
       />
       <ManagedInteractiveHint
         hint={hint}
         showHint={showHint}
+        panelId={hintPanelId}
         onToggleHint={handleHintClose}
       />
       {clickToPlayOptions && !clickedToPlay

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -256,7 +256,9 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
       event: LogEventName.toggle_hint,
       parameters: { show_hint: !showHint, hint }
     });
-    setShowHint(!showHint);
+    // Functional update so the toggle is always derived from the latest state,
+    // independent of render/flush timing (future-proof against batched updates).
+    setShowHint(prevShowHint => !prevShowHint);
   };
 
   const handleCloseDialog = () => {


### PR DESCRIPTION
Note: PR #557 builds on this PR. For testing purposes, that branch build contains the fixes from both PRs.

## Summary

Makes the "?" help/info trigger in question headers fully keyboard operable using the ARIA disclosure/accordion pattern.

Jira: [AP-112](https://concord-consortium.atlassian.net/browse/AP-112) (epic AP-81 — VPAT Accessibility). Fixes audit issue #56, WCAG 2.1.1 (Level A).

Previously the trigger was a `<div tabIndex={0}>` with only an `onClick` handler, so it was focusable but **not operable** via the keyboard (Enter/Space did nothing), had no accessible name, and exposed no expand/collapse state.

## Changes

- **`?` trigger is now a native `<button>`** (`managed-interactive-header.tsx`) — keyboard operable (Enter/Space) for free, with:
  - `aria-label` — a stable, question-contextual name (`Hint for <question>`, falling back to `Show hint`)
  - `aria-expanded` — reflects the open/closed state
  - `aria-controls` — references the hint panel's id
- **Hint panel carries a unique `id`** (`managed-interactive-hint.tsx`) derived from the embeddable `ref_id`, so `aria-controls` always references a present, unique element (the panel stays mounted when collapsed).
- **Simplified `handleShowHint`** (`managed-interactive.tsx`) — dropped the fragile global-`event` / `accessibilityClick` check (and its now-unused import); the native button handles keyboard activation.
- **SCSS** (`managed-interactive.scss`) — reset `padding`/`border` so the button renders identically to the old div, and added an explicit `:focus-visible` outline (`$cc-button-focus-ring` #0957d0, ~6.6:1 on white) so focus is clearly visible — WCAG 2.4.7 / 1.4.11 (AA).

## Accessibility audit

Ran a full WCAG audit of the diff. The disclosure pattern conforms to the [W3C APG](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/) (native button, correct `aria-expanded`/`aria-controls`, no dangling reference, accessible name). The audit's actionable findings — focus indicator and accessible-name quality — are addressed in commit 2.

## Out of scope

The hint's collapse/close **chevron** (`IconArrowUp`) is a separate pre-existing issue tracked in **AP-96** ("Fix chevron button in Hint to use semantic button element with accessible name"). A comment documenting the exact element and defects was added there.

## Testing

- New unit tests for the header trigger (button semantics, `aria-label`, `aria-expanded` true/false, `aria-controls` linkage, activation, fallback label) and the hint panel id. Written test-first (TDD).
- Full Jest suite: **364 passing**, lint clean, SCSS compiles.
- Existing Cypress `[data-cy=open-hint].click()` interactions still work (the button keeps `data-cy="open-hint"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-112]: https://concord-consortium.atlassian.net/browse/AP-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ