### PR TITLE
fix(AP-95): make Hide/Show collapsible a semantic disclosure button

### DIFF
--- a/cypress/e2e/activity-page.test.ts
+++ b/cypress/e2e/activity-page.test.ts
@@ -43,15 +43,22 @@ context("Test the overall app", () => {
 
       cy.log("verify collapsible column");
       activityPage.getNavPage(2).click();
+      // The trigger is a semantic disclosure button: aria-expanded tracks the open state and
+      // aria-controls references the panel it shows/hides (AP-95).
+      activityPage.getCollapsibleHeader().should("have.prop", "tagName", "BUTTON");
+      activityPage.getCollapsibleHeader().should("have.attr", "aria-controls");
       activityPage.getCollapsibleHeader().should("contain", "Hide");
+      activityPage.getCollapsibleHeader().should("have.attr", "aria-expanded", "true");
       activityPage.getCollapsibleHeader().click();
       // Clicking the header re-renders it (class + label both change), so keep each assertion
       // on its own statement to re-query and avoid asserting against a detached element.
       activityPage.getCollapsibleHeader().should("have.class", "collapsed");
       activityPage.getCollapsibleHeader().should("contain", "Show");
+      activityPage.getCollapsibleHeader().should("have.attr", "aria-expanded", "false");
       activityPage.getCollapsibleHeader().click();
       activityPage.getCollapsibleHeader().should("have.not.class", "collapsed");
       activityPage.getCollapsibleHeader().should("contain", "Hide");
+      activityPage.getCollapsibleHeader().should("have.attr", "aria-expanded", "true");
 
       cy.log("Required questions");
       cy.log("verify locked navigation");

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -214,6 +214,12 @@
     }
   }
 
+  // The collapsible panel groups the secondary embeddables so the trigger's aria-controls
+  // can reference it; `display: contents` keeps the embeddables as direct layout children.
+  .collapsible-panel {
+    display: contents;
+  }
+
   .collapsible-header {
     display: flex;
     justify-content: flex-end;
@@ -221,7 +227,11 @@
     box-sizing: border-box;
     padding: 20px;
     margin-bottom: 10px;
+    width: 100%;
     height: 35px;
+    border: none;
+    font: inherit;
+    text-align: inherit;
     background-color: $cc-charcoal;
     color: $cc-charcoal-light2;
     transition-duration: .25s;

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -240,6 +240,13 @@
     top: 0;
     z-index: 3;
 
+    // Explicit, high-contrast focus ring (the sticky dark header can clip or wash out the
+    // browser default). Inset so the sticky/clipped edges don't hide it.
+    &:focus-visible {
+      outline: 2px solid white;
+      outline-offset: -2px;
+    }
+
     &.right {
       justify-content: flex-start;
     }

--- a/src/components/activity-page/section.test.tsx
+++ b/src/components/activity-page/section.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Section } from "./section";
-import { configure, render } from "@testing-library/react";
+import { configure, fireEvent, render } from "@testing-library/react";
 import { DefaultTestPage, DefaultTestSection, DefaultXhtmlComponent } from "../../test-utils/model-for-tests";
 import { IEmbeddableXhtml } from "../../types";
 
@@ -130,6 +130,66 @@ describe("Section component", () => {
 
       const collapsibleHeader = getByTestId("collapsible-header");
       expect(collapsibleHeader.classList.contains("left")).toBe(true);
+    });
+  });
+
+  describe("collapsible secondary column accessibility (AP-95)", () => {
+    const createXhtmlEmbeddable = (refId: string, column: "primary" | "secondary"): IEmbeddableXhtml => ({
+      ...DefaultXhtmlComponent,
+      column,
+      ref_id: refId
+    });
+
+    const renderCollapsibleSection = () => {
+      const page = {...DefaultTestPage};
+      const section = {
+        ...DefaultTestSection,
+        embeddables: [
+          createXhtmlEmbeddable("primary-1", "primary"),
+          createXhtmlEmbeddable("secondary-1", "secondary")
+        ],
+        layout: "responsive-50-50",
+        secondary_column_collapsible: true
+      };
+      return render(<Section
+        activityLayout={0}
+        section={section}
+        page={page}
+        pluginsLoaded={true}
+        questionNumberStart={1}
+        setNavigation={stubFunction}
+      />);
+    };
+
+    it("renders the collapsible trigger as a native button", () => {
+      const { getByTestId } = renderCollapsibleSection();
+      const trigger = getByTestId("collapsible-header");
+      expect(trigger.tagName).toBe("BUTTON");
+    });
+
+    it("exposes an accessible name on the trigger", () => {
+      const { getByTestId } = renderCollapsibleSection();
+      const trigger = getByTestId("collapsible-header");
+      // accessible name must contain the visible word ("Hide") for WCAG Label in Name
+      expect(trigger.getAttribute("aria-label")).toMatch(/hide/i);
+    });
+
+    it("reflects the expanded state and toggles aria-expanded on activation", () => {
+      const { getByTestId } = renderCollapsibleSection();
+      const trigger = getByTestId("collapsible-header");
+      expect(trigger.getAttribute("aria-expanded")).toBe("true");
+      fireEvent.click(trigger);
+      expect(getByTestId("collapsible-header").getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(getByTestId("collapsible-header"));
+      expect(getByTestId("collapsible-header").getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("references the controlled panel via aria-controls", () => {
+      const { getByTestId, container } = renderCollapsibleSection();
+      const trigger = getByTestId("collapsible-header");
+      const panelId = trigger.getAttribute("aria-controls");
+      expect(panelId).toBeTruthy();
+      expect(container.querySelector(`#${panelId}`)).not.toBeNull();
     });
   });
 });

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -9,6 +9,7 @@ import { EmbeddableType, Page, SectionType } from "../../types";
 import { Logger, LogEventName } from "../../lib/logger";
 import { IGetInteractiveState, INavigationOptions } from "@concord-consortium/lara-interactive-api";
 import useResizeObserver from "@react-hook/resize-observer";
+import { nanoid } from "../../utilities/nanoid";
 
 import "./section.scss";
 
@@ -37,6 +38,10 @@ const left = "left";
 export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
   const { activityLayout, page, section, questionNumberStart, hiddenTab, addRefToQuestionMap } = props;
   const [isSecondaryCollapsed, setIsSecondaryCollapsed] = useState(false);
+
+  // Stable id wiring the collapsible "Hide/Show" trigger to the panel it controls,
+  // referenced by the trigger's aria-controls for the disclosure ARIA relationship.
+  const collapsiblePanelId = useRef(`secondary-column-panel-${nanoid()}`).current;
 
   const sectionDivRef = useRef<HTMLDivElement>(null);
   const primaryDivRef = useRef<HTMLDivElement>(null);
@@ -140,7 +145,11 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
     return (
       <div className={containerClass} ref={secondaryDivRef} data-cy="section-column-secondary">
         {secondaryEmbeddablesToRender.length > 0 && collapsible && renderCollapsibleHeader()}
-        {!isSecondaryCollapsed && renderEmbeddables(secondaryEmbeddablesToRender, questionNumStart)}
+        {/* The panel wrapper carries the id referenced by the trigger's aria-controls. It uses
+            `display: contents` so the embeddables remain direct layout children of the column. */}
+        <div id={collapsiblePanelId} className="collapsible-panel">
+          {!isSecondaryCollapsed && renderEmbeddables(secondaryEmbeddablesToRender, questionNumStart)}
+        </div>
       </div>
     );
   };
@@ -149,8 +158,12 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
     const collapsibleColumnOnLeft = section.layout === "30-70" || section.layout === "40-60" || section.layout === "responsive-30-70" || section.layout === "responsive-50-50";
     const headerClass = `collapsible-header ${isSecondaryCollapsed ? "collapsed" : ""} ${collapsibleColumnOnLeft ? left : right}`;
     return (
-      <div className={headerClass} data-cy="collapsible-header" tabIndex={0}
-            onClick={handleCollapseHeader} onKeyDown={handleCollapseHeader} >
+      // A native <button> gives the disclosure its semantics and keyboard support (Enter/Space)
+      // for free. aria-expanded reflects the open state; aria-controls points at the panel.
+      <button type="button" className={headerClass} data-cy="collapsible-header"
+            aria-expanded={!isSecondaryCollapsed} aria-controls={collapsiblePanelId}
+            aria-label={isSecondaryCollapsed ? "Show content" : "Hide content"}
+            onClick={handleCollapseHeader} >
         {isSecondaryCollapsed
           ? <React.Fragment>
               {renderCollapseArrow(collapsibleColumnOnLeft ? right : left)}
@@ -162,7 +175,7 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
               {collapsibleColumnOnLeft && <div>Hide</div>}
             </React.Fragment>
         }
-      </div>
+      </button>
     );
   };
 
@@ -186,7 +199,7 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
     );
   };
 
-  const handleCollapseHeader = (e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => {
+  const handleCollapseHeader = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (accessibilityClick(e))  {
       Logger.log({
         event: LogEventName.toggle_collapsible_column,


### PR DESCRIPTION
## Summary

Fixes [AP-95](https://concord-consortium.atlassian.net/browse/AP-95) — the "Hide/Show" collapsible secondary column was a non-semantic `<div tabIndex={0}>`, so assistive tech couldn't identify it as a control or report whether the section was expanded (audit issues #47–#50; WCAG 4.1.2, Level A).

Because the collapsible lives in the shared `Section` component, this single fix covers every page that uses it (pages 2, 4, 5, 6).

## Changes

- **Trigger → native `<button>`**: gives focusability and Enter/Space activation for free (the manual `onKeyDown` handler is removed).
- **`aria-expanded`**: reflects and updates with the open/closed state.
- **`aria-controls`**: references the panel. The secondary embeddables are wrapped in a panel `<div>` that carries the id and uses `display: contents`, so embeddables remain direct layout children of the column — **no visual change**.
- **`aria-label`** ("Hide content" / "Show content"): contains the visible word so it also satisfies Label in Name (WCAG 2.5.3).
- **SCSS**: reset native button chrome (`border`, `font`, `text-align`, `width`) so the header renders identically.

## Acceptance criteria

- [x] Trigger implemented as a native `<button>`
- [x] Full keyboard interaction (Tab to focus, Enter/Space to activate)
- [x] Accessible name via `aria-label` (+ visible text)
- [x] `aria-expanded` set true/false and updated dynamically
- [x] `aria-controls` references the associated panel id
- [x] Applied across all affected pages (single shared component)

## Testing

- `section.test.tsx`: added 4 unit tests — button role, accessible name, `aria-expanded` toggle on activation, and `aria-controls`→panel linkage.
- `cypress/e2e/activity-page.test.ts`: added `tagName`, `aria-controls`, and `aria-expanded` assertions around the toggle.
- Full Jest suite green (433 passed); ESLint (build config) clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Accessibility audit

Ran an accesslint WCAG 2.1 AA audit on the diff: **0 conformance failures**. One best-practice enhancement applied — an explicit `:focus-visible` ring on the button (2.4.7), since the browser default ring can be clipped/low-contrast on the sticky dark header. Optional findings (panel `role="region"`, more distinct accessible name) were intentionally left out.


[AP-95]: https://concord-consortium.atlassian.net/browse/AP-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ