### PR TITLE
fix(AP-82): improve text contrast for WCAG 1.4.3 AA

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -96,7 +96,10 @@ body {
     font-size: pxToRem(14);
     margin-top: 10px;
     text-align: center;
-    color: #bbb;
+    // Renders on the teal --theme-primary-color (#0592af) #app background. #bbb
+    // failed WCAG 1.4.3 contrast there. #1f1f1f clears 4.5:1 but only exactly;
+    // since --theme-primary-color is themeable, #1a1a1a (~4.6:1) keeps headroom.
+    color: #1a1a1a;
   }
 
   .activity {

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -98,7 +98,7 @@ body {
     text-align: center;
     // Renders on the teal --theme-primary-color (#0592af) #app background. #bbb
     // failed WCAG 1.4.3 contrast there. #1f1f1f clears 4.5:1 but only exactly;
-    // since --theme-primary-color is themeable, #1a1a1a (~4.6:1) keeps headroom.
+    // since --theme-primary-color is themeable, #1a1a1a (4.75:1) keeps headroom.
     color: #1a1a1a;
   }
 

--- a/src/components/toggle.scss
+++ b/src/components/toggle.scss
@@ -4,7 +4,10 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: $cc-orange-dark1;
+  // Label text color. Uses an accessible gray (#757575 >= 4.5:1 on white) rather
+  // than $cc-orange-dark1, which failed WCAG 1.4.3 contrast. The switch and hover
+  // styles below keep the orange via explicit $cc-orange-dark1 references.
+  color: #757575;
 
   &.disabled {
     color: rgba(121, 121, 121, 0.35);


### PR DESCRIPTION
## Summary

Resolves two color-contrast findings from the accessibility audit (WCAG 1.4.3 Contrast (Minimum), Level AA). [AP-82]

| Element | Before | After | Background | Ratio after |
|---|---|---|---|---|
| "Tap text to listen" toggle label | `#ea6d2f` (~2.9:1) | `#757575` | white | **4.61:1** ✅ |
| `.version-info` (version footer) | `#bbb` (~1.9:1) | `#1a1a1a` | teal `#0592af` | **4.75:1** ✅ |

## Details

- **Toggle label** (`toggle.scss`): the `.toggle` base text `color` (inherited by the `.label`) moves from `$cc-orange-dark1` to `#757575`. Only the label text changes — the switch and hover styles keep the orange via their explicit `$cc-orange-dark1` references, and the disabled state's faded gray still cascades to the label correctly.
- **Version info** (`app.scss`): `.version-info` renders directly on the teal `#app` background (`background-color: var(--theme-primary-color)` = `#0592af`), which is where the audit's `#BBBBBB on #0592AF` finding actually lives.

## Why `#1a1a1a` instead of `#1f1f1f`

The audit's suggested value `#1f1f1f` passes, but at **exactly 4.50:1** — zero headroom. Because `--theme-primary-color` is **themeable**, any future shift to the teal background could tip that pair below the 4.5:1 threshold. `#1a1a1a` clears it at **4.75:1**, keeping a safety margin against theme changes while remaining a near-imperceptible visual difference. A code comment captures this rationale.

## Verification

- Contrast ratios computed with the accesslint engine (values above).
- A full accesslint accessibility audit of the diff confirmed both changed pairs PASS WCAG 1.4.3 AA, with no issues introduced by this PR.
- `npm test` for the affected suites (`toggle.test.tsx`, `read-aloud-toggle.test.tsx`) passes.

## Out of scope

The audit also noted pre-existing toggle items unrelated to this contrast fix (no `:focus-visible` ring on the switch; disabled state communicated only by color + `alert()` rather than `disabled`/`aria-disabled`). Intentionally not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-82]: https://concord-consortium.atlassian.net/browse/AP-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ