### PR TITLE
fix(AP-83): avoid nested <main> landmarks from skip-link wrappers

### DIFF
--- a/cypress/e2e/skip-link.test.ts
+++ b/cypress/e2e/skip-link.test.ts
@@ -29,6 +29,10 @@ context("skip to main content", () => {
     // Activating the link moves keyboard focus to the main content region.
     cy.get('[data-cy="skip-link"]').click();
     cy.focused().should("have.attr", "id", "main-content");
-    cy.get("main#main-content").should("have.attr", "tabindex", "-1");
+    cy.get("#main-content").should("have.attr", "tabindex", "-1");
+
+    // The skip-link target is a wrapper that must contain exactly one <main>
+    // landmark (AP-83 regression: nested <main>s confuse AT landmark nav).
+    cy.get("main").should("have.length", 1);
   });
 });

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -163,8 +163,8 @@ body {
   }
 }
 
-/* The main landmark is focused programmatically via the skip link; it should
-   not show a focus outline since it is not an interactive control. */
-main#main-content:focus {
+/* The skip-link target is focused programmatically via the skip link; it
+   should not show a focus outline since it is not an interactive control. */
+#main-content:focus {
   outline: none;
 }

--- a/src/components/app.test.tsx
+++ b/src/components/app.test.tsx
@@ -60,18 +60,20 @@ describe("App component", () => {
     // skip link must not be a dead in-page link.
     const wrapper = shallow(<App />);
     expect(wrapper.find(".skip-link").length).toBe(0);
-    expect(wrapper.find("main#main-content").length).toBe(0);
+    expect(wrapper.find("#main-content").length).toBe(0);
     // error state with no activity also has no main-content target
     wrapper.setState({ errorType: "auth" });
     expect(wrapper.find(".skip-link").length).toBe(0);
   });
-  it("renders a main landmark targeted by the skip link", () => {
+  it("renders a focusable skip-link target wrapping the main content", () => {
     const wrapper = shallow(<App />);
     wrapper.setState({ activity });
-    const main = wrapper.find("main#main-content");
-    expect(main.length).toBe(1);
-    // tabIndex -1 makes the landmark programmatically focusable for the skip link
-    expect(main.prop("tabIndex")).toBe(-1);
+    // The target is a plain <div>, not a <main>: the layout rendered inside
+    // provides the single <main> landmark, so a <main> here would nest landmarks.
+    const target = wrapper.find("div#main-content");
+    expect(target.length).toBe(1);
+    // tabIndex -1 makes the target programmatically focusable for the skip link
+    expect(target.prop("tabIndex")).toBe(-1);
   });
   it("renders single page activity at the default fixed width", () => {
     const wrapper = shallow(<App />);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -628,7 +628,10 @@ export class App extends React.PureComponent<IProps, IState> {
         {renderTopNav &&
           this.renderNav(activity, currentPage, fullWidth, "Page navigation")
         }
-        <main id="main-content" tabIndex={-1}>
+        {/* Skip-link focus target (WCAG 2.4.1). This is a plain <div>, not a
+            <main>, because each layout rendered inside already provides its own
+            single <main> landmark; a <main> here would nest landmarks. */}
+        <div id="main-content" tabIndex={-1}>
           {activity.layout === ActivityLayouts.SinglePage
             ? this.renderSinglePageContent(activity)
             : currentPage === 0
@@ -653,7 +656,7 @@ export class App extends React.PureComponent<IProps, IState> {
                   saveInteractiveStateHistory={this.state.saveInteractiveStateHistory}
                 />
           }
-        </main>
+        </div>
         {renderBottomNav &&
           this.renderNav(activity, currentPage, fullWidth, "Page navigation (bottom)")
         }

--- a/src/components/sequence-introduction/sequence-introduction.test.tsx
+++ b/src/components/sequence-introduction/sequence-introduction.test.tsx
@@ -19,15 +19,17 @@ describe("Sequence Page Content component", () => {
     expect(wrapper.find(Footer).length).toBe(1);
     expect(wrapper.find(SequencePageContent).length).toBe(1);
   });
-  it("wraps the sequence content in a focusable main landmark", () => {
+  it("wraps the sequence content in a focusable skip-link target", () => {
     const stubFunction = () => {
       // do nothing.
     };
     const wrapper = shallow(<SequenceIntroduction sequence={sequence} username="test" onSelectActivity={stubFunction} />);
-    const main = wrapper.find("main#main-content");
-    expect(main.length).toBe(1);
-    expect(main.prop("tabIndex")).toBe(-1);
-    expect(main.find(SequencePageContent).length).toBe(1);
+    // The target is a plain <div>, not a <main>: SequencePageContent provides
+    // the single <main> landmark, so a <main> here would nest landmarks.
+    const target = wrapper.find("div#main-content");
+    expect(target.length).toBe(1);
+    expect(target.prop("tabIndex")).toBe(-1);
+    expect(target.find(SequencePageContent).length).toBe(1);
   });
   it("renders empty component", () => {
     const stubFunction = () => {

--- a/src/components/sequence-introduction/sequence-introduction.tsx
+++ b/src/components/sequence-introduction/sequence-introduction.tsx
@@ -30,12 +30,15 @@ export const SequenceIntroduction: React.FC<IProps> = (props) => {
           contentName={sequence.display_title || sequence.title || ""}
           showSequence={true}
         />
-        <main id="main-content" tabIndex={-1}>
+        {/* Skip-link focus target (WCAG 2.4.1). A plain <div>, not a <main>:
+            SequencePageContent already renders its own single <main> landmark,
+            so a <main> here would nest landmarks. */}
+        <div id="main-content" tabIndex={-1}>
           <SequencePageContent
             sequence={sequence}
             onSelectActivity={onSelectActivity}
           />
-        </main>
+        </div>
         <Footer
           fullWidth={true}
           project={sequence.project}


### PR DESCRIPTION
## Summary

Fixes a regression from [AP-83](https://concord-consortium.atlassian.net/browse/AP-83) (the skip-to-main-content link work, commit `90a1f8c`): the app was rendering **nested `<main>` landmarks** per view — invalid HTML that confuses assistive-tech landmark navigation. Flagged by Copilot while reviewing the AP-91 headings PR (#566).

### Root cause

AP-83 added an outer `<main id="main-content">` skip-link target in two places (`app.tsx`, `sequence-introduction.tsx`) without accounting for the **six pre-existing inner `<main>` elements** (2020–2021) that each layout already renders (one per view): `page-content`, `single-page-content`, `sequence-content`, `intro-content`, and `completion-page-content` (×2 branches). Every view ended up with two nested `<main>`s.

### Fix (Option C — smallest, safest)

Demote both skip-link wrappers from `<main id="main-content" tabIndex={-1}>` to `<div id="main-content" tabIndex={-1}>`, leaving each layout's inner `<main>` as the single landmark per view.

- ✅ One `<main>` landmark per view (the legacy inner one)
- ✅ Skip link still resolves to `#main-content` — focus target unchanged
- ✅ No churn in the six layout components or their existing "single main landmark" tests
- Tradeoff: the skip target is now a wrapper `<div>` whose sole child is the `<main>`, rather than the `<main>` itself — fully satisfies WCAG 2.4.1 (Bypass Blocks), whose requirement is to move focus to the main-content region.

### Changes

| File | Change |
|---|---|
| `src/components/app.tsx` | outer `<main id="main-content">` → `<div>` |
| `src/components/sequence-introduction/sequence-introduction.tsx` | same |
| `src/components/app.scss` | `main#main-content:focus` → `#main-content:focus` |
| `src/components/app.test.tsx` | assert `div#main-content` skip-link target |
| `src/components/sequence-introduction/sequence-introduction.test.tsx` | same |
| `cypress/e2e/skip-link.test.ts` | `#main-content` selector + **new guard: exactly one `<main>` per view** |

### Verification

- `npm test` (full Jest suite): 91 suites / 429 passed / 9 skipped / 0 failed
- `eslint` (build config) on changed files: clean
- The new Cypress assertion (`cy.get("main").should("have.length", 1)`) is the regression guard — it will fail loudly if a nested `<main>` ever reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-83]: https://concord-consortium.atlassian.net/browse/AP-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ