### PR TITLE
fix(AP-120): restore heading colors lost in AP-91 div→heading conversion

### DIFF
--- a/src/components/activity-page/embeddable.scss
+++ b/src/components/activity-page/embeddable.scss
@@ -17,6 +17,13 @@
 
     .embeddable-header-text {
       margin: 0;
+      // Inherit the header bar's white text. As an <h2> this element is otherwise
+      // caught by the global `.app h2 { color: $cc-charcoal }` rule, which would
+      // render the question header dark on the teal bar (AP-120). This targeted
+      // exception keeps only question/interactive headers white; other h2s (e.g.
+      // text-block headers) intentionally remain charcoal. The global element-level
+      // h1/h2 rules are legacy and slated for cleanup in a follow-up story.
+      color: inherit;
       font-size: inherit;
       font-weight: inherit;
     }

--- a/src/components/activity-page/embeddable.scss
+++ b/src/components/activity-page/embeddable.scss
@@ -26,6 +26,7 @@
       color: inherit;
       font-size: inherit;
       font-weight: inherit;
+      line-height: inherit;
     }
   }
   &.hidden {

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
@@ -4,11 +4,12 @@
   flex: 1 1 100%;
 
   // Preserve the previous visual size and color now that this is an <h2> rather
-  // than an <h1>. The global `.app h2 { color: $cc-charcoal }` rule would
-  // otherwise shift this heading from the themeable secondary color it had as an
-  // <h1> to charcoal; restore the original `--theme-secondary-color` so the
-  // div->heading conversion stays visually neutral.
-  h2 {
+  // than an <h1>. The global `.app h2` rule would otherwise shift this heading to
+  // charcoal at pxToRem(18); restore the original `--theme-secondary-color` and
+  // size so the div->heading conversion stays visually neutral. The `.app &`
+  // prefix raises specificity to (0,2,1) so it reliably beats the equal-specificity
+  // global `.app h2` rule regardless of CSS injection order.
+  .app & h2 {
     margin: 0.67em 0;
     font-size: pxToRem(32);
     color: var(--theme-secondary-color);

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
@@ -4,11 +4,12 @@
   flex: 1 1 100%;
 
   // Preserve the previous visual size and color now that this is an <h2> rather
-  // than an <h1>. The global `.app h2` rule would otherwise shift this heading to
-  // charcoal at pxToRem(18); restore the original `--theme-secondary-color` and
-  // size so the div->heading conversion stays visually neutral. The `.app &`
-  // prefix raises specificity to (0,2,1) so it reliably beats the equal-specificity
-  // global `.app h2` rule regardless of CSS injection order.
+  // than an <h1>. The global `.app h2` rule (specificity 0,1,1) would otherwise
+  // shift this heading to charcoal at pxToRem(18); restore the original
+  // `--theme-secondary-color` and size so the div->heading conversion stays
+  // visually neutral. Without the `.app &` prefix this selector would tie that
+  // global rule and lose by source order; the prefix raises it to (0,2,1) so it
+  // reliably wins regardless of CSS injection order.
   .app & h2 {
     margin: 0.67em 0;
     font-size: pxToRem(32);

--- a/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
+++ b/src/components/teacher-feedback/intro-page-activity-level-feedback.scss
@@ -3,8 +3,14 @@
 .intro-page-activity-level-feedback {
   flex: 1 1 100%;
 
+  // Preserve the previous visual size and color now that this is an <h2> rather
+  // than an <h1>. The global `.app h2 { color: $cc-charcoal }` rule would
+  // otherwise shift this heading from the themeable secondary color it had as an
+  // <h1> to charcoal; restore the original `--theme-secondary-color` so the
+  // div->heading conversion stays visually neutral.
   h2 {
     margin: 0.67em 0;
     font-size: pxToRem(32);
+    color: var(--theme-secondary-color);
   }
 }


### PR DESCRIPTION
## What & why

Fixes **[AP-120](https://concord-consortium.atlassian.net/browse/AP-120)** — the question/interactive header text was rendering dark charcoal on the teal header bar instead of white.

### Root cause
AP-91 (semantic headings) converted several styled-text `div`s into semantic `<h1>`/`<h2>` elements and added `margin` / `font-size` / `font-weight` resets to keep them visually unchanged — but it did **not** preserve their **color**. As a result the legacy global element rules in `app.scss`:

```scss
.app h1 { color: var(--theme-secondary-color); ... }
.app h2 { color: $cc-charcoal; ... }
```

began *directly matching* the new headings and overrode the colors they had previously **inherited**. (A directly-matched `color` beats an inherited one regardless of specificity.)

### Two headings regressed — both fixed here
- **Question / interactive header** (`.embeddable-header-text`): inherited white from the teal `.header` bar; now rendered dark on teal. → add `color: inherit` so it picks up the bar's white again. Targeted exception for question/interactive headers only; other `<h2>`s (e.g. text-block headers) keep the intended charcoal.
- **"Teacher Feedback" intro heading**: was an `<h1>` in the theme secondary color, became an `<h2>` in charcoal. → restore `--theme-secondary-color` so the conversion stays visually neutral, as AP-91 intended.

## Scope note / follow-up
The global `.app h1/h2` element rules are legacy (originally completion-page styling, commit `44a0d3d`) and a latent trap for semantic headings. This PR is a **targeted** fix; retiring or scoping those rules properly is tracked as a follow-up: **AP-122**.

## Testing
- `managed-interactive-header` and `intro-page-activity-level-feedback` Jest suites pass (15 tests).
- Color changes are visual (jsdom can't assert computed color) — verify in-app that the question header text and "Teacher Feedback" heading render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-120]: https://concord-consortium.atlassian.net/browse/AP-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ