### PR TITLE
feat: accessible header logo — semantic link + alt text (AP-86, AP-87)

### DIFF
--- a/cypress/e2e/header-logo-link.test.ts
+++ b/cypress/e2e/header-logo-link.test.ts
@@ -17,10 +17,8 @@ context("header logo link", () => {
     });
 
     it("renders the logo as an img whose alt matches the project title", () => {
-      cy.get("img[data-cy=logo-img]")
-        .should("have.attr", "alt", "Molecular Workbench")
-        .and("have.attr", "src")
-        .and("contain", "mw-logo");
+      cy.get("img[data-cy=logo-img]").should("have.attr", "alt", "Molecular Workbench");
+      cy.get("img[data-cy=logo-img]").invoke("attr", "src").should("contain", "mw-logo");
     });
   });
 

--- a/cypress/e2e/header-logo-link.test.ts
+++ b/cypress/e2e/header-logo-link.test.ts
@@ -1,0 +1,45 @@
+// The header logo is a semantic link with descriptive alt text:
+//  - WCAG 4.1.2 (AP-86): the logo is a native <a> announced as a link.
+//  - WCAG 1.1.1 (AP-87): the logo image alt matches the visible logo.
+
+context("header logo link", () => {
+  describe("project-supplied logo", () => {
+    beforeEach(() => {
+      cy.visit("?activity=sample-activity-multiple-layout-types&preview");
+    });
+
+    it("is a semantic anchor pointing at the project url", () => {
+      cy.get("a[data-cy=project-logo]").should("exist");
+      cy.get("[data-cy=project-logo]")
+        .should("have.attr", "href", "http://mw.concord.org/nextgen")
+        .and("have.attr", "target", "_blank");
+      cy.get("[data-cy=project-logo]").invoke("attr", "rel").should("contain", "noopener");
+    });
+
+    it("renders the logo as an img whose alt matches the project title", () => {
+      cy.get("img[data-cy=logo-img]")
+        .should("have.attr", "alt", "Molecular Workbench")
+        .and("have.attr", "src")
+        .and("contain", "mw-logo");
+    });
+  });
+
+  describe("default Concord logo", () => {
+    beforeEach(() => {
+      // sample-activity-1 has no project logo or url, so the Concord Consortium
+      // logo is shown and the link falls back to concord.org.
+      cy.visit("?activity=sample-activity-1&preview");
+    });
+
+    it("is a semantic anchor pointing at concord.org", () => {
+      cy.get("a[data-cy=project-logo]").should("exist");
+      cy.get("[data-cy=project-logo]")
+        .should("have.attr", "href", "https://concord.org/")
+        .and("have.attr", "target", "_blank");
+    });
+
+    it("renders the Concord logo as an img with matching alt text", () => {
+      cy.get("img[data-cy=logo-img]").should("have.attr", "alt", "Concord Consortium");
+    });
+  });
+});

--- a/cypress/e2e/header-logo-link.test.ts
+++ b/cypress/e2e/header-logo-link.test.ts
@@ -1,6 +1,6 @@
 // The header logo is a semantic link with descriptive alt text:
-//  - WCAG 4.1.2 (AP-86): the logo is a native <a> announced as a link.
-//  - WCAG 1.1.1 (AP-87): the logo image alt matches the visible logo.
+//  - WCAG 4.1.2: the logo is a native <a> announced as a link.
+//  - WCAG 1.1.1: the logo image alt matches the visible logo.
 
 context("header logo link", () => {
   describe("project-supplied logo", () => {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       "src/utilities/test-utils.ts"
     ],
     "moduleNameMapper": {
+      "\\.svg\\?url$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy"
     },

--- a/src/components/activity-header/header.tsx
+++ b/src/components/activity-header/header.tsx
@@ -23,11 +23,12 @@ export class Header extends React.PureComponent<IProps> {
     const { fullWidth, project, userName, showSequence, onShowSequence } = this.props;
     const logo = project?.logo_ap;
     const projectURL = project?.url || ccLogoLink;
+    const projectTitle = project?.title;
     return (
       <header className={`activity-header ${showSequence ? "in-sequence" : ""}`} data-cy="activity-header">
         <div className={`inner ${fullWidth ? "full" : ""}`}>
           <div className="header-left">
-            <Logo logo={logo} url={projectURL} />
+            <Logo logo={logo} url={projectURL} title={projectTitle} />
             <div className="separator" />
           </div>
           <div className="header-center">

--- a/src/components/activity-header/logo.scss
+++ b/src/components/activity-header/logo.scss
@@ -17,6 +17,12 @@
     &:active {
       background-color: $cc-teal;
     }
+    // Match the app-wide focus ring (see app.scss) so the logo link has a
+    // visible, branded focus indicator instead of relying on the UA default.
+    &:focus-visible {
+      box-shadow: inset 0 0 0 2.5px $cc-button-focus-ring, inset 0 0 0 3.5px white;
+      outline: none;
+    }
 
     &.no-link {
       cursor: auto;

--- a/src/components/activity-header/logo.scss
+++ b/src/components/activity-header/logo.scss
@@ -9,16 +9,13 @@
     border-radius: 4px;
     margin: 0 0 0 10px;
     cursor: pointer;
+    text-decoration: none;
 
     &:hover {
       background-color: $cc-teal-light2;
     }
     &:active {
       background-color: $cc-teal;
-
-      .icon {
-        fill: white;
-      }
     }
 
     &.no-link {

--- a/src/components/activity-header/logo.test.tsx
+++ b/src/components/activity-header/logo.test.tsx
@@ -6,7 +6,7 @@ describe("Logo component", () => {
   configure({ testIdAttribute: "data-cy" });
 
   const projectLogoUrl = "https://static.concord.org/projects/logos/ap/mw-logo.png";
-  const projectUrl = "http://mw.concord.org/nexgen";
+  const projectUrl = "http://mw.concord.org/nextgen";
 
   // AP-86: the header logo is a semantic <a> link when it has a destination, so
   // assistive technology announces it as a link and it is keyboard-reachable.

--- a/src/components/activity-header/logo.test.tsx
+++ b/src/components/activity-header/logo.test.tsx
@@ -46,6 +46,14 @@ describe("Logo component", () => {
       expect(img).toHaveAttribute("alt", "Molecular Workbench");
     });
 
+    it("falls back to a destination-oriented alt when a project logo has no title", () => {
+      // The alt is the link's accessible name, so it should describe the
+      // destination rather than the image when no title is available. A
+      // whitespace-only title is treated as empty.
+      render(<Logo logo={projectLogoUrl} url={projectUrl} title="   " />);
+      expect(screen.getByTestId("logo-img")).toHaveAttribute("alt", "Project website");
+    });
+
     it("renders the default Concord logo as an img with a matching alt", () => {
       // No project logo, so the Concord Consortium logo is shown. Its alt must
       // describe the visible logo, not the project title.

--- a/src/components/activity-header/logo.test.tsx
+++ b/src/components/activity-header/logo.test.tsx
@@ -44,6 +44,15 @@ describe("Logo component", () => {
       expect(logo).not.toHaveAttribute("href");
       expect(logo).toHaveClass("no-link");
     });
+
+    it("does not render a link for a relative (non-absolute) url", () => {
+      // Only absolute http(s) urls are linked; a relative url is not.
+      render(<Logo logo={projectLogoUrl} url={"/relative/path"} title="Relative" />);
+      const logo = screen.getByTestId("project-logo");
+      expect(logo.tagName).not.toBe("A");
+      expect(logo).not.toHaveAttribute("href");
+      expect(logo).toHaveClass("no-link");
+    });
   });
 
   // AP-87: the logo image carries alt text that matches the visible logo.

--- a/src/components/activity-header/logo.test.tsx
+++ b/src/components/activity-header/logo.test.tsx
@@ -1,48 +1,58 @@
-import { act, configure, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { configure, render, screen } from "@testing-library/react";
 import React from "react";
 import { Logo } from "./logo";
-import CCLogo from "../../assets/svg-icons/cclogo.svg";
 
 describe("Logo component", () => {
   configure({ testIdAttribute: "data-cy" });
 
-  const mockOpen = jest.fn();
-  const windowOpen = window.open;
+  const projectLogoUrl = "https://static.concord.org/projects/logos/ap/mw-logo.png";
+  const projectUrl = "http://mw.concord.org/nexgen";
 
-  beforeEach(() => {
-    window.open = mockOpen;
-    mockOpen.mockReset();
-  });
-
-  afterEach(() => {
-    window.open = windowOpen;
-  });
-
-  it("renders logo when logo is specified", () => {
-    render(<Logo logo={CCLogo} url={"https://concord.org/"} />);
-    expect(screen.getByTestId("project-logo")).toHaveClass("project-logo");
-    expect(screen.getByTestId("project-logo")).not.toHaveClass("no-link");
-    expect(screen.getByTestId("logo-img")).toHaveClass("logo-img");
-
-    act(() => {
-      userEvent.click(screen.getByTestId("project-logo"));
+  // AP-86: the header logo is a semantic <a> link when it has a destination, so
+  // assistive technology announces it as a link and it is keyboard-reachable.
+  describe("semantic link markup (AP-86)", () => {
+    it("renders the logo as a native anchor pointing at the project url", () => {
+      render(<Logo logo={projectLogoUrl} url={projectUrl} title="Molecular Workbench" />);
+      const link = screen.getByTestId("project-logo");
+      expect(link.tagName).toBe("A");
+      expect(link).toHaveAttribute("href", projectUrl);
+      expect(link).toHaveClass("project-logo");
+      expect(link).not.toHaveClass("no-link");
     });
-    expect(mockOpen).toHaveBeenCalled();
 
-    mockOpen.mockReset();
-    expect(mockOpen).not.toHaveBeenCalled();
-
-    act(() => {
-      userEvent.keyboard("{enter}");
+    it("opens the link in a new tab safely", () => {
+      render(<Logo logo={projectLogoUrl} url={projectUrl} title="Molecular Workbench" />);
+      const link = screen.getByTestId("project-logo");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link.getAttribute("rel")).toContain("noopener");
     });
-    expect(mockOpen).toHaveBeenCalled();
+
+    it("renders a non-link container when there is no destination url", () => {
+      render(<Logo logo={undefined} url={undefined} />);
+      const logo = screen.getByTestId("project-logo");
+      expect(logo.tagName).not.toBe("A");
+      expect(logo).not.toHaveAttribute("href");
+      expect(logo).toHaveClass("no-link");
+    });
   });
 
-  it("renders default logo when no logo is specified", () => {
-    render(<Logo logo={undefined} url={undefined} />);
-    expect(screen.getByTestId("project-logo")).toHaveClass("project-logo");
-    expect(screen.getByTestId("project-logo")).toHaveClass("no-link");
-    expect(screen.queryByTestId("logo-img")).toBeNull();
+  // AP-87: the logo image carries alt text that matches the visible logo.
+  describe("logo image alt text (AP-87)", () => {
+    it("uses the project title as the alt text of a project-supplied logo", () => {
+      render(<Logo logo={projectLogoUrl} url={projectUrl} title="Molecular Workbench" />);
+      const img = screen.getByTestId("logo-img");
+      expect(img.tagName).toBe("IMG");
+      expect(img).toHaveAttribute("src", projectLogoUrl);
+      expect(img).toHaveAttribute("alt", "Molecular Workbench");
+    });
+
+    it("renders the default Concord logo as an img with a matching alt", () => {
+      // No project logo, so the Concord Consortium logo is shown. Its alt must
+      // describe the visible logo, not the project title.
+      render(<Logo logo={undefined} url={projectUrl} title="Some Project" />);
+      const img = screen.getByTestId("logo-img");
+      expect(img.tagName).toBe("IMG");
+      expect(img).toHaveAttribute("alt", "Concord Consortium");
+    });
   });
 });

--- a/src/components/activity-header/logo.test.tsx
+++ b/src/components/activity-header/logo.test.tsx
@@ -8,9 +8,9 @@ describe("Logo component", () => {
   const projectLogoUrl = "https://static.concord.org/projects/logos/ap/mw-logo.png";
   const projectUrl = "http://mw.concord.org/nextgen";
 
-  // AP-86: the header logo is a semantic <a> link when it has a destination, so
+  // The header logo is a semantic <a> link when it has a destination, so
   // assistive technology announces it as a link and it is keyboard-reachable.
-  describe("semantic link markup (AP-86)", () => {
+  describe("semantic link markup", () => {
     it("renders the logo as a native anchor pointing at the project url", () => {
       render(<Logo logo={projectLogoUrl} url={projectUrl} title="Molecular Workbench" />);
       const link = screen.getByTestId("project-logo");
@@ -55,8 +55,8 @@ describe("Logo component", () => {
     });
   });
 
-  // AP-87: the logo image carries alt text that matches the visible logo.
-  describe("logo image alt text (AP-87)", () => {
+  // The logo image carries alt text that matches the visible logo.
+  describe("logo image alt text", () => {
     it("uses the project title as the alt text of a project-supplied logo", () => {
       render(<Logo logo={projectLogoUrl} url={projectUrl} title="Molecular Workbench" />);
       const img = screen.getByTestId("logo-img");

--- a/src/components/activity-header/logo.test.tsx
+++ b/src/components/activity-header/logo.test.tsx
@@ -34,6 +34,16 @@ describe("Logo component", () => {
       expect(logo).not.toHaveAttribute("href");
       expect(logo).toHaveClass("no-link");
     });
+
+    it("does not render a link for an unsafe url scheme", () => {
+      // Author-supplied urls are only linked when http(s); a javascript: url
+      // must not become an executable link.
+      render(<Logo logo={projectLogoUrl} url={"javascript:alert(1)"} title="Evil" />);
+      const logo = screen.getByTestId("project-logo");
+      expect(logo.tagName).not.toBe("A");
+      expect(logo).not.toHaveAttribute("href");
+      expect(logo).toHaveClass("no-link");
+    });
   });
 
   // AP-87: the logo image carries alt text that matches the visible logo.

--- a/src/components/activity-header/logo.tsx
+++ b/src/components/activity-header/logo.tsx
@@ -44,8 +44,11 @@ export class Logo extends React.PureComponent<IProps> {
   // Concord Consortium logo is shown with its own descriptive alt text.
   private renderLogoImage = () => {
     const { logo, title } = this.props;
+    // The alt text is the link's accessible name, so the project-logo fallback
+    // describes the destination ("Project website") rather than the image when no
+    // title is available; whitespace-only titles are treated as empty.
     return logo
-      ? <img data-cy="logo-img" className="logo-img" src={logo} alt={title || "Project logo"} />
+      ? <img data-cy="logo-img" className="logo-img" src={logo} alt={title?.trim() || "Project website"} />
       : <img data-cy="logo-img" className="logo-img cc-logo" src={ccLogoUrl} alt="Concord Consortium" />;
   }
 }

--- a/src/components/activity-header/logo.tsx
+++ b/src/components/activity-header/logo.tsx
@@ -47,7 +47,9 @@ export class Logo extends React.PureComponent<IProps> {
   private isLinkableUrl = (url?: string) => {
     if (!url) return false;
     try {
-      const { protocol } = new URL(url, window.location.origin);
+      // No base url, so relative urls throw and are treated as non-linkable —
+      // project urls are always absolute, so only absolute http(s) is linked.
+      const { protocol } = new URL(url);
       return protocol === "http:" || protocol === "https:";
     } catch {
       return false;

--- a/src/components/activity-header/logo.tsx
+++ b/src/components/activity-header/logo.tsx
@@ -17,8 +17,10 @@ export class Logo extends React.PureComponent<IProps> {
     // AP-86: render the logo as a native anchor when it has a destination so
     // assistive technology announces it as a link and it is keyboard-operable
     // with standard interaction. Fall back to a non-interactive container when
-    // there is no url to link to.
-    if (url) {
+    // there is no (safe) url to link to. The url originates from author-supplied
+    // project data, so only http(s) destinations are linked — this avoids turning
+    // a malicious scheme (e.g. javascript:) into an executable link.
+    if (this.isLinkableUrl(url)) {
       return (
         <a
           className="project-logo"
@@ -37,6 +39,19 @@ export class Logo extends React.PureComponent<IProps> {
         {this.renderLogoImage()}
       </div>
     );
+  }
+
+  // Only absolute http(s) urls are treated as links; anything else (a missing
+  // url, or an unsafe scheme such as javascript:/data:) falls back to non-link
+  // rendering.
+  private isLinkableUrl = (url?: string) => {
+    if (!url) return false;
+    try {
+      const { protocol } = new URL(url, window.location.origin);
+      return protocol === "http:" || protocol === "https:";
+    } catch {
+      return false;
+    }
   }
 
   // AP-87: render the logo as an <img> with alt text that matches the visible

--- a/src/components/activity-header/logo.tsx
+++ b/src/components/activity-header/logo.tsx
@@ -1,39 +1,51 @@
 import React from "react";
-import { accessibilityClick } from "../../utilities/accessibility-helper";
-import CCLogo from "../../assets/svg-icons/cclogo.svg";
+import ccLogoUrl from "../../assets/svg-icons/cclogo.svg?url";
 
 import "./logo.scss";
 
 interface IProps {
   logo: any;
   url: string | undefined;
+  // The project title, used as the alt text when a project-supplied logo is shown.
+  title?: string | null;
 }
 
 export class Logo extends React.PureComponent<IProps> {
   render() {
-    const { logo, url } = this.props;
-    const linkClass = url ? "" : "no-link";
-    const tIndex = url ? 0 : -1;
+    const { url } = this.props;
+
+    // AP-86: render the logo as a native anchor when it has a destination so
+    // assistive technology announces it as a link and it is keyboard-operable
+    // with standard interaction. Fall back to a non-interactive container when
+    // there is no url to link to.
+    if (url) {
+      return (
+        <a
+          className="project-logo"
+          data-cy="project-logo"
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {this.renderLogoImage()}
+        </a>
+      );
+    }
 
     return (
-      <div
-        className={`project-logo ${linkClass}`}
-        data-cy="project-logo"
-        onClick={this.handleProjectLogoLink(url)}
-        onKeyDown={this.handleProjectLogoLink(url)}
-        tabIndex={tIndex}
-      >
-        { logo
-          ? <img data-cy="logo-img" className="logo-img" src={logo} alt="Project website"/>
-          : <CCLogo className="icon" />
-        }
+      <div className="project-logo no-link" data-cy="project-logo">
+        {this.renderLogoImage()}
       </div>
     );
   }
 
-  private handleProjectLogoLink = (url?: string) => (event: any) => {
-    if (url && accessibilityClick(event)) {
-      window.open(url);
-    }
+  // AP-87: render the logo as an <img> with alt text that matches the visible
+  // logo. A project-supplied logo uses the project title; otherwise the default
+  // Concord Consortium logo is shown with its own descriptive alt text.
+  private renderLogoImage = () => {
+    const { logo, title } = this.props;
+    return logo
+      ? <img data-cy="logo-img" className="logo-img" src={logo} alt={title || "Project logo"} />
+      : <img data-cy="logo-img" className="logo-img cc-logo" src={ccLogoUrl} alt="Concord Consortium" />;
   }
 }

--- a/src/components/activity-header/logo.tsx
+++ b/src/components/activity-header/logo.tsx
@@ -4,7 +4,7 @@ import ccLogoUrl from "../../assets/svg-icons/cclogo.svg?url";
 import "./logo.scss";
 
 interface IProps {
-  logo: any;
+  logo?: string | null;
   url: string | undefined;
   // The project title, used as the alt text when a project-supplied logo is shown.
   title?: string | null;
@@ -14,7 +14,7 @@ export class Logo extends React.PureComponent<IProps> {
   render() {
     const { url } = this.props;
 
-    // AP-86: render the logo as a native anchor when it has a destination so
+    // Render the logo as a native anchor when it has a destination so
     // assistive technology announces it as a link and it is keyboard-operable
     // with standard interaction. Fall back to a non-interactive container when
     // there is no (safe) url to link to. The url originates from author-supplied
@@ -56,8 +56,8 @@ export class Logo extends React.PureComponent<IProps> {
     }
   }
 
-  // AP-87: render the logo as an <img> with alt text that matches the visible
-  // logo. A project-supplied logo uses the project title; otherwise the default
+  // Render the logo as an <img> with alt text that matches the visible logo.
+  // A project-supplied logo uses the project title; otherwise the default
   // Concord Consortium logo is shown with its own descriptive alt text.
   private renderLogoImage = () => {
     const { logo, title } = this.props;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,4 +1,5 @@
 declare module "*.png";
 declare module "*.svg";
+declare module "*.svg?url";
 declare module "iframe-phone";
 declare module "shutterbug";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,16 +77,12 @@ module.exports = (env, argv) => {
           test: /\.svg$/,
           oneOf: [
             {
-              // Import an SVG as a plain asset URL via an explicit `?url` query
-              // (e.g. `import logoUrl from "./logo.svg?url"`) so it can be used as
-              // an <img src> rather than an inlined SVGR React component.
-              resourceQuery: /url/,
-              type: "asset",
-              parser: {
-                dataUrlCondition: {
-                  maxSize: 8192
-                }
-              }
+              // Import an SVG as a plain asset-file URL via an explicit `?url`
+              // query (e.g. `import logoUrl from "./logo.svg?url"`) so it can be
+              // used as an <img src> rather than an inlined SVGR React component.
+              // `asset/resource` always emits a file (never an inlined data URL).
+              resourceQuery: /[?&]url(?:&|$)/,
+              type: "asset/resource"
             },
             {
               // Do not apply SVGR import in CSS files.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,18 @@ module.exports = (env, argv) => {
           test: /\.svg$/,
           oneOf: [
             {
+              // Import an SVG as a plain asset URL via an explicit `?url` query
+              // (e.g. `import logoUrl from "./logo.svg?url"`) so it can be used as
+              // an <img src> rather than an inlined SVGR React component.
+              resourceQuery: /url/,
+              type: "asset",
+              parser: {
+                dataUrlCondition: {
+                  maxSize: 8192
+                }
+              }
+            },
+            {
               // Do not apply SVGR import in CSS files.
               issuer: /\.(css|scss|less)$/,
               type: "asset",


### PR DESCRIPTION
## What & why

Makes the activity-player header logo accessible. Two sibling stories under the VPAT Accessibility epic (AP-81), both touching `logo.tsx`, done together to avoid a self-conflict:

- **AP-86 (WCAG 4.1.2, Level A)** — the logo was a clickable `<div>` with `onClick`/`onKeyDown`/`tabIndex` and a `window.open` handler, so assistive tech did not announce it as a link. It's now a native `<a href target="_blank" rel="noopener noreferrer">` when it has a destination (the normal case, since the project url falls back to `https://concord.org/`), with a non-interactive `<div class="no-link">` fallback when there is no url.
- **AP-87 (WCAG 1.1.1, Level A)** — the logo image alt was the generic "Project website". It now matches the *visible* logo:
  - project-supplied logo → `project.title` (e.g. "Molecular Workbench")
  - default Concord logo → `"Concord Consortium"`

  The default Concord logo was an inline `<svg>` (can't carry `alt`), so it's now rendered as an `<img>`.

## Implementation notes

- To render the bundled Concord SVG as an `<img src>`, added a webpack `?url` resource-query rule that emits the SVG as an asset URL instead of an SVGR React component, plus the matching jest `moduleNameMapper` and a TS module declaration (`*.svg?url`).
- The `Logo` component gains an optional `title` prop, passed from `Header` (`project?.title`).

## Alt-text mapping (the subtlety)

Alt text matches the *visible* image, not the project. So when a project exists but has no `logo_ap`, the Concord logo is shown and its alt is `"Concord Consortium"` — the project title only becomes the alt when the project's own image is actually displayed.

## Testing

- Rewrote `logo.test.tsx` (TDD) covering anchor markup, `href`/`target`/`rel`, the non-link fallback, and alt text for both logo paths.
- Added `cypress/e2e/header-logo-link.test.ts` (4 tests) exercising both the project-logo and default-Concord-logo cases in a real browser.
- Full Jest suite passes (377 passed); all three lint configs clean; production build succeeds and emits `cclogo.svg` as a served asset.
- Visually verified both header variants render correctly (no overflow/distortion).

## Base branch

⚠️ Stacked on `AP-project-improvements` (#559), **not** `master`. Review/merge that first; this PR's diff is scoped to the logo changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
