### PR TITLE
fix(AP-92,AP-93): semantic list and link markup for activity page links

### DIFF
--- a/cypress/e2e/workspace.test.ts
+++ b/cypress/e2e/workspace.test.ts
@@ -37,8 +37,10 @@ context("Test the overall app", () => {
       cy.log("go to correct page when tabbed and keydown enter from page list");
       cy.get("[data-cy=nav-pages] a").eq(1).type("{enter}");
       cy.get("[data-cy=intro-page-content]").should("be.visible");
+      // realPress dispatches a trusted Enter so the native <a> activates the way
+      // it does for a real keyboard user; synthetic .type("{enter}") cannot.
       cy.get(".page-item").eq(1).focus();
-      cy.focused().type("{enter}");
+      cy.realPress("Enter");
       activityPage.getSidebarTab().should("be.visible");
     });
   });

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,5 +1,8 @@
 // add code coverage support
 import "@cypress/code-coverage/support";
+// adds cy.realPress/realClick/etc. which dispatch trusted events (e.g. so a
+// native <a> activates on a real keyboard Enter, which synthetic .type() cannot do)
+import "cypress-real-events";
 
 Cypress.on("uncaught:exception", (err, runnable) => {
   // returning false here prevents Cypress from

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "include": [
     "../node_modules/cypress/types",
+    "../node_modules/cypress-real-events/index.d.ts",
     "**/*.ts"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "copy-webpack-plugin": "^6.4.1",
         "css-loader": "^5.2.7",
         "cypress": "^13.6.3",
+        "cypress-real-events": "^1.15.0",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.6",
         "eslint": "^7.32.0",
@@ -11192,6 +11193,16 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-real-events": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.15.0.tgz",
+      "integrity": "sha512-in98xxTnnM9Z7lZBvvVozm99PBT2eEOjXRG5LKWyYvQnj9mGWXMiPNpfw7e7WiraBFh7XlXIxnE9Cu5o+52kQQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "cypress": "^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x || ^15.x"
       }
     },
     "node_modules/cypress/node_modules/buffer": {
@@ -34472,6 +34483,12 @@
           "dev": true
         }
       }
+    },
+    "cypress-real-events": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/cypress-real-events/-/cypress-real-events-1.15.0.tgz",
+      "integrity": "sha512-in98xxTnnM9Z7lZBvvVozm99PBT2eEOjXRG5LKWyYvQnj9mGWXMiPNpfw7e7WiraBFh7XlXIxnE9Cu5o+52kQQ==",
+      "dev": true
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.2.7",
     "cypress": "^13.6.3",
+    "cypress-real-events": "^1.15.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.32.0",

--- a/src/components/activity-introduction/activity-page-links.scss
+++ b/src/components/activity-introduction/activity-page-links.scss
@@ -28,6 +28,11 @@
 
   .page-item-container {
     position: relative;
+    // The absolutely-positioned feedback badge overlaps the link's top-left
+    // corner; let clicks fall through to the link rather than being swallowed.
+    .teacher-feedback-small-badge {
+      pointer-events: none;
+    }
   }
 
   .page-item {

--- a/src/components/activity-introduction/activity-page-links.scss
+++ b/src/components/activity-introduction/activity-page-links.scss
@@ -20,22 +20,37 @@
     margin: 10px;
   }
 
+  .page-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .page-item-container {
+    position: relative;
+  }
+
   .page-item {
     display: flex;
     align-items: center;
     width: 260px;
     height: 40px;
     padding: 0 10px;
-    position: relative;
     cursor: pointer;
+    color: inherit;
+    text-decoration: none;
     &:hover {
       background-color: $cc-teal-light4;
       .page-link {
         text-decoration: underline;
       }
     }
+    &:focus-visible {
+      box-shadow: inset 0 0 0 2.5px $cc-button-focus-ring, inset 0 0 0 3.5px white;
+      outline: none;
+    }
     &:active {
-      background-color: $cc-teal;
+      background-color: $cc-teal-dark2;
       color: white;
     }
 

--- a/src/components/activity-introduction/activity-page-links.scss
+++ b/src/components/activity-introduction/activity-page-links.scss
@@ -44,6 +44,9 @@
     cursor: pointer;
     color: inherit;
     text-decoration: none;
+    &:visited {
+      color: inherit;
+    }
     &:hover {
       background-color: $cc-teal-light4;
       .page-link {

--- a/src/components/activity-introduction/activity-page-links.test.tsx
+++ b/src/components/activity-introduction/activity-page-links.test.tsx
@@ -1,7 +1,21 @@
 import React from "react";
 import { ActivityPageLinks } from "./activity-page-links";
 import { shallow } from "enzyme";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { DefaultTestPage } from "../../test-utils/model-for-tests";
+import { DynamicTextTester } from "../../test-utils/dynamic-text";
+import { Page } from "../../types";
+
+const noop = () => {
+  // do nothing.
+};
+
+const renderPageLinks = (activityPages: Page[], onPageChange: (page: number) => void = noop) =>
+  render(
+    <DynamicTextTester>
+      <ActivityPageLinks activityPages={activityPages} onPageChange={onPageChange} />
+    </DynamicTextTester>
+  );
 
 jest.mock("../../firebase-db", () => ({
   watchActivityLevelFeedback: jest.fn(),
@@ -24,5 +38,80 @@ describe("Activity Page Links component", () => {
     expect(wrapper.containsMatchingElement(<span>Page 2</span>)).toEqual(true);
     expect(wrapper.containsMatchingElement(<span>Page 3</span>)).toEqual(true);
     expect(wrapper.containsMatchingElement(<button>Begin Activity</button>)).toEqual(true);
+  });
+});
+
+describe("Activity Page Links accessibility", () => {
+  // Pages with distinct ids so each link's href resolves to a specific page.
+  const pagesWithIds = [
+    {...DefaultTestPage, name: "Page One", id: 101, position: 1},
+    {...DefaultTestPage, name: "Page Two", id: 102, position: 2},
+    {...DefaultTestPage, name: "Page Three", id: 103, position: 3},
+  ];
+
+  it("renders the page list as a <ul> of <li> wrapping native <a> links", () => {
+    const { container } = renderPageLinks(pagesWithIds);
+    expect(container.querySelector("ul.page-list")).not.toBeNull();
+    expect(container.querySelectorAll("li.page-item-container > a.page-item").length).toBe(3);
+    expect(screen.getAllByRole("link").length).toBe(3);
+  });
+
+  it("builds each link href from the page id", () => {
+    renderPageLinks(pagesWithIds);
+    expect(screen.getByRole("link", { name: "1: Page One" }).getAttribute("href")).toBe("?page=page_101");
+    expect(screen.getByRole("link", { name: "2: Page Two" }).getAttribute("href")).toBe("?page=page_102");
+    expect(screen.getByRole("link", { name: "3: Page Three" }).getAttribute("href")).toBe("?page=page_103");
+  });
+
+  it("includes the index prefix in each link's accessible name", () => {
+    // The trailing space after the index keeps the name as "1: Page One" rather
+    // than "1:Page One"; getByRole would not match the name without it.
+    renderPageLinks(pagesWithIds);
+    expect(screen.getByRole("link", { name: "1: Page One" })).toBeTruthy();
+  });
+
+  it("omits hidden pages from the list", () => {
+    const pages = [
+      {...DefaultTestPage, name: "Visible", id: 201, position: 1},
+      {...DefaultTestPage, name: "Hidden", id: 202, position: 2, is_hidden: true},
+      {...DefaultTestPage, name: "Also Visible", id: 203, position: 3},
+    ];
+    renderPageLinks(pages);
+    expect(screen.getAllByRole("link").length).toBe(2);
+    expect(screen.queryByRole("link", { name: /Hidden/ })).toBeNull();
+  });
+
+  it("requests the page change on a plain click", () => {
+    const onPageChange = jest.fn();
+    renderPageLinks(pagesWithIds, onPageChange);
+    fireEvent.click(screen.getByRole("link", { name: "2: Page Two" }));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it("defers modified clicks to the browser without requesting a page change", () => {
+    // cmd/ctrl/shift/alt-clicks should open the page natively (e.g. new tab) via
+    // the anchor href, not trigger an in-app page change.
+    const onPageChange = jest.fn();
+    renderPageLinks(pagesWithIds, onPageChange);
+    const link = screen.getByRole("link", { name: "1: Page One" });
+    fireEvent.click(link, { metaKey: true });
+    fireEvent.click(link, { ctrlKey: true });
+    fireEvent.click(link, { shiftKey: true });
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("renders no stray text nodes inside the list", () => {
+    const { container } = renderPageLinks(pagesWithIds);
+    const list = container.querySelector("ul.page-list")!;
+    const textNodes = Array.from(list.childNodes).filter((n) => n.nodeType === Node.TEXT_NODE);
+    expect(textNodes).toHaveLength(0);
+    Array.from(list.children).forEach((child) => expect(child.tagName).toBe("LI"));
+  });
+
+  it("requests the first page from the Begin Activity button", () => {
+    const onPageChange = jest.fn();
+    renderPageLinks(pagesWithIds, onPageChange);
+    fireEvent.click(screen.getByRole("button", { name: "Begin Activity" }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
   });
 });

--- a/src/components/activity-introduction/activity-page-links.test.tsx
+++ b/src/components/activity-introduction/activity-page-links.test.tsx
@@ -81,10 +81,11 @@ describe("Activity Page Links accessibility", () => {
     expect(screen.queryByRole("link", { name: /Hidden/ })).toBeNull();
   });
 
-  it("navigates by page position, not visible index, so href and click stay aligned", () => {
-    // A hidden page at position 2 shifts the visible indices: the second visible
-    // page lives at position 3 / id 303, even though its display ordinal is "2".
-    // Both the href (by id) and the click (by position) must resolve to it.
+  it("navigates by 1-based visible page index while linking by page id", () => {
+    // The app renders pages by visible index (pagesVisible[currentPage - 1]), so
+    // onPageChange must receive that index, not page.position. A hidden page does
+    // not get a link, so the second *visible* page is index 2 even though its
+    // page.position is 3. The href, by contrast, is built from the page id.
     const onPageChange = jest.fn();
     const pages = [
       {...DefaultTestPage, name: "First", id: 301, position: 1},
@@ -95,7 +96,7 @@ describe("Activity Page Links accessibility", () => {
     const thirdLink = screen.getByRole("link", { name: "2: Third" });
     expect(thirdLink.getAttribute("href")).toBe("?page=page_303");
     fireEvent.click(thirdLink);
-    expect(onPageChange).toHaveBeenCalledWith(3);
+    expect(onPageChange).toHaveBeenCalledWith(2);
   });
 
   it("requests the page change on a plain click", () => {

--- a/src/components/activity-introduction/activity-page-links.test.tsx
+++ b/src/components/activity-introduction/activity-page-links.test.tsx
@@ -115,6 +115,7 @@ describe("Activity Page Links accessibility", () => {
     fireEvent.click(link, { metaKey: true });
     fireEvent.click(link, { ctrlKey: true });
     fireEvent.click(link, { shiftKey: true });
+    fireEvent.click(link, { altKey: true });
     expect(onPageChange).not.toHaveBeenCalled();
   });
 

--- a/src/components/activity-introduction/activity-page-links.test.tsx
+++ b/src/components/activity-introduction/activity-page-links.test.tsx
@@ -81,6 +81,23 @@ describe("Activity Page Links accessibility", () => {
     expect(screen.queryByRole("link", { name: /Hidden/ })).toBeNull();
   });
 
+  it("navigates by page position, not visible index, so href and click stay aligned", () => {
+    // A hidden page at position 2 shifts the visible indices: the second visible
+    // page lives at position 3 / id 303, even though its display ordinal is "2".
+    // Both the href (by id) and the click (by position) must resolve to it.
+    const onPageChange = jest.fn();
+    const pages = [
+      {...DefaultTestPage, name: "First", id: 301, position: 1},
+      {...DefaultTestPage, name: "Hidden", id: 302, position: 2, is_hidden: true},
+      {...DefaultTestPage, name: "Third", id: 303, position: 3},
+    ];
+    renderPageLinks(pages, onPageChange);
+    const thirdLink = screen.getByRole("link", { name: "2: Third" });
+    expect(thirdLink.getAttribute("href")).toBe("?page=page_303");
+    fireEvent.click(thirdLink);
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
   it("requests the page change on a plain click", () => {
     const onPageChange = jest.fn();
     renderPageLinks(pagesWithIds, onPageChange);

--- a/src/components/activity-introduction/activity-page-links.test.tsx
+++ b/src/components/activity-introduction/activity-page-links.test.tsx
@@ -133,4 +133,13 @@ describe("Activity Page Links accessibility", () => {
     fireEvent.click(screen.getByRole("button", { name: "Begin Activity" }));
     expect(onPageChange).toHaveBeenCalledWith(1);
   });
+
+  it("navigates from the Begin Activity button even with a modifier key held", () => {
+    // The button is not a link, so a modified click should still start the
+    // activity rather than being deferred to the browser like the anchors are.
+    const onPageChange = jest.fn();
+    renderPageLinks(pagesWithIds, onPageChange);
+    fireEvent.click(screen.getByRole("button", { name: "Begin Activity" }), { metaKey: true });
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/components/activity-introduction/activity-page-links.tsx
+++ b/src/components/activity-introduction/activity-page-links.tsx
@@ -70,6 +70,7 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
                     className="page-item"
                     href={getPageHref(page.id)}
                     onClick={this.handlePageChange(index + 1)}
+                    title={hasFeedback ? "Your teacher left feedback on this page." : undefined}
                   >
                     <span>{`${index + 1}: `}</span>
                     <span className="page-link">{`${page.name ? page.name : "Page " + (index + 1)}`}</span>

--- a/src/components/activity-introduction/activity-page-links.tsx
+++ b/src/components/activity-introduction/activity-page-links.tsx
@@ -4,7 +4,7 @@ import { DynamicText } from "@concord-consortium/dynamic-text";
 import { ActivityFeedback, Page } from "../../types";
 import { pageHasFeedback, subscribeToActivityLevelFeedback, subscribeToQuestionLevelFeedback } from "../../utilities/feedback-utils";
 import { TeacherFeedbackSmallBadge } from "../teacher-feedback/teacher-feedback-small-badge";
-import { accessibilityClick } from "../../utilities/accessibility-helper";
+import { getPageHref } from "../../utilities/url-query";
 import { QuestionInfoContext } from "../question-info-context";
 
 import "./activity-page-links.scss";
@@ -61,27 +61,28 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
       <div className="activity-page-links" data-cy="activity-page-links">
         <div className="pages"><DynamicText>Pages in this Activity</DynamicText></div>
         <div className="separator" />
-        { this.props.activityPages.filter((page) => !page.is_hidden).map((page, index: number) => {
-            const hasFeedback = pageHasFeedback(page, this.state.pagesWithFeedback, this.state.hasActivityLevelFeedback);
-            return (
-              <div
-                className="page-item"
-                key={`index ${index}`}
-                onClick={this.handlePageChange(index + 1)}
-                onKeyDown={this.handlePageChange(index + 1)}
-                tabIndex={0}
-              >
-                <span>{`${index + 1}:`}</span>
-                <span className="page-link">{`${page.name ? page.name : "Page " + (index + 1)}`}</span>
-                {hasFeedback && <TeacherFeedbackSmallBadge location="page-links" />}
-              </div>
-            );
-        })
-        }
+        <ul className="page-list">
+          { this.props.activityPages.filter((page) => !page.is_hidden).map((page, index: number) => {
+              const hasFeedback = pageHasFeedback(page, this.state.pagesWithFeedback, this.state.hasActivityLevelFeedback);
+              return (
+                <li className="page-item-container" key={`index ${index}`}>
+                  <a
+                    className="page-item"
+                    href={getPageHref(page.id)}
+                    onClick={this.handlePageChange(index + 1)}
+                  >
+                    <span>{`${index + 1}: `}</span>
+                    <span className="page-link">{`${page.name ? page.name : "Page " + (index + 1)}`}</span>
+                  </a>
+                  {hasFeedback && <TeacherFeedbackSmallBadge location="page-links" />}
+                </li>
+              );
+          })
+          }
+        </ul>
         <button
           className="button begin"
           onClick={this.handlePageChange(1)}
-          onKeyDown={this.handlePageChange(1)}
         >
           Begin Activity
         </button>
@@ -89,10 +90,14 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
     );
   }
 
-  private handlePageChange = (page: number) => () => {
-    if (accessibilityClick(event)) {
-      this.props.onPageChange(page);
+  private handlePageChange = (page: number) => (e?: React.MouseEvent) => {
+    // Let the browser handle modified clicks (e.g. cmd/ctrl-click to open the
+    // page in a new tab) natively via the anchor's href.
+    if (e && (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)) {
+      return;
     }
+    e?.preventDefault();
+    this.props.onPageChange(page);
   }
 
   private unsubscribeActivityLevelFeedback: (() => void) | undefined = undefined;

--- a/src/components/activity-introduction/activity-page-links.tsx
+++ b/src/components/activity-introduction/activity-page-links.tsx
@@ -69,7 +69,7 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
                   <a
                     className="page-item"
                     href={getPageHref(page.id)}
-                    onClick={this.handlePageChange(page.position)}
+                    onClick={this.handlePageChange(index + 1)}
                   >
                     <span>{`${index + 1}: `}</span>
                     <span className="page-link">{`${page.name ? page.name : "Page " + (index + 1)}`}</span>

--- a/src/components/activity-introduction/activity-page-links.tsx
+++ b/src/components/activity-introduction/activity-page-links.tsx
@@ -69,7 +69,7 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
                   <a
                     className="page-item"
                     href={getPageHref(page.id)}
-                    onClick={this.handlePageChange(index + 1)}
+                    onClick={this.handlePageLinkClick(index + 1)}
                     title={hasFeedback ? "Your teacher left feedback on this page." : undefined}
                   >
                     <span>{`${index + 1}: `}</span>
@@ -83,7 +83,7 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
         </ul>
         <button
           className="button begin"
-          onClick={this.handlePageChange(1)}
+          onClick={this.handleBeginClick}
         >
           Begin Activity
         </button>
@@ -91,14 +91,20 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
     );
   }
 
-  private handlePageChange = (page: number) => (e?: React.MouseEvent) => {
+  private handlePageLinkClick = (page: number) => (e: React.MouseEvent) => {
     // Let the browser handle modified clicks (e.g. cmd/ctrl-click to open the
     // page in a new tab) natively via the anchor's href.
-    if (e && (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)) {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
       return;
     }
-    e?.preventDefault();
+    e.preventDefault();
     this.props.onPageChange(page);
+  }
+
+  // The Begin Activity button is not a link (no href), so it always navigates
+  // in-app regardless of any modifier key the user happens to be holding.
+  private handleBeginClick = () => {
+    this.props.onPageChange(1);
   }
 
   private unsubscribeActivityLevelFeedback: (() => void) | undefined = undefined;

--- a/src/components/activity-introduction/activity-page-links.tsx
+++ b/src/components/activity-introduction/activity-page-links.tsx
@@ -65,11 +65,11 @@ export class ActivityPageLinks extends React.PureComponent <IProps, IState> {
           { this.props.activityPages.filter((page) => !page.is_hidden).map((page, index: number) => {
               const hasFeedback = pageHasFeedback(page, this.state.pagesWithFeedback, this.state.hasActivityLevelFeedback);
               return (
-                <li className="page-item-container" key={`index ${index}`}>
+                <li className="page-item-container" key={page.id}>
                   <a
                     className="page-item"
                     href={getPageHref(page.id)}
-                    onClick={this.handlePageChange(index + 1)}
+                    onClick={this.handlePageChange(page.position)}
                   >
                     <span>{`${index + 1}: `}</span>
                     <span className="page-link">{`${page.name ? page.name : "Page " + (index + 1)}`}</span>


### PR DESCRIPTION
## Summary

Makes the "Pages in this Activity" navigation list on the activity introduction page accessible, addressing two sibling VPAT stories under epic AP-81:

- **AP-92** (WCAG 1.3.1, Level A) — proper `<ul>`/`<li>` list semantics
- **AP-93** (WCAG 4.1.2, Level A) — each item rendered as a native `<a href>` link

This mirrors the accessible pagination pattern established in AP-90 (`nav-pages.tsx`).

## Changes

- **`activity-page-links.tsx`**: page items are now a `<ul className="page-list">` of `<li>`, each wrapping a native `<a href={getPageHref(page.id)}>`. The click handler `preventDefault()`s and routes through `onPageChange`, while deferring modified clicks (cmd/ctrl/shift/alt) to the browser for open-in-new-tab. Removed the now-unused `accessibilityClick` / `tabIndex` / `onKeyDown` plumbing.
- **`activity-page-links.scss`**: list reset, `position: relative` moved to the `<li>` container (preserves feedback-badge anchoring), and neutralized default anchor color/underline so the visual design is unchanged.

## Accessibility polish (from an accesslint audit)

- **1.4.3 (AA):** `:active` background darkened `$cc-teal` → `$cc-teal-dark2` so white text reaches ~7:1 (was 3.66:1) — consistent with AP-82.
- **2.4.7 (AA):** added a `:focus-visible` ring matching `nav-pages` / header buttons.
- **4.1.2:** trailing space in the index span so the link's accessible name reads "1: Page name" reliably across browsers/AT.

Heading semantics for the "Pages in this Activity" title (an advisory finding) are handled separately in AP-91.

## Testing

- ✅ Full Jest suite (91 suites, 429 passed, 9 skipped)
- ✅ ESLint clean (`lint:build` config)
- Cypress runs on CI; existing `.page-item` selectors (click/focus + the two child spans) are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
