### PR TITLE
feat(AP-96): semantic keyboard-operable hint close button

### DIFF
--- a/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
@@ -68,6 +68,12 @@ describe("ManagedInteractiveHeader hint trigger", () => {
     expect(onToggleHint).toHaveBeenCalledTimes(1);
   });
 
+  it("hides the decorative question icon from assistive technology", () => {
+    const { trigger } = renderHeader();
+    const icon = trigger?.querySelector("[aria-hidden='true']");
+    expect(icon).not.toBeNull();
+  });
+
   it("does not render a trigger when there is no hint", () => {
     const { trigger } = renderHeader({ hint: "" });
     expect(trigger).toBeNull();

--- a/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
@@ -8,11 +8,12 @@ interface IProps {
   hint: string;
   showHint: boolean;
   hintPanelId: string;
+  triggerRef?: React.Ref<HTMLButtonElement>;
   onToggleHint: () => void;
   hideHeader: boolean;
 }
 
-export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, questionName, hint, showHint, hintPanelId, onToggleHint, hideHeader }) => {
+export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, questionName, hint, showHint, hintPanelId, triggerRef, onToggleHint, hideHeader }) => {
   if (hideHeader) return null;
 
   return (
@@ -24,6 +25,7 @@ export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, que
       </DynamicText>
       {hint && (
         <button
+          ref={triggerRef}
           type="button"
           className="question-container"
           onClick={onToggleHint}
@@ -32,7 +34,7 @@ export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, que
           aria-expanded={showHint}
           aria-controls={hintPanelId}
         >
-          <IconQuestion className="question" height={22} width={22} />
+          <IconQuestion className="question" height={22} width={22} aria-hidden="true" focusable="false" />
         </button>
       )}
     </div>

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
@@ -12,6 +12,7 @@ const renderHint = (props: Partial<React.ComponentProps<typeof ManagedInteractiv
         hint="<p>this is a hint</p>"
         showHint={true}
         panelId={panelId}
+        questionName="My question"
         onToggleHint={jest.fn()}
         {...props}
       />
@@ -37,10 +38,23 @@ describe("ManagedInteractiveHint close control", () => {
     expect(close?.tagName).toBe("BUTTON");
   });
 
-  it("gives the close button an accessible name via aria-label", () => {
+  it("gives the close button a question-contextual accessible name", () => {
     const { container } = renderHint();
     const close = container.querySelector("[data-cy='close-hint']");
-    expect(close?.getAttribute("aria-label")).toBeTruthy();
+    expect(close?.getAttribute("aria-label")).toBe("Hide hint for My question");
+  });
+
+  it("falls back to a generic close label when there is no question name", () => {
+    const { container } = renderHint({ questionName: "" });
+    const close = container.querySelector("[data-cy='close-hint']");
+    expect(close?.getAttribute("aria-label")).toBe("Hide hint");
+  });
+
+  it("hides the decorative chevron icon from assistive technology", () => {
+    const { container } = renderHint();
+    const close = container.querySelector("[data-cy='close-hint']");
+    const icon = close?.querySelector("[aria-hidden='true']");
+    expect(icon).not.toBeNull();
   });
 
   it("calls onToggleHint when the close button is activated", () => {

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
@@ -50,6 +50,12 @@ describe("ManagedInteractiveHint close control", () => {
     expect(close?.getAttribute("aria-label")).toBe("Hide hint");
   });
 
+  it("trims surrounding whitespace from the question name in the accessible name", () => {
+    const { container } = renderHint({ questionName: "  My question  " });
+    const close = container.querySelector("[data-cy='close-hint']");
+    expect(close?.getAttribute("aria-label")).toBe("Hide hint for My question");
+  });
+
   it("hides the decorative chevron icon from assistive technology", () => {
     const { container } = renderHint();
     const close = container.querySelector("[data-cy='close-hint']");

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { ManagedInteractiveHint } from "./managed-interactive-hint";
 import { DynamicTextTester } from "../../../test-utils/dynamic-text";
@@ -26,5 +26,28 @@ describe("ManagedInteractiveHint panel", () => {
     const panel = container.querySelector(`#${panelId}`);
     expect(panel).not.toBeNull();
     expect(panel?.classList.contains("hint-container")).toBe(true);
+  });
+});
+
+describe("ManagedInteractiveHint close control", () => {
+  it("renders the close control as a native button element", () => {
+    const { container } = renderHint();
+    const close = container.querySelector("[data-cy='close-hint']");
+    expect(close).not.toBeNull();
+    expect(close?.tagName).toBe("BUTTON");
+  });
+
+  it("gives the close button an accessible name via aria-label", () => {
+    const { container } = renderHint();
+    const close = container.querySelector("[data-cy='close-hint']");
+    expect(close?.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("calls onToggleHint when the close button is activated", () => {
+    const onToggleHint = jest.fn();
+    const { container } = renderHint({ onToggleHint });
+    const close = container.querySelector<HTMLElement>("[data-cy='close-hint']");
+    fireEvent.click(close!);
+    expect(onToggleHint).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.tsx
@@ -14,6 +14,8 @@ interface IProps {
 export const ManagedInteractiveHint: React.FC<IProps> = ({hint, showHint, panelId, questionName, onToggleHint}) => {
   if (!hint) return null;
 
+  const trimmedQuestionName = questionName.trim();
+
   return (
     <div id={panelId} className={`hint-container ${showHint ? "" : "collapsed"}`}>
       <DynamicText>
@@ -27,7 +29,7 @@ export const ManagedInteractiveHint: React.FC<IProps> = ({hint, showHint, panelI
           className="close-button"
           onClick={onToggleHint}
           data-cy="close-hint"
-          aria-label={questionName.trim() ? `Hide hint for ${questionName}` : "Hide hint"}
+          aria-label={trimmedQuestionName ? `Hide hint for ${trimmedQuestionName}` : "Hide hint"}
         >
           <IconArrowUp className="close" width={26} height={26} aria-hidden="true" focusable="false" />
         </button>

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.tsx
@@ -7,10 +7,11 @@ interface IProps {
   hint: string;
   showHint: boolean;
   panelId: string;
+  questionName: string;
   onToggleHint: () => void;
 }
 
-export const ManagedInteractiveHint: React.FC<IProps> = ({hint, showHint, panelId, onToggleHint}) => {
+export const ManagedInteractiveHint: React.FC<IProps> = ({hint, showHint, panelId, questionName, onToggleHint}) => {
   if (!hint) return null;
 
   return (
@@ -26,9 +27,9 @@ export const ManagedInteractiveHint: React.FC<IProps> = ({hint, showHint, panelI
           className="close-button"
           onClick={onToggleHint}
           data-cy="close-hint"
-          aria-label="Hide hint"
+          aria-label={questionName.trim() ? `Hide hint for ${questionName}` : "Hide hint"}
         >
-          <IconArrowUp className="close" width={26} height={26} />
+          <IconArrowUp className="close" width={26} height={26} aria-hidden="true" focusable="false" />
         </button>
       </div>
     </div>

--- a/src/components/activity-page/managed-interactive/managed-interactive-hint.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-hint.tsx
@@ -21,15 +21,15 @@ export const ManagedInteractiveHint: React.FC<IProps> = ({hint, showHint, panelI
         </div>
       </DynamicText>
       <div className="close-container">
-        <IconArrowUp
-          className={"close"}
-          width={26}
-          height={26}
+        <button
+          type="button"
+          className="close-button"
           onClick={onToggleHint}
-          onKeyDown={onToggleHint}
           data-cy="close-hint"
-          tabIndex={0}
-        />
+          aria-label="Hide hint"
+        >
+          <IconArrowUp className="close" width={26} height={26} />
+        </button>
       </div>
     </div>
   );

--- a/src/components/activity-page/managed-interactive/managed-interactive.scss
+++ b/src/components/activity-page/managed-interactive/managed-interactive.scss
@@ -50,9 +50,20 @@
     justify-content: center;
     align-items: center;
     width: 100%;
+    .close-button {
+      display: flex;
+      padding: 0;
+      border: none;
+      background: none;
+      cursor: pointer;
+
+      &:focus-visible {
+        outline: 2px solid $cc-button-focus-ring;
+        outline-offset: 2px;
+      }
+    }
     .close {
       fill: $cc-charcoal;
-      cursor: pointer;
     }
   }
 }

--- a/src/components/activity-page/managed-interactive/managed-interactive.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.test.tsx
@@ -1,5 +1,5 @@
 import { Credentials, Resource } from "@concord-consortium/token-service";
-import { act, configure, render, screen } from "@testing-library/react";
+import { act, configure, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { ManagedInteractive } from "./managed-interactive";
 import { EmbeddableType, IMwInteractive } from "../../../types";
@@ -431,6 +431,44 @@ describe("ManagedInteractive component", () => {
 
     // allow initialization to complete
     jest.runAllTimers();
+  });
+
+  it("returns focus to the hint trigger when the hint is closed via the close button", async () => {
+    const sampleEmbeddable: IMwInteractive = {
+      type: "MwInteractive",
+      name: "interactive with a hint",
+      is_hidden: false,
+      ref_id: "hint-focus-test",
+    };
+
+    render(<DynamicTextTester><ManagedInteractive
+              embeddable={sampleEmbeddable}
+              questionNumber={1}
+              setSupportedFeatures={mockSetSupportedFeatures}
+              setSendCustomMessage={mockSetSendCustomMessage}
+              setNavigation={mockSetNavigation}
+              showQuestionPrefix={true}
+              />
+           </DynamicTextTester>);
+    // allow initialization to complete
+    jest.runAllTimers();
+
+    // the interactive reports a hint, which surfaces the "?" trigger and hint panel
+    act(() => {
+      dispatchMessageFromChild("hint", { text: "<p>this is a hint</p>" });
+    });
+
+    const openHint = screen.getByTestId("open-hint");
+    act(() => {
+      fireEvent.click(openHint);
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("close-hint"));
+    });
+
+    // focus should return to the "?" trigger rather than falling back to <body>
+    expect(document.activeElement).toBe(screen.getByTestId("open-hint"));
   });
 
 });

--- a/src/components/activity-page/managed-interactive/managed-interactive.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive.tsx
@@ -84,6 +84,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
   const [loadingLegacyLinkedInteractiveState, setLoadingLegacyLinkedInteractiveState] = useState(shouldLoadLegacyLinkedInteractiveState);
   const interactiveInfo = useRef<IInteractiveInfo | undefined>(undefined);
   const headerTarget = React.useRef(null);
+  const hintTriggerRef = useRef<HTMLButtonElement>(null);
   const divTarget = React.useRef<HTMLDivElement>(null);
   const divSize = useSize(divTarget);
   const headerSize = useSize(headerTarget);
@@ -250,6 +251,9 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
       parameters: { show_hint: false, hint }
     });
     setShowHint(false);
+    // Return focus to the "?" trigger so keyboard users aren't dropped to <body>
+    // when the panel that contained the close button collapses.
+    hintTriggerRef.current?.focus();
   };
   const handleShowHint = () => {
     Logger.log({
@@ -411,6 +415,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
         hint={hint}
         showHint={showHint}
         hintPanelId={hintPanelId}
+        triggerRef={hintTriggerRef}
         onToggleHint={handleShowHint}
         hideHeader={hideQuestionHeader}
       />
@@ -418,6 +423,7 @@ export const ManagedInteractive: React.ForwardRefExoticComponent<IProps> = forwa
         hint={hint}
         showHint={showHint}
         panelId={hintPanelId}
+        questionName={questionName}
         onToggleHint={handleHintClose}
       />
       {clickToPlayOptions && !clickedToPlay


### PR DESCRIPTION
## Summary

Makes the hint container's collapse/close **chevron** a proper semantic, keyboard-operable button — the companion fix to the "?" hint trigger in #556.

Jira: [AP-96](https://concord-consortium.atlassian.net/browse/AP-96) (epic AP-81 — VPAT Accessibility). Fixes audit issues #51–#54, WCAG 4.1.2 (Level A).

> **Base branch:** this PR targets `AP-112-hint-button-keyboard-accordion` (#556), so the diff shown is only the AP-96 work. It will retarget to `master` automatically once #556 merges.

Previously the chevron was an `<IconArrowUp>` SVG with `tabIndex={0}` and `onClick`/`onKeyDown`, so it had no accessible name and its `onKeyDown` fired on **any** key — e.g. pressing Tab to leave the panel collapsed it.

## Changes

- **Chevron is now a native `<button>`** (`managed-interactive-hint.tsx`) wrapping the (decorative) icon — keyboard operable (Enter/Space) with a proper role. Since it's a shared component, this covers all audited pages (2, 4, 5, 6) at once.
- **Accessible name** — `aria-label` is `Hide hint for <question>` (fallback `Hide hint`), consistent with the AP-112 trigger so multiple hints on a page are distinguishable to screen-reader users.
- **Focus management** — closing the hint via this button returns focus to the "?" trigger (a `triggerRef` threaded to the header button, focused in `handleHintClose`) instead of dropping focus to `<body>` (WCAG 2.4.3).
- **Decorative icons hidden** — `aria-hidden="true" focusable="false"` on both `IconArrowUp` and `IconQuestion` so they can never leak an accessible name (WCAG 1.1.1, defensive).
- **SCSS** — `.close-button` resets + a `:focus-visible` ring matching the AP-112 trigger convention (`$cc-button-focus-ring` #0957d0 ≈ 5.86:1 on the #f5f5f5 panel — passes 1.4.11). `data-cy="close-hint"` preserved.

## Accessibility audit

Ran a full WCAG audit of the diff. The core fix (semantic button, role/name, keyboard, focus-ring contrast) is conformant; the audit's actionable findings — contextual accessible name (M-1), focus return (M-2), and hidden decorative icons (L-1) — are all addressed in commit 2.

## Testing

- New unit/integration tests (TDD): close control is a `<button>`, contextual + fallback accessible name, decorative icons hidden, and an integration test asserting focus returns to the "?" trigger after closing via the chevron.
- Full Jest suite: **371 passing**, lint clean, SCSS compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-96]: https://concord-consortium.atlassian.net/browse/AP-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ