### PR TITLE
feat(AP-84): add semantic landmark regions to activity player pages

### DIFF
--- a/src/components/activity-completion/completion-page-content.test.tsx
+++ b/src/components/activity-completion/completion-page-content.test.tsx
@@ -1,9 +1,18 @@
 import React from "react";
 import { CompletionPageContent } from "./completion-page-content";
 import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { Activity } from "../../types";
 import _activityPlugins from "../../data/version-2/sample-new-sections-multiple-layout-types.json";
 import { DynamicTextTester } from "../../test-utils/dynamic-text";
+
+// The full RTL render runs the answer/feedback watcher effects, so stub
+// firebase-db (same approach as nav-pages.test.tsx). With no answers delivered,
+// the component renders its "Fetching your data" state, which still has a <main>.
+jest.mock("../../firebase-db", () => ({
+  watchAllAnswers: jest.fn(() => jest.fn()),
+  watchQuestionLevelFeedback: jest.fn(() => jest.fn()),
+}));
 
 const activityPlugins = _activityPlugins as unknown as Activity;
 
@@ -24,5 +33,20 @@ describe("Completion Page Content component", () => {
     expect(wrapperComplete.html()).toContain('data-cy="completion-page-content"');
     expect(wrapperComplete.html()).toContain('data-cy="progress-container"');
     expect(wrapperComplete.html()).toContain("Fetching your data");
+  });
+  it("exposes a single main landmark", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    render(
+      <DynamicTextTester>
+        <CompletionPageContent
+          activity={activityPlugins}
+          activityName={"test"}
+          onPageChange={stubFunction}
+        />
+      </DynamicTextTester>
+    );
+    expect(screen.getByRole("main")).toBeInTheDocument();
   });
 });

--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -143,14 +143,14 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
 
   return (
     !answers
-      ? <div className="completion-page-content" data-cy="completion-page-content">
+      ? <main className="completion-page-content" data-cy="completion-page-content">
           <div className="progress-container" data-cy="progress-container">
             <div className="progress-text">
               <DynamicText>Fetching your data ...</DynamicText>
             </div>
           </div>
-        </div>
-      : <div className="completion-page-content" data-cy="completion-page-content">
+        </main>
+      : <main className="completion-page-content" data-cy="completion-page-content">
           <div className="banners">
             <div className={`progress-container ${!isActivityComplete ? "incomplete" : ""}`} data-cy="progress-container">
               {isActivityComplete
@@ -191,6 +191,6 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
               </div>
             }
           </div>
-        </div>
+        </main>
   );
 };

--- a/src/components/activity-header/activity-nav.test.tsx
+++ b/src/components/activity-header/activity-nav.test.tsx
@@ -35,7 +35,7 @@ describe("Activity Nav Header component", () => {
     expect(screen.getByRole("navigation", { name: "Page navigation" })).toBeInTheDocument();
   });
   it("honors a custom ariaLabel (used to distinguish the bottom nav)", () => {
-    render(<ActivityNav activityPages={activityPages} currentPage={0} onPageChange={stubFunction} singlePage={false} ariaLabel="Page navigation, bottom" />);
-    expect(screen.getByRole("navigation", { name: "Page navigation, bottom" })).toBeInTheDocument();
+    render(<ActivityNav activityPages={activityPages} currentPage={0} onPageChange={stubFunction} singlePage={false} ariaLabel="Page navigation (bottom)" />);
+    expect(screen.getByRole("navigation", { name: "Page navigation (bottom)" })).toBeInTheDocument();
   });
 });

--- a/src/components/activity-header/activity-nav.test.tsx
+++ b/src/components/activity-header/activity-nav.test.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 import { ActivityNav } from "./activity-nav";
 import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { DefaultTestPage } from "../../test-utils/model-for-tests";
 import { NavPages } from "./nav-pages";
+
+// NavPages subscribes to feedback watchers; the full RTL render below runs those
+// effects, so stub firebase-db (same approach as nav-pages.test.tsx).
+jest.mock("../../firebase-db", () => ({
+  watchActivityLevelFeedback: jest.fn(() => jest.fn()),
+  watchQuestionLevelFeedback: jest.fn(() => jest.fn()),
+}));
 
 const stubFunction = () => {
   // do nothing.
@@ -21,5 +29,13 @@ describe("Activity Nav Header component", () => {
       onPageChange={stubFunction}
       currentPage={0}
     />)).toEqual(true);
+  });
+  it("exposes a navigation landmark with the default label", () => {
+    render(<ActivityNav activityPages={activityPages} currentPage={0} onPageChange={stubFunction} singlePage={false} />);
+    expect(screen.getByRole("navigation", { name: "Page navigation" })).toBeInTheDocument();
+  });
+  it("honors a custom ariaLabel (used to distinguish the bottom nav)", () => {
+    render(<ActivityNav activityPages={activityPages} currentPage={0} onPageChange={stubFunction} singlePage={false} ariaLabel="Page navigation, bottom" />);
+    expect(screen.getByRole("navigation", { name: "Page navigation, bottom" })).toBeInTheDocument();
   });
 });

--- a/src/components/activity-header/activity-nav.test.tsx
+++ b/src/components/activity-header/activity-nav.test.tsx
@@ -38,4 +38,8 @@ describe("Activity Nav Header component", () => {
     render(<ActivityNav activityPages={activityPages} currentPage={0} onPageChange={stubFunction} singlePage={false} ariaLabel="Page navigation (bottom)" />);
     expect(screen.getByRole("navigation", { name: "Page navigation (bottom)" })).toBeInTheDocument();
   });
+  it("does not emit an (empty) navigation landmark in single-page layouts", () => {
+    render(<ActivityNav activityPages={activityPages} currentPage={0} onPageChange={stubFunction} singlePage={true} />);
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/activity-header/activity-nav.tsx
+++ b/src/components/activity-header/activity-nav.tsx
@@ -22,20 +22,25 @@ export class ActivityNav extends React.PureComponent <IProps> {
   render() {
     const { activityId, activityPages, currentPage, fullWidth, lockForwardNav, onPageChange, singlePage, usePageNames,
             hideNextPrevButtons, isSequence, ariaLabel = "Page navigation" } = this.props;
+    // Single-page layouts have no page-navigation UI, so don't emit an empty
+    // navigation landmark (it would confuse screen readers and fail landmark
+    // audits). Keep a plain wrapper div to preserve layout, matching the
+    // pre-landmark markup.
+    if (singlePage) {
+      return <div className={`activity-nav ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header" />;
+    }
     return (
       <nav className={`activity-nav ${fullWidth ? "full" : ""}`} aria-label={ariaLabel} data-cy="activity-nav-header">
-        { !singlePage &&
-          <NavPages
-            activityId={activityId}
-            pages={activityPages}
-            onPageChange={onPageChange}
-            currentPage={currentPage}
-            lockForwardNav={lockForwardNav}
-            usePageNames={usePageNames}
-            hideNextPrevButtons={hideNextPrevButtons}
-            isSequence={isSequence}
-          />
-        }
+        <NavPages
+          activityId={activityId}
+          pages={activityPages}
+          onPageChange={onPageChange}
+          currentPage={currentPage}
+          lockForwardNav={lockForwardNav}
+          usePageNames={usePageNames}
+          hideNextPrevButtons={hideNextPrevButtons}
+          isSequence={isSequence}
+        />
       </nav>
     );
   }

--- a/src/components/activity-header/activity-nav.tsx
+++ b/src/components/activity-header/activity-nav.tsx
@@ -15,14 +15,15 @@ interface IProps {
   usePageNames?: boolean;
   hideNextPrevButtons?: boolean;
   isSequence?: boolean;
+  ariaLabel?: string;
 }
 
 export class ActivityNav extends React.PureComponent <IProps> {
   render() {
     const { activityId, activityPages, currentPage, fullWidth, lockForwardNav, onPageChange, singlePage, usePageNames,
-            hideNextPrevButtons, isSequence } = this.props;
+            hideNextPrevButtons, isSequence, ariaLabel = "Page navigation" } = this.props;
     return (
-      <div className={`activity-nav ${fullWidth ? "full" : ""}`} data-cy="activity-nav-header">
+      <nav className={`activity-nav ${fullWidth ? "full" : ""}`} aria-label={ariaLabel} data-cy="activity-nav-header">
         { !singlePage &&
           <NavPages
             activityId={activityId}
@@ -35,7 +36,7 @@ export class ActivityNav extends React.PureComponent <IProps> {
             isSequence={isSequence}
           />
         }
-      </div>
+      </nav>
     );
   }
 }

--- a/src/components/activity-header/header.test.tsx
+++ b/src/components/activity-header/header.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Header } from "./header";
 import { AccountOwner } from "./account-owner";
 import { mount, shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { Logo } from "./logo";
 import { DynamicTextTester } from "../../test-utils/dynamic-text";
 
@@ -60,5 +61,9 @@ describe("Header component", () => {
       const wrapperHeader = shallow(<Header project={project1} userName={user} contentName={"test activity"} />);
       expect(wrapperHeader.containsMatchingElement(accountOwner)).toEqual(true);
       expect(wrapperAccountOwner.text()).toContain(user);
+  });
+  it("exposes a banner landmark", () => {
+    render(<DynamicTextTester><Header project={project1} userName={"test student"} contentName={"test activity"} /></DynamicTextTester>);
+    expect(screen.getByRole("banner")).toBeInTheDocument();
   });
 });

--- a/src/components/activity-header/header.tsx
+++ b/src/components/activity-header/header.tsx
@@ -24,7 +24,7 @@ export class Header extends React.PureComponent<IProps> {
     const logo = project?.logo_ap;
     const projectURL = project?.url || ccLogoLink;
     return (
-      <div className={`activity-header ${showSequence ? "in-sequence" : ""}`} data-cy="activity-header">
+      <header className={`activity-header ${showSequence ? "in-sequence" : ""}`} data-cy="activity-header">
         <div className={`inner ${fullWidth ? "full" : ""}`}>
           <div className="header-left">
             <Logo logo={logo} url={projectURL} />
@@ -40,7 +40,7 @@ export class Header extends React.PureComponent<IProps> {
             <AccountOwner userName={userName} />
           </div>
         </div>
-      </div>
+      </header>
     );
   }
 

--- a/src/components/activity-header/sequence-nav.test.tsx
+++ b/src/components/activity-header/sequence-nav.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SequenceNav } from "./sequence-nav";
 import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { CustomSelect } from "../custom-select";
 
 const stubFunction = () => {
@@ -18,5 +19,9 @@ describe("Sequence Nav Header component", () => {
     expect(wrapper.find('[data-cy="sequence-nav-header"]').length).toBe(1);
     expect(wrapper.text()).toContain("Activity:");
     expect(wrapper.find(CustomSelect)).toHaveLength(1);
+  });
+  it("exposes a navigation landmark labeled 'Activity selection'", () => {
+    render(<SequenceNav activities={activities} currentActivity={"activity1"} onActivityChange={stubFunction} />);
+    expect(screen.getByRole("navigation", { name: "Activity selection" })).toBeInTheDocument();
   });
 });

--- a/src/components/activity-header/sequence-nav.tsx
+++ b/src/components/activity-header/sequence-nav.tsx
@@ -16,7 +16,7 @@ export class SequenceNav extends React.PureComponent <IProps> {
   render() {
     const { activities, fullWidth, currentActivity } = this.props;
     return (
-      <div className={`sequence-nav ${fullWidth ? "full" : ""}`} data-cy="sequence-nav-header">
+      <nav className={`sequence-nav ${fullWidth ? "full" : ""}`} aria-label="Activity selection" data-cy="sequence-nav-header">
         <div className="select-label">Activity:</div>
         { activities &&
           <CustomSelect
@@ -26,7 +26,7 @@ export class SequenceNav extends React.PureComponent <IProps> {
             onSelectItem={this.handleSelect}
           />
         }
-      </div>
+      </nav>
     );
   }
 

--- a/src/components/activity-introduction/footer.test.tsx
+++ b/src/components/activity-introduction/footer.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Footer } from "./footer";
 import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 
 describe("Footer component", () => {
   const aboutText = "This is a test project.";
@@ -70,5 +71,9 @@ describe("Footer component", () => {
     const defaultFooterText = `Copyright © ${currentYear} The Concord Consortium. All rights reserved. This material is licensed under a Creative Commons Attribution 4.0 License. The software is licensed under Simplified BSD, MIT or Apache 2.0 licenses. Please provide attribution to the Concord Consortium and the URL https://concord.org.`;
     const wrapper = shallow(<Footer fullWidth={true} project={null} />);
     expect(wrapper.text()).toContain(defaultFooterText);
+  });
+  it("exposes a contentinfo landmark", () => {
+    render(<Footer fullWidth={true} project={null} />);
+    expect(screen.getByRole("contentinfo")).toBeInTheDocument();
   });
 });

--- a/src/components/activity-introduction/footer.tsx
+++ b/src/components/activity-introduction/footer.tsx
@@ -33,14 +33,14 @@ export class Footer extends React.PureComponent<IProps> {
     const contactContent = contactEmail ? this.buildContactContent(contactEmail) : null;
 
     return (
-      <div className="footer" data-cy="footer">
+      <footer className="footer" data-cy="footer">
         <div className={`inner ${fullWidth ? "full" : ""}`}>
           <div className="footer-text">
             {mainFooterContent}
             {contactContent}
           </div>
         </div>
-      </div>
+      </footer>
     );
   }
 

--- a/src/components/activity-introduction/introduction-page-content.test.tsx
+++ b/src/components/activity-introduction/introduction-page-content.test.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { IntroductionPageContent } from "./introduction-page-content";
 import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { DefaultTestActivity } from "../../test-utils/model-for-tests";
+import { DynamicTextTester } from "../../test-utils/dynamic-text";
 
 describe("Introduction Page Content component", () => {
   it("renders component", () => {
@@ -10,5 +12,12 @@ describe("Introduction Page Content component", () => {
     };
     const wrapper = shallow(<IntroductionPageContent activity={DefaultTestActivity} onPageChange={stubFunction} />);
     expect(wrapper.find('[data-cy="intro-page-content"]').length).toBe(1);
+  });
+  it("exposes a single main landmark", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    render(<DynamicTextTester><IntroductionPageContent activity={DefaultTestActivity} onPageChange={stubFunction} /></DynamicTextTester>);
+    expect(screen.getByRole("main")).toBeInTheDocument();
   });
 });

--- a/src/components/activity-introduction/introduction-page-content.tsx
+++ b/src/components/activity-introduction/introduction-page-content.tsx
@@ -31,7 +31,7 @@ export const IntroductionPageContent: React.FC<IProps> = (props) => {
   }, [activity.id, isSequence]);
 
   return (
-    <div className="intro-content" data-cy="intro-page-content">
+    <main className="intro-content" data-cy="intro-page-content">
       <div className="introduction">
         <ActivitySummary
           activityName={activity.name}
@@ -51,6 +51,6 @@ export const IntroductionPageContent: React.FC<IProps> = (props) => {
           <IntroPageActivityLevelFeedback teacherFeedback={feedback} />
         )
       }
-    </div>
+    </main>
   );
 };

--- a/src/components/activity-page/activity-page-content.test.tsx
+++ b/src/components/activity-page/activity-page-content.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ActivityPageContent } from "./activity-page-content";
-import { configure, render } from "@testing-library/react";
+import { configure, render, screen } from "@testing-library/react";
 import { DefaultTestPage, DefaultTestActivity } from "../../test-utils/model-for-tests";
 import { DynamicTextTester } from "../../test-utils/dynamic-text";
 
@@ -30,6 +30,24 @@ describe("Activity Page Content component", () => {
 
     const notifications = queryAllByTestId("page-change-notification");
     expect(notifications.length).toBe(0);
+  });
+
+  it("exposes a single main landmark", () => {
+    render(
+      <DynamicTextTester>
+        <ActivityPageContent
+          enableReportButton={false}
+          activityLayout={0}
+          page={page}
+          pageNumber={5}
+          activity={DefaultTestActivity}
+          totalPreviousQuestions={5}
+          setNavigation={stubFunction}
+          pluginsLoaded={true}
+        />
+      </DynamicTextTester>
+    );
+    expect(screen.getAllByRole("main")).toHaveLength(1);
   });
 
   describe("with page change notification", () => {

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -119,7 +119,7 @@ export class ActivityPageContent extends React.Component<IProps, IState> {
       <>
         {page.is_hidden && this.renderHiddenWarningBanner()}
         {this.renderPageChangeNotification()}
-        <div className={`page-content full ${isResponsiveLayout ? "responsive" : ""}`} data-cy="page-content">
+        <main className={`page-content full ${isResponsiveLayout ? "responsive" : ""}`} data-cy="page-content">
           <div className={headerClass}>
             <div className="name"><DynamicText>{pageTitle}</DynamicText></div>
             <ReadAloudToggle />
@@ -134,7 +134,7 @@ export class ActivityPageContent extends React.Component<IProps, IState> {
               onGenerateReport={this.handleReport}
             />
           }
-        </div>
+        </main>
         {this.renderPageChangeNotification()}
       </>
     );

--- a/src/components/app.test.tsx
+++ b/src/components/app.test.tsx
@@ -38,6 +38,9 @@ describe("App component", () => {
     expect(wrapper.find('[data-cy="app"]').length).toBe(1);
     wrapper.setState({ activity });
     expect(wrapper.find(ActivityNav).length).toBe(2);
+    // The top and bottom page-nav landmarks must have distinct accessible names (AP-84)
+    expect(wrapper.find(ActivityNav).at(0).prop("ariaLabel")).toBe("Page navigation");
+    expect(wrapper.find(ActivityNav).at(1).prop("ariaLabel")).toBe("Page navigation, bottom");
     expect(wrapper.find(Header).length).toBe(1);
     expect(wrapper.find(Footer).length).toBe(1);
   });

--- a/src/components/app.test.tsx
+++ b/src/components/app.test.tsx
@@ -40,7 +40,7 @@ describe("App component", () => {
     expect(wrapper.find(ActivityNav).length).toBe(2);
     // The top and bottom page-nav landmarks must have distinct accessible names (AP-84)
     expect(wrapper.find(ActivityNav).at(0).prop("ariaLabel")).toBe("Page navigation");
-    expect(wrapper.find(ActivityNav).at(1).prop("ariaLabel")).toBe("Page navigation, bottom");
+    expect(wrapper.find(ActivityNav).at(1).prop("ariaLabel")).toBe("Page navigation (bottom)");
     expect(wrapper.find(Header).length).toBe(1);
     expect(wrapper.find(Footer).length).toBe(1);
   });

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -642,7 +642,7 @@ export class App extends React.PureComponent<IProps, IState> {
               />
         }
         {renderBottomNav &&
-          this.renderNav(activity, currentPage, fullWidth, "Page navigation, bottom")
+          this.renderNav(activity, currentPage, fullWidth, "Page navigation (bottom)")
         }
       </>
     );

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -615,7 +615,7 @@ export class App extends React.PureComponent<IProps, IState> {
       <>
         {this.state.sequence && this.renderSequenceNav(fullWidth)}
         {renderTopNav &&
-          this.renderNav(activity, currentPage, fullWidth)
+          this.renderNav(activity, currentPage, fullWidth, "Page navigation")
         }
         {activity.layout === ActivityLayouts.SinglePage
           ? this.renderSinglePageContent(activity)
@@ -642,13 +642,13 @@ export class App extends React.PureComponent<IProps, IState> {
               />
         }
         {renderBottomNav &&
-          this.renderNav(activity, currentPage, fullWidth)
+          this.renderNav(activity, currentPage, fullWidth, "Page navigation, bottom")
         }
       </>
     );
   }
 
-  private renderNav = (activity: Activity, currentPage: number, fullWidth: boolean) => {
+  private renderNav = (activity: Activity, currentPage: number, fullWidth: boolean, ariaLabel?: string) => {
     const isNotebook = activity.layout === ActivityLayouts.Notebook;
 
     return (
@@ -663,6 +663,7 @@ export class App extends React.PureComponent<IProps, IState> {
         usePageNames={isNotebook}
         hideNextPrevButtons={isNotebook}
         isSequence={!!this.state.sequence}
+        ariaLabel={ariaLabel}
       />
     );
   }

--- a/src/components/sequence-introduction/sequence-page-content.test.tsx
+++ b/src/components/sequence-introduction/sequence-page-content.test.tsx
@@ -1,8 +1,17 @@
 import React from "react";
 import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { SequencePageContent } from "./sequence-page-content";
 import { Sequence } from "../../types";
 import _sequence from "../../data/version-2/sample-new-sections-sequence.json";
+import { DynamicTextTester } from "../../test-utils/dynamic-text";
+
+// SequencePageContent subscribes to feedback watchers in effects that the full
+// RTL render runs, so stub firebase-db (same approach as nav-pages.test.tsx).
+jest.mock("../../firebase-db", () => ({
+  watchActivityLevelFeedback: jest.fn(() => jest.fn()),
+  watchQuestionLevelFeedback: jest.fn(() => jest.fn()),
+}));
 
 const sequence = _sequence as Sequence;
 
@@ -13,5 +22,12 @@ describe("Sequence Page Content component", () => {
     };
     const wrapper = shallow(<SequencePageContent sequence={sequence} onSelectActivity={stubFunction} />);
     expect(wrapper.find('[data-cy="sequence-page-content"]').length).toBe(1);
+  });
+  it("exposes a single main landmark", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    render(<DynamicTextTester><SequencePageContent sequence={sequence} onSelectActivity={stubFunction} /></DynamicTextTester>);
+    expect(screen.getByRole("main")).toBeInTheDocument();
   });
 });

--- a/src/components/sequence-introduction/sequence-page-content.tsx
+++ b/src/components/sequence-introduction/sequence-page-content.tsx
@@ -64,7 +64,7 @@ export const SequencePageContent: React.FC<IProps> = (props) => {
   }, [questionMap]);
 
   return (
-    <div className="sequence-content" data-cy="sequence-page-content">
+    <main className="sequence-content" data-cy="sequence-page-content">
       {isNotebookLayout && <div className="notebookHeader" />}
       <div className="introduction">
         <div className="introduction-content">
@@ -100,6 +100,6 @@ export const SequencePageContent: React.FC<IProps> = (props) => {
           </div>
         </div>
       </div>
-    </div>
+    </main>
   );
 };

--- a/src/components/single-page/single-page-content.test.tsx
+++ b/src/components/single-page/single-page-content.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SinglePageContent } from "./single-page-content";
 import { shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { Activity } from "../../types";
 import { DefaultTestActivity } from "../../test-utils/model-for-tests";
 import _activitySinglePage from "../../data/version-2/sample-new-sections-single-page-layout.json";
@@ -18,5 +19,9 @@ describe("Single Page Content component", () => {
     console.log("wrapper", wrapper.html());
     expect(wrapper.html()).toContain('data-cy="single-page-content"');
     expect(wrapper.html().split('<div class="section').length).toBe(7); // 6 sections = 7 split parts
+  });
+  it("exposes a single main landmark", () => {
+    render(<DynamicTextTester><SinglePageContent activity={DefaultTestActivity} pluginsLoaded={true} /></DynamicTextTester>);
+    expect(screen.getByRole("main")).toBeInTheDocument();
   });
 });

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -47,7 +47,7 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
   };
 
   return (
-    <div className="single-page-content" data-cy="single-page-content">
+    <main className="single-page-content" data-cy="single-page-content">
       <ReadAloudToggle style={{justifyContent: "flex-end"}} />
 
       {activity.pages.filter((page) => !page.is_hidden).map((page, index: number) => (
@@ -55,6 +55,6 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
       ))}
       { activity.related && <RelatedContent relatedContentText={activity.related} /> }
       { activity.show_submit_button && <SubmitButton/> }
-    </div>
+    </main>
   );
 };


### PR DESCRIPTION
## Summary

Adds semantic HTML landmark regions to the Activity Player so screen reader users can navigate between major page sections (header, navigation, main content, footer) without reading through every element.

Implements [AP-84](https://concord-consortium.atlassian.net/browse/AP-84) — **WCAG 2.1 SC 1.3.1 Info and Relationships, Level A**. Blocks AP-83 (skip navigation link).

## Changes

Converted layout wrapper `<div>`s to native semantic elements across every layout (their implicit ARIA roles satisfy the criteria with no `role=` attributes needed):

| Element | Component |
|---|---|
| `<header>` (banner) | `activity-header/header.tsx` |
| `<nav aria-label="Activity selection">` | `activity-header/sequence-nav.tsx` |
| `<nav aria-label="…">` | `activity-header/activity-nav.tsx` (new `ariaLabel` prop) |
| `<main>` | intro, activity page, single page, sequence intro, completion |
| `<footer>` (contentinfo) | `activity-introduction/footer.tsx` |

### Key correctness points
- **Exactly one `<main>` per page** — the five content components are mutually exclusive (driven by `currentPage`/layout in `app.tsx`), so only one is ever in the DOM.
- **Unique navigation names** — in the `MultiplePages` layout `ActivityNav` renders at both top and bottom, so `app.tsx` passes distinct labels: `"Page navigation"` (top) and `"Page navigation (bottom)"` (bottom). `SequenceNav` uses `"Activity selection"`. No two navigation landmarks share an accessible name.
- **One banner / one contentinfo** — `SequenceIntroduction` and `renderActivity()` are mutually exclusive and share the same `Header`/`Footer` components, so there's never a duplicate. `<header>`/`<footer>` are top-level siblings of `<main>` (not nested in a sectioning element), preserving their banner/contentinfo roles.
- classNames and `data-cy` hooks are preserved, so existing styles and Cypress selectors are unaffected.

## Tests

Added React Testing Library assertions that query the **accessibility tree** (`getByRole`) rather than tag names, so the behavior is verified semantically and would still pass for a `role=`-based implementation:

- `banner`, `contentinfo`, and one `main` per content component
- `navigation` landmarks with their expected accessible names
- `ActivityNav` honors a custom `ariaLabel` (covers the new prop)
- `app.test.tsx` asserts the top/bottom navs receive distinct labels — verifies the wiring without a Firebase-backed full App render

`firebase-db` is stubbed where a full render runs watcher effects (same approach as the existing `nav-pages.test.tsx`).

## Accessibility audit

Ran an automated WCAG landmark audit on the diff: **compliant with SC 1.3.1 (Level A)**, all acceptance criteria pass, 0 critical/high/medium issues. The one low/cosmetic finding (bottom-nav label wording) is addressed in this PR.

## Verification

- `npm test` — 86 suites, 365 passed / 9 skipped
- `npm run lint:build` style lint clean on changed files

## Note for AP-83 (skip nav)

The active `<main>` will need an `id` + `tabIndex={-1}` to be a skip-link focus target. Safe to use a single shared `id` since exactly one `<main>` renders at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-84]: https://concord-consortium.atlassian.net/browse/AP-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ