### PR TITLE
feat(AP-91): use semantic heading elements for visually styled headings

### DIFF
--- a/src/components/activity-completion/next-steps.scss
+++ b/src/components/activity-completion/next-steps.scss
@@ -33,8 +33,6 @@
           font-style: italic;
         }
         .activity-title {
-          margin: 0;
-          font-size: inherit;
           font-weight: bold;
         }
       }

--- a/src/components/activity-completion/next-steps.scss
+++ b/src/components/activity-completion/next-steps.scss
@@ -33,6 +33,8 @@
           font-style: italic;
         }
         .activity-title {
+          margin: 0;
+          font-size: inherit;
           font-weight: bold;
         }
       }

--- a/src/components/activity-completion/next-steps.tsx
+++ b/src/components/activity-completion/next-steps.tsx
@@ -25,9 +25,9 @@ export const NextSteps: React.FC<IProps> = (props) => {
             <div className="next">
               <DynamicText>Next Up ...</DynamicText>
             </div>
-            <h2 className="activity-title">
+            <div className="activity-title">
               <DynamicText>{nextActivityTitle}</DynamicText>
-            </h2>
+            </div>
           </div>
         </div>
         <div className="preview-description">

--- a/src/components/activity-completion/next-steps.tsx
+++ b/src/components/activity-completion/next-steps.tsx
@@ -25,9 +25,9 @@ export const NextSteps: React.FC<IProps> = (props) => {
             <div className="next">
               <DynamicText>Next Up ...</DynamicText>
             </div>
-            <div className="activity-title">
+            <h2 className="activity-title">
               <DynamicText>{nextActivityTitle}</DynamicText>
-            </div>
+            </h2>
           </div>
         </div>
         <div className="preview-description">

--- a/src/components/activity-introduction/activity-page-links.test.tsx
+++ b/src/components/activity-introduction/activity-page-links.test.tsx
@@ -25,4 +25,12 @@ describe("Activity Page Links component", () => {
     expect(wrapper.containsMatchingElement(<span>Page 3</span>)).toEqual(true);
     expect(wrapper.containsMatchingElement(<button>Begin Activity</button>)).toEqual(true);
   });
+
+  it("renders the 'Pages in this Activity' label as an h2 heading", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const wrapper = shallow(<ActivityPageLinks activityPages={[]} onPageChange={stubFunction} />);
+    expect(wrapper.find("h2.pages").length).toBe(1);
+  });
 });

--- a/src/components/activity-introduction/activity-page-links.tsx
+++ b/src/components/activity-introduction/activity-page-links.tsx
@@ -59,7 +59,7 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
   render() {
     return (
       <div className="activity-page-links" data-cy="activity-page-links">
-        <div className="pages"><DynamicText>Pages in this Activity</DynamicText></div>
+        <h2 className="pages"><DynamicText>Pages in this Activity</DynamicText></h2>
         <div className="separator" />
         { this.props.activityPages.filter((page) => !page.is_hidden).map((page, index: number) => {
             const hasFeedback = pageHasFeedback(page, this.state.pagesWithFeedback, this.state.hasActivityLevelFeedback);

--- a/src/components/activity-page/activity-page-content.scss
+++ b/src/components/activity-page/activity-page-content.scss
@@ -17,6 +17,7 @@
 
     .name {
       flex-grow: 1;
+      margin: 0;
       font-size: pxToRem(24);
       font-weight: bold;
       max-width: 850px;

--- a/src/components/activity-page/activity-page-content.test.tsx
+++ b/src/components/activity-page/activity-page-content.test.tsx
@@ -70,6 +70,26 @@ describe("Activity Page Content component", () => {
     expect(h1).toHaveTextContent("Test Page Title");
   });
 
+  it("falls back to 'Page N' for the h1 when the page has no name (avoids an empty heading)", () => {
+    const unnamedPage = { ...page, name: null };
+    render(
+      <DynamicTextTester>
+        <ActivityPageContent
+          enableReportButton={false}
+          activityLayout={0}
+          page={unnamedPage}
+          pageNumber={5}
+          activity={DefaultTestActivity}
+          totalPreviousQuestions={5}
+          setNavigation={stubFunction}
+          pluginsLoaded={true}
+        />
+      </DynamicTextTester>
+    );
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toHaveTextContent("Page 5");
+  });
+
   describe("with page change notification", () => {
     it("renders page change started notification", () => {
       const { getAllByTestId } = render(

--- a/src/components/activity-page/activity-page-content.test.tsx
+++ b/src/components/activity-page/activity-page-content.test.tsx
@@ -50,6 +50,26 @@ describe("Activity Page Content component", () => {
     expect(screen.getAllByRole("main")).toHaveLength(1);
   });
 
+  it("renders the page title as an h1", () => {
+    const namedPage = { ...page, name: "Test Page Title" };
+    render(
+      <DynamicTextTester>
+        <ActivityPageContent
+          enableReportButton={false}
+          activityLayout={0}
+          page={namedPage}
+          pageNumber={5}
+          activity={DefaultTestActivity}
+          totalPreviousQuestions={5}
+          setNavigation={stubFunction}
+          pluginsLoaded={true}
+        />
+      </DynamicTextTester>
+    );
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toHaveTextContent("Test Page Title");
+  });
+
   describe("with page change notification", () => {
     it("renders page change started notification", () => {
       const { getAllByTestId } = render(

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -121,7 +121,7 @@ export class ActivityPageContent extends React.Component<IProps, IState> {
         {this.renderPageChangeNotification()}
         <main className={`page-content full ${isResponsiveLayout ? "responsive" : ""}`} data-cy="page-content">
           <div className={headerClass}>
-            <div className="name"><DynamicText>{pageTitle}</DynamicText></div>
+            <h1 className="name"><DynamicText>{pageTitle}</DynamicText></h1>
             <ReadAloudToggle />
           </div>
           {isNotebookLayout && <div className="notebookHeader" />}

--- a/src/components/activity-page/activity-page-content.tsx
+++ b/src/components/activity-page/activity-page-content.tsx
@@ -105,7 +105,9 @@ export class ActivityPageContent extends React.Component<IProps, IState> {
 
   render() {
     const { enableReportButton, page, totalPreviousQuestions } = this.props;
-    const pageTitle = page.name || "";
+    // Fall back to "Page N" so the page's sole <h1> always has an accessible name
+    // (page names are routinely absent; this mirrors the nav label in activity-page-links).
+    const pageTitle = page.name || `Page ${this.props.pageNumber}`;
     const sections = page.sections.filter(section => !section.is_hidden);
     const responsiveLayoutSections = sections.filter(s => s.layout.includes("responsive"));
     const isResponsiveLayout = responsiveLayoutSections.length > 0;

--- a/src/components/activity-page/embeddable.scss
+++ b/src/components/activity-page/embeddable.scss
@@ -14,6 +14,12 @@
     padding: 0 0 0 10px;
     color: white;
     background-color: $cc-teal-dark1;
+
+    .embeddable-header-text {
+      margin: 0;
+      font-size: inherit;
+      font-weight: inherit;
+    }
   }
   &.hidden {
     display: none;

--- a/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.test.tsx
@@ -84,3 +84,29 @@ describe("ManagedInteractiveHeader hint trigger", () => {
     expect(trigger).toBeNull();
   });
 });
+
+describe("ManagedInteractiveHeader heading semantics", () => {
+  it("renders the question title as an h2 heading", () => {
+    const { container } = renderHeader();
+    const heading = container.querySelector("h2.embeddable-header-text");
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toContain("Question #1: My question");
+  });
+
+  it("uses the interactive name (with no number) as the heading when question numbers are hidden", () => {
+    const { container } = renderHeader({ questionNumber: undefined, questionName: "Drawing Tool Name" });
+    const heading = container.querySelector("h2.embeddable-header-text");
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toContain("Drawing Tool Name");
+    expect(heading?.textContent).not.toContain("Question #");
+  });
+
+  it("renders no heading element when the header exists only for a hint", () => {
+    // Hidden question number + no name, but a hint is present: the header bar must
+    // still render for the hint trigger, but must NOT introduce an empty heading.
+    const { container, trigger } = renderHeader({ questionNumber: undefined, questionName: "" });
+    expect(container.querySelector("h2")).toBeNull();
+    expect(container.querySelector(".header")).not.toBeNull();
+    expect(trigger).not.toBeNull();
+  });
+});

--- a/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
+++ b/src/components/activity-page/managed-interactive/managed-interactive-header.tsx
@@ -17,14 +17,24 @@ export const ManagedInteractiveHeader: React.FC<IProps> = ({ questionNumber, que
   if (hideHeader) return null;
 
   const trimmedQuestionName = questionName.trim();
+  const hasHeadingText = !!questionNumber || trimmedQuestionName.length > 0;
+
+  const headingContent = (
+    <DynamicText>
+      {questionNumber && `Question #${questionNumber}`}
+      {trimmedQuestionName.length > 0 && questionNumber && ": "}
+      {questionName}
+    </DynamicText>
+  );
 
   return (
     <div className="header">
-      <DynamicText>
-        {questionNumber && `Question #${questionNumber}`}
-        {trimmedQuestionName.length > 0 && questionNumber && ": "}
-        {questionName}
-      </DynamicText>
+      {/* Use a semantic heading when there is title text; otherwise keep the bare
+          (empty) DynamicText so the header still occupies the layout slot for the
+          hint button without introducing an empty heading. */}
+      {hasHeadingText
+        ? <h2 className="embeddable-header-text">{headingContent}</h2>
+        : headingContent}
       {hint && (
         <button
           ref={triggerRef}

--- a/src/components/activity-page/text-box/text-box.scss
+++ b/src/components/activity-page/text-box/text-box.scss
@@ -18,6 +18,8 @@
   }
 
   .text-name {
+    margin: 0;
+    font-size: inherit;
     font-weight: bold;
     padding: 8px 0 5px;
   }

--- a/src/components/activity-page/text-box/text-box.tsx
+++ b/src/components/activity-page/text-box/text-box.tsx
@@ -16,9 +16,10 @@ interface IProps {
 
 export const TextBox: React.FC<IProps> = (props) => {
   const { embeddable} = props;
+  const trimmedName = embeddable.name?.trim();
   return(
     <div className={`textbox ${embeddable.is_callout ? "callout" : ""}`} data-cy="text-box">
-      { embeddable.name && <h2 className="text-name"><DynamicText context={dynamicTextManager}>{embeddable.name}</DynamicText></h2> }
+      { trimmedName && <h2 className="text-name"><DynamicText context={dynamicTextManager}>{trimmedName}</DynamicText></h2> }
       <div className="content">
         <DynamicText context={dynamicTextManager}>
           <div className="question-txt">

--- a/src/components/activity-page/text-box/text-box.tsx
+++ b/src/components/activity-page/text-box/text-box.tsx
@@ -18,7 +18,7 @@ export const TextBox: React.FC<IProps> = (props) => {
   const { embeddable} = props;
   return(
     <div className={`textbox ${embeddable.is_callout ? "callout" : ""}`} data-cy="text-box">
-      { embeddable.name && <div className="text-name"><DynamicText context={dynamicTextManager}>{embeddable.name}</DynamicText></div> }
+      { embeddable.name && <h2 className="text-name"><DynamicText context={dynamicTextManager}>{embeddable.name}</DynamicText></h2> }
       <div className="content">
         <DynamicText context={dynamicTextManager}>
           <div className="question-txt">

--- a/src/components/page-sidebar/sidebar-panel.scss
+++ b/src/components/page-sidebar/sidebar-panel.scss
@@ -11,8 +11,10 @@
     height: 40px;
 
     .sidebar-title{
+      margin: 0;
       color: white;
       font-size: pxToRem(20);
+      font-weight: normal;
       width: 100%;
       text-align: center;
     }

--- a/src/components/page-sidebar/sidebar-panel.tsx
+++ b/src/components/page-sidebar/sidebar-panel.tsx
@@ -20,7 +20,7 @@ export class SidebarPanel extends React.PureComponent<IProps>{
     return (
       <div className={`sidebar-panel ${this.props.show ? "visible " : "hidden"}`}>
         <div className="sidebar-header">
-          <div className="sidebar-title" data-cy="sidebar-title">{this.props.title}</div>
+          <h2 className="sidebar-title" data-cy="sidebar-title">{this.props.title}</h2>
           <div className="icon" onClick={this.handleCloseButton} onKeyDown={this.handleCloseButton}
                data-cy="sidebar-close-button" tabIndex={0} role="button" aria-label="Close">
             <IconClose aria-hidden="true" focusable="false" />

--- a/src/components/page-sidebar/sidebar-panel.tsx
+++ b/src/components/page-sidebar/sidebar-panel.tsx
@@ -17,10 +17,15 @@ interface IProps {
 export class SidebarPanel extends React.PureComponent<IProps>{
   render() {
     const innerContent = this.props.content ? this.props.content : "";
+    // Only use a heading when there is title text; otherwise keep a non-heading
+    // placeholder so the close button stays positioned without an empty heading.
+    const hasTitle = !!this.props.title?.trim();
     return (
       <div className={`sidebar-panel ${this.props.show ? "visible " : "hidden"}`}>
         <div className="sidebar-header">
-          <h2 className="sidebar-title" data-cy="sidebar-title">{this.props.title}</h2>
+          {hasTitle
+            ? <h2 className="sidebar-title" data-cy="sidebar-title">{this.props.title}</h2>
+            : <div className="sidebar-title" data-cy="sidebar-title" />}
           <div className="icon" onClick={this.handleCloseButton} onKeyDown={this.handleCloseButton}
                data-cy="sidebar-close-button" tabIndex={0} role="button" aria-label="Close">
             <IconClose aria-hidden="true" focusable="false" />

--- a/src/components/page-sidebar/sidebar.test.tsx
+++ b/src/components/page-sidebar/sidebar.test.tsx
@@ -31,4 +31,30 @@ describe("SidebarTab component", () => {
     expect(wrapper.find('[data-cy="sidebar-title"]').text()).toContain(title);
     expect(wrapper.find('[data-cy="sidebar-content"]').length).toBe(1);
   });
+  it("renders the panel title as an h2 heading when present", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const wrapper = shallow(<SidebarPanel
+      title={"Did you know?"}
+      index={0}
+      content={"content"}
+      show={true}
+      handleCloseSidebarContent={stubFunction} />);
+    expect(wrapper.find("h2.sidebar-title").length).toBe(1);
+  });
+  it("renders no heading element when the sidebar has no title (avoids an empty heading)", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const wrapper = shallow(<SidebarPanel
+      title={null}
+      index={0}
+      content={"content"}
+      show={true}
+      handleCloseSidebarContent={stubFunction} />);
+    expect(wrapper.find("h2").length).toBe(0);
+    // The placeholder keeps the data-cy hook so layout/selectors are preserved.
+    expect(wrapper.find('[data-cy="sidebar-title"]').length).toBe(1);
+  });
 });

--- a/src/components/sequence-introduction/sequence-page-content.scss
+++ b/src/components/sequence-introduction/sequence-page-content.scss
@@ -21,7 +21,7 @@
         flex-grow: 1;
 
 
-        h2 {
+        h1 {
           font-size: pxToRem(32);
           font-weight: 900;
           margin: 0;

--- a/src/components/sequence-introduction/sequence-page-content.test.tsx
+++ b/src/components/sequence-introduction/sequence-page-content.test.tsx
@@ -36,6 +36,6 @@ describe("Sequence Page Content component", () => {
     };
     render(<DynamicTextTester><SequencePageContent sequence={sequence} onSelectActivity={stubFunction} /></DynamicTextTester>);
     const h1 = screen.getByRole("heading", { level: 1 });
-    expect(h1).toHaveTextContent(sequence.display_title || sequence.title || "");
+    expect(h1).toHaveTextContent(sequence.display_title || sequence.title || "Sequence");
   });
 });

--- a/src/components/sequence-introduction/sequence-page-content.test.tsx
+++ b/src/components/sequence-introduction/sequence-page-content.test.tsx
@@ -30,4 +30,12 @@ describe("Sequence Page Content component", () => {
     render(<DynamicTextTester><SequencePageContent sequence={sequence} onSelectActivity={stubFunction} /></DynamicTextTester>);
     expect(screen.getByRole("main")).toBeInTheDocument();
   });
+  it("renders the sequence title as an h1", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    render(<DynamicTextTester><SequencePageContent sequence={sequence} onSelectActivity={stubFunction} /></DynamicTextTester>);
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toHaveTextContent(sequence.display_title || sequence.title || "");
+  });
 });

--- a/src/components/sequence-introduction/sequence-page-content.tsx
+++ b/src/components/sequence-introduction/sequence-page-content.tsx
@@ -70,7 +70,7 @@ export const SequencePageContent: React.FC<IProps> = (props) => {
         <div className="introduction-content">
           <div className="sequence-header">
             <div className="sequence-title">
-              <h1><DynamicText>{sequence.display_title || sequence.title || ""}</DynamicText></h1>
+              <h1><DynamicText>{sequence.display_title || sequence.title || "Sequence"}</DynamicText></h1>
             </div>
             <ReadAloudToggle />
           </div>

--- a/src/components/sequence-introduction/sequence-page-content.tsx
+++ b/src/components/sequence-introduction/sequence-page-content.tsx
@@ -70,7 +70,7 @@ export const SequencePageContent: React.FC<IProps> = (props) => {
         <div className="introduction-content">
           <div className="sequence-header">
             <div className="sequence-title">
-              <h2><DynamicText>{sequence.display_title || sequence.title || ""}</DynamicText></h2>
+              <h1><DynamicText>{sequence.display_title || sequence.title || ""}</DynamicText></h1>
             </div>
             <ReadAloudToggle />
           </div>

--- a/src/components/single-page/related-content.scss
+++ b/src/components/single-page/related-content.scss
@@ -15,9 +15,12 @@
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    margin: 0;
     padding: 0 0 0 10px;
     color: white;
     background-color: $cc-teal-dark1;
+    font-size: inherit;
+    font-weight: inherit;
   }
   .related-content-text {
     padding: 20px;

--- a/src/components/single-page/related-content.test.tsx
+++ b/src/components/single-page/related-content.test.tsx
@@ -12,6 +12,8 @@ describe("Related Content component", () => {
 
   it("renders the 'Related activities' bar as an h2 heading", () => {
     const wrapper = shallow(<RelatedContent relatedContentText={"content here"} />);
-    expect(wrapper.find("h2.header").length).toBe(1);
+    const heading = wrapper.find("h2.header");
+    expect(heading.length).toBe(1);
+    expect(heading.text()).toBe("Related activities");
   });
 });

--- a/src/components/single-page/related-content.test.tsx
+++ b/src/components/single-page/related-content.test.tsx
@@ -9,4 +9,9 @@ describe("Related Content component", () => {
     expect(wrapper.find('[data-cy="related-content-header"]').length).toBe(1);
     expect(wrapper.find('[data-cy="related-content-text"]').length).toBe(1);
   });
+
+  it("renders the 'Related activities' bar as an h2 heading", () => {
+    const wrapper = shallow(<RelatedContent relatedContentText={"content here"} />);
+    expect(wrapper.find("h2.header").length).toBe(1);
+  });
 });

--- a/src/components/single-page/related-content.tsx
+++ b/src/components/single-page/related-content.tsx
@@ -10,7 +10,7 @@ interface RelatedContentProps {
 export const RelatedContent: React.FC<RelatedContentProps> = (props) => {
   return (
     <div className="related-content" data-cy="related-content">
-      <div className="header" data-cy="related-content-header">Related activities</div>
+      <h2 className="header" data-cy="related-content-header">Related activities</h2>
       <div className="related-content-text" data-cy="related-content-text">
         { renderHTML(props.relatedContentText) }
       </div>

--- a/src/components/single-page/single-page-content.scss
+++ b/src/components/single-page/single-page-content.scss
@@ -6,4 +6,11 @@
   background-color: rgba(255,255,255,0.95);
   padding: 20px;
   margin-bottom: 20px;
+
+  .activity-name {
+    margin: 0;
+    font-size: pxToRem(24);
+    font-weight: bold;
+    color: var(--theme-secondary-color);
+  }
 }

--- a/src/components/single-page/single-page-content.test.tsx
+++ b/src/components/single-page/single-page-content.test.tsx
@@ -23,4 +23,9 @@ describe("Single Page Content component", () => {
     render(<DynamicTextTester><SinglePageContent activity={DefaultTestActivity} pluginsLoaded={true} /></DynamicTextTester>);
     expect(screen.getByRole("main")).toBeInTheDocument();
   });
+  it("renders the activity name as the page h1", () => {
+    render(<DynamicTextTester><SinglePageContent activity={DefaultTestActivity} pluginsLoaded={true} /></DynamicTextTester>);
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toHaveTextContent("name");
+  });
 });

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -49,7 +49,7 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
 
   return (
     <main className="single-page-content" data-cy="single-page-content">
-      <h1 className="activity-name"><DynamicText>{activity.name}</DynamicText></h1>
+      <h1 className="activity-name"><DynamicText>{activity.name || "Activity"}</DynamicText></h1>
       <ReadAloudToggle style={{justifyContent: "flex-end"}} />
 
       {activity.pages.filter((page) => !page.is_hidden).map((page, index: number) => (

--- a/src/components/single-page/single-page-content.tsx
+++ b/src/components/single-page/single-page-content.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { DynamicText } from "@concord-consortium/dynamic-text";
 
 import { numQuestionsOnPreviousSections, numQuestionsOnPreviousPages } from "../../utilities/activity-utils";
 import { RelatedContent } from "./related-content";
@@ -48,6 +49,7 @@ export const SinglePageContent: React.FC<IProps> = (props) => {
 
   return (
     <main className="single-page-content" data-cy="single-page-content">
+      <h1 className="activity-name"><DynamicText>{activity.name}</DynamicText></h1>
       <ReadAloudToggle style={{justifyContent: "flex-end"}} />
 
       {activity.pages.filter((page) => !page.is_hidden).map((page, index: number) => (

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
@@ -2,4 +2,10 @@
 
 .intro-page-activity-level-feedback {
   flex: 1 1 100%;
+
+  // Preserve the previous visual size now that this is an <h2> rather than an <h1>
+  h2 {
+    margin: 0.67em 0;
+    font-size: pxToRem(32);
+  }
 }

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
@@ -3,7 +3,6 @@
 .intro-page-activity-level-feedback {
   flex: 1 1 100%;
 
-  // Preserve the previous visual size now that this is an <h2> rather than an <h1>
   h2 {
     margin: 0.67em 0;
     font-size: pxToRem(32);

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.test.tsx
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.test.tsx
@@ -13,4 +13,10 @@ describe("Activity Level Feedback component", () => {
     const wrapper = shallow(<IntroPageActivityLevelFeedback teacherFeedback={mockFeedback} />);
     expect(wrapper.find('[data-testid="intro-page-activity-level-feedback"]').length).toBe(1);
   });
+
+  it("renders the 'Teacher Feedback' label as an h2 (not an h1, to avoid a duplicate page h1)", () => {
+    const wrapper = shallow(<IntroPageActivityLevelFeedback teacherFeedback={mockFeedback} />);
+    expect(wrapper.find("h2").length).toBe(1);
+    expect(wrapper.find("h1").length).toBe(0);
+  });
 });

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.tsx
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.tsx
@@ -12,7 +12,7 @@ interface IProps {
 export const IntroPageActivityLevelFeedback = ({ teacherFeedback }: IProps) => {
   return (
     <div className="intro-page-activity-level-feedback" data-testid="intro-page-activity-level-feedback">
-      <h1><DynamicText>Teacher Feedback</DynamicText></h1>
+      <h2><DynamicText>Teacher Feedback</DynamicText></h2>
       <ActivityLevelFeedbackBanner teacherFeedback={teacherFeedback} />
     </div>
   );


### PR DESCRIPTION
## AP-91 — Use semantic heading elements for visually styled headings

[AP-91](https://concord-consortium.atlassian.net/browse/AP-91) · WCAG **1.3.1 Info and Relationships** (Level A)

Text that visually functions as a heading is now wrapped in semantic `<h1>`–`<h6>` elements so screen-reader users get a meaningful document outline and can navigate by heading. The audit finding (Issue #10) was the intro page's **"Pages in this Activity"** label, which wasn't a heading; this PR also brings the rest of the AP's own styled headings into a consistent outline.

Scope is the Activity Player's own code only — **not** question/managed interactives, whose prompt content lives in iframes (per the story's clarification).

### Outline model

- Each view's primary in-page title is its **sole `<h1>`**; the persistent banner ("Activity: X") stays a non-heading landmark.
- Embeddable-level headings (text blocks, question/interactive headers) are `<h2>` under the page `<h1>`.

| View | `h1` | `h2`(s) |
|---|---|---|
| Activity intro | Activity name *(already h1)* | **Pages in this Activity** *(audit fix)* · Teacher Feedback *(was a 2nd h1)* |
| Content page | Page title *(was `div.name`; now falls back to "Page N" when unnamed)* | Text-block names · Question/interactive headers |
| Single-page layout | **Activity name (new h1 — none before)** | Text-block names · Question/interactive headers · "Related activities" |
| Sequence intro | Sequence title *(was h2)* | — |
| Completion | "Summary of Work" *(already h1)* | — |

### What changed (current state → fix)

**Existing semantic headings audited:** activity-summary `h1` ✓, completion "Summary of Work" `h1` ✓, error/idle-warning `h1` ✓ (left as-is); sequence title `h2`→`h1`; "Teacher Feedback" `h1`→`h2` (was a duplicate h1 on the intro page).

**Visual headings promoted to semantic elements:**

| Element | Was | Now |
|---|---|---|
| "Pages in this Activity" (`activity-page-links`) | `div.pages` | `h2` |
| Content page title (`activity-page-content`) | `div.name` | `h1` |
| Text-box section name (`text-box`) | `div.text-name` | `h2` |
| Sidebar panel title (`sidebar-panel`) | `div.sidebar-title` | `h2` |
| Question/interactive header (`managed-interactive-header`) | `div.header` text | `h2.embeddable-header-text` |
| "Related activities" bar (`related-content`) | `div.header` | `h2` |
| Single-page activity title (`single-page-content`) | *(none)* | `h1` |

Each `div`→heading conversion has a matching SCSS reset (`margin: 0`, preserved `font-size`/`font-weight`) so there is **no visual change**. The question/interactive header keeps a bare (empty) `DynamicText` when it renders only for a hint, so it never produces an empty heading and the existing `.header div` DOM contract + hint-button alignment are preserved.

### Accessibility audit (accesslint) — addressed

A full accesslint audit of the PR returned **PASS WITH NOTES**. Findings actioned:

- **(major)** Content page `<h1>` fell back to `""` for the many LARA pages without a name → empty heading / nameless sole h1. **Fixed:** falls back to `Page ${pageNumber}` (matching the nav label convention).
- **(minor)** Next-activity title on a mid-sequence completion page rendered an `<h2>` before the page `<h1>` (h2-before-h1). **Fixed:** reverted that label to a non-heading `<div>` — it's a preview-card label, not a document section heading.

Confirmed clean by the audit: no skipped heading levels, exactly one `h1` per view, banner correctly non-heading, no interactive control nested inside a heading, no empty headings reachable in the guarded components.

### Verification

- Drove the running app (Playwright) and confirmed the live outline on the intro page (`h1` "Sample Layout Types" → `h2` "Pages in this Activity") and a content page (`h1` "Full Width" → `h2` question/interactive/text-block headers); teal header bars visually unchanged.
- New Jest tests lock in the heading markup (tag + level), including the empty-name "Page N" fallback and the no-empty-heading behavior of the hint-only interactive header.
- `npm test`: **91 suites / 439 passed / 9 skipped.** Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-91]: https://concord-consortium.atlassian.net/browse/AP-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ