### PR TITLE
feat(AP-88): hide decorative SVG icons from assistive technology

### DIFF
--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -154,8 +154,8 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
           <div className="banners">
             <div className={`progress-container ${!isActivityComplete ? "incomplete" : ""}`} data-cy="progress-container">
               {isActivityComplete
-                ? <IconCheck width={24} height={24} className="check" />
-                : <IconUnfinishedCheck width={24} height={24} className="check incomplete" />
+                ? <IconCheck width={24} height={24} className="check" aria-hidden="true" focusable="false" />
+                : <IconUnfinishedCheck width={24} height={24} className="check incomplete" aria-hidden="true" focusable="false" />
               }
               <div className="progress-text" data-cy="progress-text">
                 <DynamicText>{progressText}</DynamicText>

--- a/src/components/activity-completion/summary-table.test.tsx
+++ b/src/components/activity-completion/summary-table.test.tsx
@@ -24,4 +24,17 @@ describe("Summary Table component", () => {
     expect(wrapperComplete.find('[data-testid="question-page-and-number"]').at(2).text()).toContain("Page 2: Question 3.");
     expect(wrapperComplete.find('[data-testid="question-prompt"]').at(2).text()).toContain("Where are we going?");
   });
+
+  it("gives the meaningful complete/incomplete status icons accessible names", () => {
+    const wrapper = mount(
+      <DynamicTextTester><SummaryTable questionsStatus={questionsStatus} onPageChange={mockOnPageChange} /></DynamicTextTester>
+    );
+    // One status icon per question; these convey answered/unanswered state with no adjacent text,
+    // so they must be exposed to assistive technology with a name rather than hidden.
+    const icons = wrapper.find("test-file-stub");
+    expect(icons.length).toBe(3);
+    icons.forEach((icon) => expect(icon.prop("role")).toBe("img"));
+    expect(icons.at(0).prop("aria-label")).toBe("Complete");   // answered: true
+    expect(icons.at(2).prop("aria-label")).toBe("Incomplete");  // answered: false
+  });
 });

--- a/src/components/activity-completion/summary-table.tsx
+++ b/src/components/activity-completion/summary-table.tsx
@@ -47,8 +47,8 @@ export const SummaryTable: React.FC<IProps> = (props) => {
       {questionsStatus.map((question: IQuestionStatus, index) => {
         const refId = question.embeddableId && answersQuestionIdToRefId(question.embeddableId);
           const questionAnswered = question.answered
-            ? <IconComplete className="complete" role="img" aria-label="Complete" />
-            : <IconIncomplete className="incomplete" role="img" aria-label="Incomplete" />;
+            ? <IconComplete className="complete" role="img" aria-label="Complete" focusable="false" />
+            : <IconIncomplete className="incomplete" role="img" aria-label="Incomplete" focusable="false" />;
           // Remove all the HTML tags to avoid unnecessary formatting and whitespace in the summary table.
           // `renderHTML()` is still necessary to render encoded characters like &quot; => ", etc.
           const questionPrompt = question.prompt ? renderHTML(question.prompt.replace(/<\/?[^>]+(>|$)/g, "")) : "";

--- a/src/components/activity-completion/summary-table.tsx
+++ b/src/components/activity-completion/summary-table.tsx
@@ -46,7 +46,9 @@ export const SummaryTable: React.FC<IProps> = (props) => {
       <tbody>
       {questionsStatus.map((question: IQuestionStatus, index) => {
         const refId = question.embeddableId && answersQuestionIdToRefId(question.embeddableId);
-          const questionAnswered = question.answered ? <IconComplete className="complete" /> : <IconIncomplete className="incomplete" />;
+          const questionAnswered = question.answered
+            ? <IconComplete className="complete" role="img" aria-label="Complete" />
+            : <IconIncomplete className="incomplete" role="img" aria-label="Incomplete" />;
           // Remove all the HTML tags to avoid unnecessary formatting and whitespace in the summary table.
           // `renderHTML()` is still necessary to render encoded characters like &quot; => ", etc.
           const questionPrompt = question.prompt ? renderHTML(question.prompt.replace(/<\/?[^>]+(>|$)/g, "")) : "";

--- a/src/components/activity-header/account-owner.test.tsx
+++ b/src/components/activity-header/account-owner.test.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { AccountOwner } from "./account-owner";
+import { mount } from "enzyme";
+
+describe("AccountOwner component", () => {
+  it("renders the user name", () => {
+    const wrapper = mount(<AccountOwner userName="Jan Doe" />);
+    expect(wrapper.text()).toContain("Jan Doe");
+  });
+
+  it("marks the decorative profile icon as hidden from assistive technology", () => {
+    const wrapper = mount(<AccountOwner userName="Jan Doe" />);
+    const icon = wrapper.find("test-file-stub");
+    expect(icon.length).toBe(1);
+    expect(icon.prop("aria-hidden")).toBe("true");
+  });
+});

--- a/src/components/activity-header/account-owner.tsx
+++ b/src/components/activity-header/account-owner.tsx
@@ -10,7 +10,7 @@ export class AccountOwner extends React.PureComponent <IProps> {
   render() {
     return (
       <div className="account-owner" data-cy="account-owner">
-        <AccountOwnerIcon className="icon" />
+        <AccountOwnerIcon className="icon" aria-hidden="true" focusable="false" />
         <div className="account-owner-name">{this.props.userName}</div>
       </div>
     );

--- a/src/components/activity-header/header.tsx
+++ b/src/components/activity-header/header.tsx
@@ -33,7 +33,7 @@ export class Header extends React.PureComponent<IProps> {
           </div>
           <div className="header-center">
             <div className={`title-container ${showSequence && onShowSequence ? "link" : ""}`} onClick={onShowSequence}>
-              {showSequence && onShowSequence && <SequenceBackIcon className="sequence-icon" />}
+              {showSequence && onShowSequence && <SequenceBackIcon className="sequence-icon" aria-hidden="true" focusable="false" />}
               {showSequence && onShowSequence ? this.renderContentTitle() : <DynamicText>{this.renderContentTitle()}</DynamicText>}
             </div>
           </div>

--- a/src/components/activity-header/nav-pages.tsx
+++ b/src/components/activity-header/nav-pages.tsx
@@ -101,7 +101,7 @@ export class NavPages extends React.Component <IProps, IState> {
           aria-label="Previous page"
           data-cy="previous-page-button"
         >
-          <ArrowPrevious className="icon"/>
+          <ArrowPrevious className="icon" aria-hidden="true" focusable="false" />
         </button>
       </div>
     );
@@ -125,7 +125,7 @@ export class NavPages extends React.Component <IProps, IState> {
           aria-label="Next page"
           data-cy="next-page-button"
         >
-          <ArrowNext className="icon"/>
+          <ArrowNext className="icon" aria-hidden="true" focusable="false" />
         </button>
       </div>
     );
@@ -161,9 +161,9 @@ export class NavPages extends React.Component <IProps, IState> {
         const completionClass = page.is_completion ? "completion-page-button" : "";
         const disabledClass = (pageChangeInProgress || lockForwardNav && currentPage < pageNum) ? "disabled" : "";
         const buttonContent = page.is_hidden
-                                ? <HiddenIcon className={`icon ${currentClass}`} width={28} height={28}/>
+                                ? <HiddenIcon className={`icon ${currentClass}`} width={28} height={28} aria-hidden="true" focusable="false" />
                                 : page.is_completion
-                                    ? <IconCompletion className={`icon ${currentClass}`} width={28} height={28} />
+                                    ? <IconCompletion className={`icon ${currentClass}`} width={28} height={28} aria-hidden="true" focusable="false" />
                                     : pageLabel;
 
         return (
@@ -204,6 +204,8 @@ export class NavPages extends React.Component <IProps, IState> {
             className={`icon ${this.props.currentPage === 0 ? "current" : ""}`}
             width={28}
             height={28}
+            aria-hidden="true"
+            focusable="false"
           />
           {this.props.usePageNames && "Home"}
         </button>

--- a/src/components/activity-introduction/estimated-time.test.tsx
+++ b/src/components/activity-introduction/estimated-time.test.tsx
@@ -9,4 +9,11 @@ describe("Estimated Time component", () => {
     const wrapper = mount(<DynamicTextTester><EstimatedTime time={10} /></DynamicTextTester>);
     expect(wrapper.text()).toContain(estimatedTimeText);
   });
+
+  it("marks the decorative clock icon as hidden from assistive technology", () => {
+    const wrapper = mount(<DynamicTextTester><EstimatedTime time={10} /></DynamicTextTester>);
+    const icon = wrapper.find("test-file-stub");
+    expect(icon.length).toBe(1);
+    expect(icon.prop("aria-hidden")).toBe("true");
+  });
 });

--- a/src/components/activity-introduction/estimated-time.tsx
+++ b/src/components/activity-introduction/estimated-time.tsx
@@ -13,7 +13,7 @@ export class EstimatedTime extends React.PureComponent <IProps> {
   render() {
     return (
       <div className="estimated-time" data-cy="estimated-time">
-        <IconClock />
+        <IconClock aria-hidden="true" focusable="false" />
         <DynamicText>
           <div className="label">
             <div className="estimate">Estimated Time to Complete This Module:</div>

--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -562,7 +562,7 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
         {showDeleteDataButton &&
           <button className="button reset" data-cy="reset-button" onClick={handleResetButtonClick} onKeyDown={handleResetButtonClick}>
             Clear &amp; start over
-            <ReloadIcon />
+            <ReloadIcon aria-hidden="true" focusable="false" />
           </button>
         }
         {feedback && <IframeRuntimeFeedback embeddableRefId={id} feedback={feedback} />}

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -173,11 +173,15 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
           width={32}
           height={32}
           fill={"white"}
+          aria-hidden="true"
+          focusable="false"
         />
         : <IconChevronRight
           width={32}
           height={32}
           fill={"white"}
+          aria-hidden="true"
+          focusable="false"
         />
     );
   };

--- a/src/components/custom-select.tsx
+++ b/src/components/custom-select.tsx
@@ -54,9 +54,9 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
     return (
       <div className={`header ${showListClass} ${disabled}`} data-cy="custom-select-header"
             onClick={this.handleHeaderClick} tabIndex={0}>
-        { HeaderIcon && <HeaderIcon className={`icon ${showListClass}`} /> }
+        { HeaderIcon && <HeaderIcon className={`icon ${showListClass}`} aria-hidden="true" focusable="false" /> }
         <div className="current">{currentItem && currentItem}</div>
-        { <ArrowIcon className={`arrow ${showListClass} ${disabled}`} /> }
+        { <ArrowIcon className={`arrow ${showListClass} ${disabled}`} aria-hidden="true" focusable="false" /> }
       </div>
     );
   }
@@ -76,7 +76,7 @@ export class CustomSelect extends React.PureComponent<IProps, IState> {
                 onClick={this.handleChange(item)}
                 data-cy={`list-item-${item.toLowerCase().replace(" ", "-")}`}
               >
-                { <CheckIcon className={`check ${currentClass}`} /> }
+                { <CheckIcon className={`check ${currentClass}`} aria-hidden="true" focusable="false" /> }
                 <div className="label">{item}</div>
               </div>
             );})

--- a/src/components/page-sidebar/sidebar-panel.tsx
+++ b/src/components/page-sidebar/sidebar-panel.tsx
@@ -34,8 +34,8 @@ export class SidebarPanel extends React.PureComponent<IProps>{
     );
   }
 
-  private handleCloseButton = () => {
-    if (accessibilityClick(event)){
+  private handleCloseButton = (e: React.MouseEvent | React.KeyboardEvent) => {
+    if (accessibilityClick(e)){
       this.props.handleCloseSidebarContent(this.props.index, false);
     }
   }

--- a/src/components/page-sidebar/sidebar-panel.tsx
+++ b/src/components/page-sidebar/sidebar-panel.tsx
@@ -22,8 +22,8 @@ export class SidebarPanel extends React.PureComponent<IProps>{
         <div className="sidebar-header">
           <div className="sidebar-title" data-cy="sidebar-title">{this.props.title}</div>
           <div className="icon" onClick={this.handleCloseButton} onKeyDown={this.handleCloseButton}
-               data-cy="sidebar-close-button" tabIndex={0}>
-            <IconClose />
+               data-cy="sidebar-close-button" tabIndex={0} role="button" aria-label="Close">
+            <IconClose aria-hidden="true" focusable="false" />
           </div>
         </div>
         <DynamicText>

--- a/src/components/page-sidebar/sidebar-panel.tsx
+++ b/src/components/page-sidebar/sidebar-panel.tsx
@@ -36,6 +36,10 @@ export class SidebarPanel extends React.PureComponent<IProps>{
 
   private handleCloseButton = (e: React.MouseEvent | React.KeyboardEvent) => {
     if (accessibilityClick(e)){
+      // role="button" div: stop Space from also scrolling the page on keyboard activation
+      if (e.type === "keydown") {
+        e.preventDefault();
+      }
       this.props.handleCloseSidebarContent(this.props.index, false);
     }
   }

--- a/src/components/page-sidebar/sidebar-tab.tsx
+++ b/src/components/page-sidebar/sidebar-tab.tsx
@@ -21,7 +21,7 @@ export class SidebarTab extends React.PureComponent<IProps>{
       <div className="sidebar-tab" onClick={this.handleSidebarShow} onKeyDown={this.handleSidebarShow} 
            data-cy="sidebar-tab" tabIndex={0}>
         <div className={`icon ${this.props.sidebarOpen ? "open" : ""}`}>
-          <IconArrow />
+          <IconArrow aria-hidden="true" focusable="false" />
         </div>
         <div className="tab-name" data-cy="sidebar-tab-title">{this.props.title}</div>
       </div>

--- a/src/components/page-sidebar/sidebar-tab.tsx
+++ b/src/components/page-sidebar/sidebar-tab.tsx
@@ -28,8 +28,8 @@ export class SidebarTab extends React.PureComponent<IProps>{
     );
   }
 
-  private handleSidebarShow = () => {
-    if (accessibilityClick(event)) {
+  private handleSidebarShow = (e: React.MouseEvent | React.KeyboardEvent) => {
+    if (accessibilityClick(e)) {
       this.props.handleShowSidebarContent(this.props.index, !this.props.sidebarOpen);
     }
   }

--- a/src/components/page-sidebar/sidebar-tab.tsx
+++ b/src/components/page-sidebar/sidebar-tab.tsx
@@ -18,8 +18,8 @@ export class SidebarTab extends React.PureComponent<IProps>{
 
   render() {
     return (
-      <div className="sidebar-tab" onClick={this.handleSidebarShow} onKeyDown={this.handleSidebarShow} 
-           data-cy="sidebar-tab" tabIndex={0}>
+      <div className="sidebar-tab" onClick={this.handleSidebarShow} onKeyDown={this.handleSidebarShow}
+           data-cy="sidebar-tab" tabIndex={0} role="button" aria-expanded={this.props.sidebarOpen}>
         <div className={`icon ${this.props.sidebarOpen ? "open" : ""}`}>
           <IconArrow aria-hidden="true" focusable="false" />
         </div>

--- a/src/components/page-sidebar/sidebar-tab.tsx
+++ b/src/components/page-sidebar/sidebar-tab.tsx
@@ -30,6 +30,10 @@ export class SidebarTab extends React.PureComponent<IProps>{
 
   private handleSidebarShow = (e: React.MouseEvent | React.KeyboardEvent) => {
     if (accessibilityClick(e)) {
+      // role="button" div: stop Space from also scrolling the page on keyboard activation
+      if (e.type === "keydown") {
+        e.preventDefault();
+      }
       this.props.handleShowSidebarContent(this.props.index, !this.props.sidebarOpen);
     }
   }

--- a/src/components/teacher-edition-banner.tsx
+++ b/src/components/teacher-edition-banner.tsx
@@ -6,7 +6,7 @@ import "./teacher-edition-banner.scss";
 export const TeacherEditionBanner: React.FC = () => {
   return (
     <div className="teacher-edition-banner" data-cy="teacher-edition-banner">
-      <IconTeacherEdition height={48} width={48}/>
+      <IconTeacherEdition height={48} width={48} aria-hidden="true" focusable="false" />
       Teacher Edition
     </div>
   );

--- a/src/components/teacher-feedback/activity-level-feedback-banner.tsx
+++ b/src/components/teacher-feedback/activity-level-feedback-banner.tsx
@@ -20,7 +20,7 @@ export const ActivityLevelFeedbackBanner = ({ teacherFeedback }: IProps) => {
 
   return (
     <div className={bannerClass} data-testid="activity-level-feedback-banner">
-      <TeacherFeedbackIcon className="teacher-feedback-icon" />
+      <TeacherFeedbackIcon className="teacher-feedback-icon" aria-hidden="true" focusable="false" />
       {shouldRenderRubric && (
         <div className="activity-level-feedback-title">
           <DynamicText><strong>Overall Teacher Feedback for This Activity:</strong></DynamicText>

--- a/src/components/teacher-feedback/iframe-runtime-feedback.tsx
+++ b/src/components/teacher-feedback/iframe-runtime-feedback.tsx
@@ -32,7 +32,7 @@ export const IframeRuntimeFeedback: React.FC<IProps> = ({feedback, embeddableRef
     showFeedback ?
     <div className="teacher-feedback" data-testid="teacher-feedback">
       <div>
-        <TeacherFeedbackIcon/>
+        <TeacherFeedbackIcon aria-hidden="true" focusable="false" />
       </div>
       <DynamicText>
           <strong>Teacher Feedback:</strong> {feedback.content}
@@ -41,7 +41,7 @@ export const IframeRuntimeFeedback: React.FC<IProps> = ({feedback, embeddableRef
     <button className="feedback-button" onClick={handleShowFeedback} data-testid="feedback-button">
       <div className="feedback-button-content">
         <div className="button-icon">
-          <TeacherFeedbackIcon/>
+          <TeacherFeedbackIcon aria-hidden="true" focusable="false" />
         </div>
         <div className="feedback-button-text">
           <DynamicText>

--- a/src/components/teacher-feedback/sequence-activity-feedback-badge.tsx
+++ b/src/components/teacher-feedback/sequence-activity-feedback-badge.tsx
@@ -5,6 +5,6 @@ import "./sequence-activity-feedback-badge.scss";
 
 export const FeedbackBadge = () => {
   return (
-    <TeacherFeedbackBadge className="feedback-badge"/>
+    <TeacherFeedbackBadge className="feedback-badge" aria-hidden="true" focusable="false" />
   );
 };

--- a/src/components/teacher-feedback/sequence-activity-feedback-badge.tsx
+++ b/src/components/teacher-feedback/sequence-activity-feedback-badge.tsx
@@ -5,6 +5,6 @@ import "./sequence-activity-feedback-badge.scss";
 
 export const FeedbackBadge = () => {
   return (
-    <TeacherFeedbackBadge className="feedback-badge" role="img" aria-label="Your teacher left feedback on this activity." />
+    <TeacherFeedbackBadge className="feedback-badge" role="img" aria-label="Your teacher left feedback on this activity." focusable="false" />
   );
 };

--- a/src/components/teacher-feedback/sequence-activity-feedback-badge.tsx
+++ b/src/components/teacher-feedback/sequence-activity-feedback-badge.tsx
@@ -5,6 +5,6 @@ import "./sequence-activity-feedback-badge.scss";
 
 export const FeedbackBadge = () => {
   return (
-    <TeacherFeedbackBadge className="feedback-badge" aria-hidden="true" focusable="false" />
+    <TeacherFeedbackBadge className="feedback-badge" role="img" aria-label="Your teacher left feedback on this activity." />
   );
 };

--- a/src/components/teacher-feedback/sequence-intro-feedback-banner.tsx
+++ b/src/components/teacher-feedback/sequence-intro-feedback-banner.tsx
@@ -6,7 +6,7 @@ import "./sequence-intro-feedback-banner.scss";
 export const SequenceIntroFeedbackBanner = () => {
   return (
     <div data-cy="intro-feedback-banner" className="intro-feedback-banner">
-      <TeacherFeedbackIcon className="teacher-feedback-icon" />
+      <TeacherFeedbackIcon className="teacher-feedback-icon" aria-hidden="true" focusable="false" />
       Your teacher has provided feedback.
     </div>
   );

--- a/src/components/teacher-feedback/summary-page-question-feedback.tsx
+++ b/src/components/teacher-feedback/summary-page-question-feedback.tsx
@@ -11,7 +11,7 @@ interface IProps {
 export const SummaryPageQuestionFeedback = ({ teacherFeedback }: IProps) => {
   return (
     <div className="summary-page-question-feedback" data-testid="summary-page-question-feedback">
-      <TeacherFeedbackIcon className="teacher-feedback-icon" />
+      <TeacherFeedbackIcon className="teacher-feedback-icon" aria-hidden="true" focusable="false" />
       <div className="summary-page-question-feedback-content" data-testid="summary-page-question-feedback-content">
         <strong>Teacher Feedback:</strong> {teacherFeedback.content}
       </div>

--- a/src/components/teacher-feedback/teacher-feedback-small-badge.test.tsx
+++ b/src/components/teacher-feedback/teacher-feedback-small-badge.test.tsx
@@ -7,7 +7,6 @@ describe("Teacher Feedback Small Badge component", () => {
   it("renders component for page-links location", () => {
     const wrapper = shallow(<TeacherFeedbackSmallBadge location="page-links" />);
     expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').length).toBe(1);
-    expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').prop("title")).toBe("Your teacher left feedback on this page.");
     expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').hasClass("teacher-feedback-small-badge")).toBe(true);
     expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').hasClass("page-links-badge")).toBe(true);
   });
@@ -15,7 +14,6 @@ describe("Teacher Feedback Small Badge component", () => {
   it("renders component for nav-pages location", () => {
     const wrapper = shallow(<TeacherFeedbackSmallBadge location="nav-pages" />);
     expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').length).toBe(1);
-    expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').prop("title")).toBe("Your teacher left feedback on this page.");
     expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').hasClass("teacher-feedback-small-badge")).toBe(true);
     expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').hasClass("nav-pages-badge")).toBe(true);
   });

--- a/src/components/teacher-feedback/teacher-feedback-small-badge.test.tsx
+++ b/src/components/teacher-feedback/teacher-feedback-small-badge.test.tsx
@@ -19,4 +19,14 @@ describe("Teacher Feedback Small Badge component", () => {
     expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').hasClass("teacher-feedback-small-badge")).toBe(true);
     expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').hasClass("nav-pages-badge")).toBe(true);
   });
+
+  it("exposes the badge icon to assistive technology with an accessible name", () => {
+    // The badge is the only indicator that feedback exists, so the icon must be a named
+    // image for screen readers rather than hidden.
+    const wrapper = shallow(<TeacherFeedbackSmallBadge location="page-links" />);
+    const icon = wrapper.find('[role="img"]');
+    expect(icon.length).toBe(1);
+    expect(icon.prop("aria-label")).toBe("Your teacher left feedback on this page.");
+    expect(icon.prop("aria-hidden")).toBeUndefined();
+  });
 });

--- a/src/components/teacher-feedback/teacher-feedback-small-badge.test.tsx
+++ b/src/components/teacher-feedback/teacher-feedback-small-badge.test.tsx
@@ -20,11 +20,20 @@ describe("Teacher Feedback Small Badge component", () => {
 
   it("exposes the badge icon to assistive technology with an accessible name", () => {
     // The badge is the only indicator that feedback exists, so the icon must be a named
-    // image for screen readers rather than hidden.
+    // image for screen readers rather than hidden, and not a stray keyboard tab stop.
     const wrapper = shallow(<TeacherFeedbackSmallBadge location="page-links" />);
     const icon = wrapper.find('[role="img"]');
     expect(icon.length).toBe(1);
     expect(icon.prop("aria-label")).toBe("Your teacher left feedback on this page.");
     expect(icon.prop("aria-hidden")).toBeUndefined();
+    expect(icon.prop("focusable")).toBe("false");
+  });
+
+  it("keeps a hover tooltip on the wrapper for sighted users", () => {
+    // The <div title> is a sighted-only tooltip; it stays off the non-focusable wrapper
+    // so it does not duplicate the icon's accessible name in the a11y tree.
+    const wrapper = shallow(<TeacherFeedbackSmallBadge location="page-links" />);
+    expect(wrapper.find('[data-testid="teacher-feedback-small-badge"]').prop("title"))
+      .toBe("Your teacher left feedback on this page.");
   });
 });

--- a/src/components/teacher-feedback/teacher-feedback-small-badge.tsx
+++ b/src/components/teacher-feedback/teacher-feedback-small-badge.tsx
@@ -18,8 +18,9 @@ export const TeacherFeedbackSmallBadge = ({location}: IProps) => {
     <div
       className={className}
       data-testid="teacher-feedback-small-badge"
+      title="Your teacher left feedback on this page."
     >
-      <TeacherFeedbackBadgeIcon className="teacher-feedback-small-badge-icon" role="img" aria-label="Your teacher left feedback on this page." />
+      <TeacherFeedbackBadgeIcon className="teacher-feedback-small-badge-icon" role="img" aria-label="Your teacher left feedback on this page." focusable="false" />
     </div>
   );
 };

--- a/src/components/teacher-feedback/teacher-feedback-small-badge.tsx
+++ b/src/components/teacher-feedback/teacher-feedback-small-badge.tsx
@@ -20,7 +20,7 @@ export const TeacherFeedbackSmallBadge = ({location}: IProps) => {
       data-testid="teacher-feedback-small-badge"
       title="Your teacher left feedback on this page."
     >
-      <TeacherFeedbackBadgeIcon className="teacher-feedback-small-badge-icon" />
+      <TeacherFeedbackBadgeIcon className="teacher-feedback-small-badge-icon" aria-hidden="true" focusable="false" />
     </div>
   );
 };

--- a/src/components/teacher-feedback/teacher-feedback-small-badge.tsx
+++ b/src/components/teacher-feedback/teacher-feedback-small-badge.tsx
@@ -20,7 +20,7 @@ export const TeacherFeedbackSmallBadge = ({location}: IProps) => {
       data-testid="teacher-feedback-small-badge"
       title="Your teacher left feedback on this page."
     >
-      <TeacherFeedbackBadgeIcon className="teacher-feedback-small-badge-icon" aria-hidden="true" focusable="false" />
+      <TeacherFeedbackBadgeIcon className="teacher-feedback-small-badge-icon" role="img" aria-label="Your teacher left feedback on this page." />
     </div>
   );
 };

--- a/src/components/teacher-feedback/teacher-feedback-small-badge.tsx
+++ b/src/components/teacher-feedback/teacher-feedback-small-badge.tsx
@@ -18,7 +18,6 @@ export const TeacherFeedbackSmallBadge = ({location}: IProps) => {
     <div
       className={className}
       data-testid="teacher-feedback-small-badge"
-      title="Your teacher left feedback on this page."
     >
       <TeacherFeedbackBadgeIcon className="teacher-feedback-small-badge-icon" role="img" aria-label="Your teacher left feedback on this page." />
     </div>


### PR DESCRIPTION
## AP-88 — Mark decorative SVG elements as hidden from assistive technologies

Screen readers were announcing decorative SVG icons across the activity player. This marks the decorative ones `aria-hidden="true" focusable="false"` (the pattern already used by the managed-interactive hint/header icons) so assistive technology skips them, while exposing the icons that actually convey information with accessible names instead.

### Acceptance criteria
- [x] Header profile icon `<svg>` marked decorative (`account-owner.tsx`) — audit issue `#7`
- [x] Main-content time icon `<svg>` marked decorative (`estimated-time.tsx`) — audit issue `#12`
- [x] No decorative SVGs announce themselves — swept every SVG render site in `src/`
- [x] Meaningful SVGs are **not** hidden and instead have accessible names

### Decorative icons hidden (`aria-hidden="true" focusable="false"`)
`account-owner`, `estimated-time`, `custom-select` (arrow + check, covers the sequence activity-selector icon), the teacher-feedback **banner/inline** icons (`activity-level-feedback-banner`, `sequence-intro-feedback-banner`, `summary-page-question-feedback`, `iframe-runtime-feedback`), `teacher-edition-banner`, `section` collapse chevrons, `iframe-runtime` reload, `sidebar-tab` arrow, `completion-page-content` checkmark, `header` sequence-back, and `nav-pages` prev/next/home/hidden/completion icons.

### Meaningful icons exposed with an accessible name (`role="img"` + `aria-label`, `focusable="false"`)
These convey state/status with no adjacent text, so they are named for AT rather than hidden:
- **`summary-table` complete/incomplete icons** — the only content of the "Complete" cell → `aria-label="Complete"`/`"Incomplete"`.
- **`teacher-feedback-small-badge`** — the only cue that a page has feedback → `aria-label="Your teacher left feedback on this page."` (the wrapper `<div title>` is kept as a sighted-only hover tooltip).
- **`sequence-activity-feedback-badge`** — the only cue that an activity has feedback → `aria-label="Your teacher left feedback on this activity."`

### Icon-only control named (`role="button"` + `aria-label`)
- **`sidebar-panel` close control** is icon-only, so the control itself gains `role="button"` + `aria-label="Close"` before its icon is hidden — otherwise hiding the icon would leave the control nameless.

### Review-driven refinements
- `sidebar-tab` toggle now exposes `role="button"` + `aria-expanded` (matching the close control), and both sidebar handlers receive the React event arg and `preventDefault()` on keyboard activation so Space activates the control without scrolling the page.

### Already-accessible (left as-is)
`managed-interactive` hint/header icons (already `aria-hidden`); the logo (already an `<img>` with `alt`).

### Tests
- `account-owner.test.tsx` (new) and `estimated-time.test.tsx` assert the two named decorative icons are `aria-hidden`.
- `summary-table.test.tsx` asserts the status icons expose `role="img"` + accessible names.
- `teacher-feedback-small-badge.test.tsx` asserts the badge is a named, non-focusable image and keeps its sighted tooltip.

`npm run lint` and the affected Jest suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
