### PR TITLE
fix(AP-98,100,101,102): accessible "Did you know?" sidebar (semantic buttons + contrast)

### DIFF
--- a/src/components/page-sidebar/sidebar-panel.scss
+++ b/src/components/page-sidebar/sidebar-panel.scss
@@ -21,6 +21,10 @@
     }
 
     .icon {
+      // Reset native <button> chrome so the close control renders identically to the former div.
+      border: none;
+      background: none;
+      padding: 0;
       // Charcoal fill meets WCAG 1.4.11 non-text contrast against the orange header (was white).
       fill: $cc-charcoal;
       width: 24px;

--- a/src/components/page-sidebar/sidebar-panel.scss
+++ b/src/components/page-sidebar/sidebar-panel.scss
@@ -41,6 +41,13 @@
       &:active {
         background-color: $cc-orange-light2;
       }
+      // Theme-independent focus indicator matching .version-info in app.scss: a solid charcoal
+      // outline reads 5.32:1 on the orange header and survives forced-colors mode, where the
+      // themed box-shadow ring used by .button can drop below contrast under the orange theme.
+      &:focus-visible {
+        outline: 2px solid $cc-charcoal;
+        outline-offset: 2px;
+      }
     }
   }
 

--- a/src/components/page-sidebar/sidebar-panel.scss
+++ b/src/components/page-sidebar/sidebar-panel.scss
@@ -21,7 +21,8 @@
     }
 
     .icon {
-      fill: white;
+      // Charcoal fill meets WCAG 1.4.11 non-text contrast against the orange header (was white).
+      fill: $cc-charcoal;
       width: 24px;
       height: 18px;
       margin-right: 9px;

--- a/src/components/page-sidebar/sidebar-panel.scss
+++ b/src/components/page-sidebar/sidebar-panel.scss
@@ -12,7 +12,8 @@
 
     .sidebar-title{
       margin: 0;
-      color: white;
+      // Charcoal on the orange header meets WCAG 1.4.3 AA contrast (was white).
+      color: $cc-charcoal;
       font-size: pxToRem(20);
       font-weight: normal;
       width: 100%;

--- a/src/components/page-sidebar/sidebar-panel.scss
+++ b/src/components/page-sidebar/sidebar-panel.scss
@@ -33,13 +33,13 @@
       border-radius: 5px;
       cursor: pointer;
 
+      // Keep the charcoal fill in hover/active (only the background shifts) so the "x" stays
+      // above 3:1 non-text contrast throughout interaction: 8.77:1 on hover, 6.64:1 on active.
       &:hover {
         background-color: $cc-orange-light4;
-        fill: $cc-orange-light2;
       }
       &:active {
         background-color: $cc-orange-light2;
-        fill: $cc-orange;
       }
     }
   }

--- a/src/components/page-sidebar/sidebar-panel.tsx
+++ b/src/components/page-sidebar/sidebar-panel.tsx
@@ -26,10 +26,12 @@ export class SidebarPanel extends React.PureComponent<IProps>{
           {hasTitle
             ? <h2 className="sidebar-title" data-cy="sidebar-title">{this.props.title}</h2>
             : <div className="sidebar-title" data-cy="sidebar-title" />}
-          <div className="icon" onClick={this.handleCloseButton} onKeyDown={this.handleCloseButton}
-               data-cy="sidebar-close-button" tabIndex={0} role="button" aria-label="Close">
+          {/* A native <button> gives the close control its semantics and Enter/Space activation
+              for free; aria-label supplies its accessible name since the "x" icon is decorative. */}
+          <button type="button" className="icon" onClick={this.handleCloseButton}
+               data-cy="sidebar-close-button" aria-label="Close">
             <IconClose aria-hidden="true" focusable="false" />
-          </div>
+          </button>
         </div>
         <DynamicText>
           <div className="sidebar-content help-content" data-cy="sidebar-content">{renderHTML(innerContent)}
@@ -39,12 +41,8 @@ export class SidebarPanel extends React.PureComponent<IProps>{
     );
   }
 
-  private handleCloseButton = (e: React.MouseEvent | React.KeyboardEvent) => {
+  private handleCloseButton = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (accessibilityClick(e)){
-      // role="button" div: stop Space from also scrolling the page on keyboard activation
-      if (e.type === "keydown") {
-        e.preventDefault();
-      }
       this.props.handleCloseSidebarContent(this.props.index, false);
     }
   }

--- a/src/components/page-sidebar/sidebar-tab.scss
+++ b/src/components/page-sidebar/sidebar-tab.scss
@@ -1,6 +1,10 @@
 @import "../vars.scss";
 
 .sidebar-tab {
+  // Reset native <button> chrome so the trigger renders identically to the former div.
+  border: none;
+  font: inherit;
+  color: inherit;
   cursor: pointer;
   width: 75px;
   min-height: 70px;

--- a/src/components/page-sidebar/sidebar-tab.scss
+++ b/src/components/page-sidebar/sidebar-tab.scss
@@ -25,6 +25,13 @@
   &:active {
     background-color: $cc-orange-light3;
   }
+  // Theme-independent focus indicator matching .version-info in app.scss: a solid charcoal
+  // outline reads 5.32:1 on the orange tab and survives forced-colors mode, where the themed
+  // box-shadow ring used by .button can drop below the required contrast under the orange theme.
+  &:focus-visible {
+    outline: 2px solid $cc-charcoal;
+    outline-offset: 2px;
+  }
 
   .icon {
     height: 30px;

--- a/src/components/page-sidebar/sidebar-tab.scss
+++ b/src/components/page-sidebar/sidebar-tab.scss
@@ -2,6 +2,10 @@
 
 .sidebar-tab {
   // Reset native <button> chrome so the trigger renders identically to the former div.
+  // box-sizing: content-box is part of that reset — a native <button> defaults to border-box,
+  // which would subtract the 5px padding from the 75px width and leave a gap between the tab's
+  // right edge and the viewport (the former div was content-box).
+  box-sizing: content-box;
   border: none;
   font: inherit;
   color: inherit;

--- a/src/components/page-sidebar/sidebar-tab.tsx
+++ b/src/components/page-sidebar/sidebar-tab.tsx
@@ -18,22 +18,21 @@ export class SidebarTab extends React.PureComponent<IProps>{
 
   render() {
     return (
-      <div className="sidebar-tab" onClick={this.handleSidebarShow} onKeyDown={this.handleSidebarShow}
-           data-cy="sidebar-tab" tabIndex={0} role="button" aria-expanded={this.props.sidebarOpen}>
+      // A native <button> gives the trigger its semantics and Enter/Space activation for free.
+      // aria-haspopup="dialog" announces that it opens the sidebar panel; aria-expanded reflects
+      // the open state. The visible "tab-name" text supplies the button's accessible name.
+      <button type="button" className="sidebar-tab" onClick={this.handleSidebarShow}
+           data-cy="sidebar-tab" aria-haspopup="dialog" aria-expanded={this.props.sidebarOpen}>
         <div className={`icon ${this.props.sidebarOpen ? "open" : ""}`}>
           <IconArrow aria-hidden="true" focusable="false" />
         </div>
         <div className="tab-name" data-cy="sidebar-tab-title">{this.props.title}</div>
-      </div>
+      </button>
     );
   }
 
-  private handleSidebarShow = (e: React.MouseEvent | React.KeyboardEvent) => {
+  private handleSidebarShow = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (accessibilityClick(e)) {
-      // role="button" div: stop Space from also scrolling the page on keyboard activation
-      if (e.type === "keydown") {
-        e.preventDefault();
-      }
       this.props.handleShowSidebarContent(this.props.index, !this.props.sidebarOpen);
     }
   }

--- a/src/components/page-sidebar/sidebar-tab.tsx
+++ b/src/components/page-sidebar/sidebar-tab.tsx
@@ -27,10 +27,12 @@ export class SidebarTab extends React.PureComponent<IProps>{
       <button type="button" className="sidebar-tab" onClick={this.handleSidebarShow}
            data-cy="sidebar-tab" aria-haspopup="dialog" aria-expanded={this.props.sidebarOpen}
            aria-label={hasTitle ? undefined : "Show sidebar"}>
-        <div className={`icon ${this.props.sidebarOpen ? "open" : ""}`}>
+        {/* A <button> may only contain phrasing content, so these are <span>s, not <div>s;
+            the parent's display:flex blockifies them, so layout is unchanged. */}
+        <span className={`icon ${this.props.sidebarOpen ? "open" : ""}`}>
           <IconArrow aria-hidden="true" focusable="false" />
-        </div>
-        <div className="tab-name" data-cy="sidebar-tab-title">{this.props.title}</div>
+        </span>
+        <span className="tab-name" data-cy="sidebar-tab-title">{this.props.title}</span>
       </button>
     );
   }

--- a/src/components/page-sidebar/sidebar-tab.tsx
+++ b/src/components/page-sidebar/sidebar-tab.tsx
@@ -17,12 +17,16 @@ export class SidebarTab extends React.PureComponent<IProps>{
   }
 
   render() {
+    // The visible "tab-name" text is the button's accessible name when a title exists; fall back
+    // to a static aria-label only when there is none, so the button is never unnamed.
+    const hasTitle = !!this.props.title?.trim();
     return (
       // A native <button> gives the trigger its semantics and Enter/Space activation for free.
       // aria-haspopup="dialog" announces that it opens the sidebar panel; aria-expanded reflects
-      // the open state. The visible "tab-name" text supplies the button's accessible name.
+      // the open state.
       <button type="button" className="sidebar-tab" onClick={this.handleSidebarShow}
-           data-cy="sidebar-tab" aria-haspopup="dialog" aria-expanded={this.props.sidebarOpen}>
+           data-cy="sidebar-tab" aria-haspopup="dialog" aria-expanded={this.props.sidebarOpen}
+           aria-label={hasTitle ? undefined : "Show sidebar"}>
         <div className={`icon ${this.props.sidebarOpen ? "open" : ""}`}>
           <IconArrow aria-hidden="true" focusable="false" />
         </div>

--- a/src/components/page-sidebar/sidebar.test.tsx
+++ b/src/components/page-sidebar/sidebar.test.tsx
@@ -31,6 +31,21 @@ describe("SidebarTab component", () => {
     expect(wrapper.find('[data-cy="sidebar-title"]').text()).toContain(title);
     expect(wrapper.find('[data-cy="sidebar-content"]').length).toBe(1);
   });
+  it("renders the close control as a semantic button with an accessible name", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const wrapper = shallow(<SidebarPanel
+      title={"Did you know?"}
+      index={0}
+      content={"content"}
+      show={true}
+      handleCloseSidebarContent={stubFunction} />);
+    const closeButton = wrapper.find('button[data-cy="sidebar-close-button"]');
+    expect(closeButton.length).toBe(1);
+    expect(closeButton.prop("type")).toBe("button");
+    expect(closeButton.prop("aria-label")).toBe("Close");
+  });
   it("renders the panel title as an h2 heading when present", () => {
     const stubFunction = () => {
       // do nothing.

--- a/src/components/page-sidebar/sidebar.test.tsx
+++ b/src/components/page-sidebar/sidebar.test.tsx
@@ -42,6 +42,28 @@ describe("SidebarTab component", () => {
       sidebarOpen={true} />);
     expect(wrapper.find('button[data-cy="sidebar-tab"]').prop("aria-expanded")).toBe(true);
   });
+  it("gives the tab trigger a fallback accessible name when there is no title", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const wrapper = shallow(<SidebarTab
+      title={null}
+      handleShowSidebarContent={stubFunction}
+      index={0}
+      sidebarOpen={false} />);
+    expect(wrapper.find('button[data-cy="sidebar-tab"]').prop("aria-label")).toBe("Show sidebar");
+  });
+  it("uses the visible title as the trigger's accessible name when present (no redundant aria-label)", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const wrapper = shallow(<SidebarTab
+      title={"Did you know?"}
+      handleShowSidebarContent={stubFunction}
+      index={0}
+      sidebarOpen={false} />);
+    expect(wrapper.find('button[data-cy="sidebar-tab"]').prop("aria-label")).toBeUndefined();
+  });
   it("renders panel component", () => {
     const stubFunction = () => {
       // do nothing.

--- a/src/components/page-sidebar/sidebar.test.tsx
+++ b/src/components/page-sidebar/sidebar.test.tsx
@@ -16,6 +16,32 @@ describe("SidebarTab component", () => {
       sidebarOpen={false} />);
     expect(wrapper.find('[data-cy="sidebar-tab-title"]').text()).toContain(title);
   });
+  it("renders the tab trigger as a semantic button that announces it opens a dialog", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const wrapper = shallow(<SidebarTab
+      title={"Did you know?"}
+      handleShowSidebarContent={stubFunction}
+      index={0}
+      sidebarOpen={false} />);
+    const button = wrapper.find('button[data-cy="sidebar-tab"]');
+    expect(button.length).toBe(1);
+    expect(button.prop("type")).toBe("button");
+    expect(button.prop("aria-haspopup")).toBe("dialog");
+    expect(button.prop("aria-expanded")).toBe(false);
+  });
+  it("reflects the open state on the tab trigger's aria-expanded", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const wrapper = shallow(<SidebarTab
+      title={"Did you know?"}
+      handleShowSidebarContent={stubFunction}
+      index={0}
+      sidebarOpen={true} />);
+    expect(wrapper.find('button[data-cy="sidebar-tab"]').prop("aria-expanded")).toBe(true);
+  });
   it("renders panel component", () => {
     const stubFunction = () => {
       // do nothing.


### PR DESCRIPTION
## Summary

Accessibility fixes for the "Did you know?" page sidebar (the orange tab + slide-out panel), addressing four VPAT audit stories under epic AP-81. The sidebar is a single shared component, so these fixes apply on every page where it appears.

Resolves **AP-98**, **AP-100**, **AP-101**, **AP-102**. (AP-99 — focus trap / dialog semantics — is intentionally a separate follow-up PR; the audit checklist is captured on that ticket.)

## Changes by story

- **AP-98** — Tab trigger converted from `<div role="button" tabIndex={0}>` to a native `<button type="button">` with `aria-haspopup="dialog"` and `aria-expanded`. Native Enter/Space activation replaces the manual keydown handling. Added an `aria-label="Show sidebar"` fallback so the button is never unnamed when a sidebar has no title. _(WCAG 4.1.2 A)_
- **AP-100** — Header title text `white` → `$cc-charcoal` (#3f3f3f) on the #ffa350 header: **5.32:1**, clears the 4.5:1 AA threshold. _(WCAG 1.4.3 AA)_
- **AP-101** — Close-icon fill `white` → `$cc-charcoal` (#3f3f3f): **5.32:1** default, and the icon now keeps its charcoal fill through `:hover` (8.77:1) and `:active` (6.64:1) instead of fading to light orange. _(WCAG 1.4.11 AA)_
- **AP-102** — Close ("x") control converted from `<div role="button">` to a native `<button type="button">` with `aria-label="Close"`. _(WCAG 4.1.2 A)_

Both converted buttons also get a theme-independent focus indicator (solid `$cc-charcoal` outline, matching `.version-info` in `app.scss`) — they sit on the orange theme, exactly the case where the themed box-shadow ring can drop below contrast, and the charcoal outline survives forced-colors mode. _(WCAG 2.4.7 AA)_

Native button chrome is reset in SCSS (`border`/`background`/`padding`, leaving `outline` intact) so the controls render identically to the former divs. `data-cy` hooks are preserved, so Cypress selectors/interactions are unaffected.

## Testing

- Added unit tests (test-first) covering the new semantic buttons, `aria-haspopup`/`aria-expanded`, the close button's accessible name, and the title-fallback name.
- Full Jest suite green; lint clean.
- All contrast ratios verified with a WCAG contrast analyzer.
- A read-only accessibility audit of the branch confirmed all four stories' acceptance criteria are met (0 critical / 0 high findings).

## Out of scope (follow-ups)

- Tab arrow-icon contrast (1.65:1, pre-existing) — to be ticketed under AP-81.
- AP-99: expose the panel as a real `role="dialog"` with focus trap / return-focus — separate PR; checklist captured on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
