### PR TITLE
test(AP-103): cover completion-page SVG icon text alternatives

### DIFF
--- a/src/components/activity-completion/completion-page-content.test.tsx
+++ b/src/components/activity-completion/completion-page-content.test.tsx
@@ -73,10 +73,13 @@ describe("Completion Page Content component", () => {
     // Deliver answers so the component leaves its "Fetching your data" state and renders the
     // status banner. With no questions in the activity it is "complete", showing the check icon.
     // The adjacent progress text conveys completion, so the icon itself is decorative.
+    expect(mockAnswersCallback).toBeDefined();
     act(() => {
       mockAnswersCallback?.([]);
     });
-    const icons = container.querySelectorAll(IconCheck);
+    const banner = container.querySelector('[data-cy="progress-container"]');
+    expect(banner).not.toBeNull();
+    const icons = banner!.querySelectorAll(IconCheck);
     expect(icons).toHaveLength(1);
     expect(icons[0]).toHaveAttribute("aria-hidden", "true");
     expect(icons[0]).toHaveAttribute("focusable", "false");

--- a/src/components/activity-completion/completion-page-content.test.tsx
+++ b/src/components/activity-completion/completion-page-content.test.tsx
@@ -1,16 +1,18 @@
 import React from "react";
 import { CompletionPageContent } from "./completion-page-content";
 import { shallow } from "enzyme";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import { Activity } from "../../types";
 import _activityPlugins from "../../data/version-2/sample-new-sections-multiple-layout-types.json";
 import { DynamicTextTester } from "../../test-utils/dynamic-text";
 
 // The full RTL render runs the answer/feedback watcher effects, so stub
-// firebase-db (same approach as nav-pages.test.tsx). With no answers delivered,
-// the component renders its "Fetching your data" state, which still has a <main>.
+// firebase-db (same approach as nav-pages.test.tsx). The answers watcher's callback
+// is captured so a test can deliver answers and exercise the rendered status banner;
+// until it is invoked, the component renders its "Fetching your data" state.
+let mockAnswersCallback: ((answers: unknown[]) => void) | undefined;
 jest.mock("../../firebase-db", () => ({
-  watchAllAnswers: jest.fn(() => jest.fn()),
+  watchAllAnswers: jest.fn((cb: (answers: unknown[]) => void) => { mockAnswersCallback = cb; return jest.fn(); }),
   watchQuestionLevelFeedback: jest.fn(() => jest.fn()),
 }));
 
@@ -48,5 +50,29 @@ describe("Completion Page Content component", () => {
       </DynamicTextTester>
     );
     expect(screen.getByRole("main")).toBeInTheDocument();
+  });
+  it("hides the decorative completion status icon from assistive technology", () => {
+    const stubFunction = () => {
+      // do nothing.
+    };
+    const { container } = render(
+      <DynamicTextTester>
+        <CompletionPageContent
+          activity={activityPlugins}
+          activityName={"test"}
+          onPageChange={stubFunction}
+        />
+      </DynamicTextTester>
+    );
+    // Deliver answers so the component leaves its "Fetching your data" state and renders the
+    // status banner. With no questions in the activity it is "complete", showing the check icon.
+    // The adjacent progress text conveys completion, so the icon itself is decorative.
+    act(() => {
+      mockAnswersCallback?.([]);
+    });
+    const icon = container.querySelector("test-file-stub");
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
+    expect(icon?.getAttribute("focusable")).toBe("false");
   });
 });

--- a/src/components/activity-completion/completion-page-content.test.tsx
+++ b/src/components/activity-completion/completion-page-content.test.tsx
@@ -5,6 +5,7 @@ import { act, render, screen } from "@testing-library/react";
 import { Activity } from "../../types";
 import _activityPlugins from "../../data/version-2/sample-new-sections-multiple-layout-types.json";
 import { DynamicTextTester } from "../../test-utils/dynamic-text";
+import IconCheck from "../../assets/svg-icons/icon-check-circle.svg";
 
 // The full RTL render runs the answer/feedback watcher effects, so stub
 // firebase-db (same approach as nav-pages.test.tsx). The answers watcher's callback
@@ -19,6 +20,11 @@ jest.mock("../../firebase-db", () => ({
 const activityPlugins = _activityPlugins as unknown as Activity;
 
 describe("Completion Page Content component", () => {
+  // Each test re-renders and re-registers the watcher, but reset the captured callback so the
+  // suite never depends on a callback left over from a prior test.
+  beforeEach(() => {
+    mockAnswersCallback = undefined;
+  });
   it("renders component", () => {
     const stubFunction = () => {
       // do nothing.
@@ -70,9 +76,9 @@ describe("Completion Page Content component", () => {
     act(() => {
       mockAnswersCallback?.([]);
     });
-    const icon = container.querySelector("test-file-stub");
-    expect(icon).not.toBeNull();
-    expect(icon?.getAttribute("aria-hidden")).toBe("true");
-    expect(icon?.getAttribute("focusable")).toBe("false");
+    const icons = container.querySelectorAll(IconCheck);
+    expect(icons).toHaveLength(1);
+    expect(icons[0]).toHaveAttribute("aria-hidden", "true");
+    expect(icons[0]).toHaveAttribute("focusable", "false");
   });
 });

--- a/src/components/activity-completion/summary-table.test.tsx
+++ b/src/components/activity-completion/summary-table.test.tsx
@@ -34,6 +34,8 @@ describe("Summary Table component", () => {
     const icons = wrapper.find("test-file-stub");
     expect(icons.length).toBe(3);
     icons.forEach((icon) => expect(icon.prop("role")).toBe("img"));
+    // Labelled but not in the tab order: the name is for the AT, the icon is not interactive.
+    icons.forEach((icon) => expect(icon.prop("focusable")).toBe("false"));
     expect(icons.at(0).prop("aria-label")).toBe("Complete");   // answered: true
     expect(icons.at(2).prop("aria-label")).toBe("Incomplete");  // answered: false
   });

--- a/src/components/activity-completion/summary-table.test.tsx
+++ b/src/components/activity-completion/summary-table.test.tsx
@@ -31,9 +31,10 @@ describe("Summary Table component", () => {
     );
     // One status icon per question; these convey answered/unanswered state with no adjacent text,
     // so they must be exposed to assistive technology with a name rather than hidden.
-    const icons = wrapper.find("test-file-stub");
+    // Select by the role the icons are asserted to expose, rather than the Jest SVG stub tag;
+    // matching exactly three confirms all the status icons are exposed as images to the AT.
+    const icons = wrapper.find('[role="img"]');
     expect(icons.length).toBe(3);
-    icons.forEach((icon) => expect(icon.prop("role")).toBe("img"));
     // Labelled but not in the tab order: the name is for the AT, the icon is not interactive.
     icons.forEach((icon) => expect(icon.prop("focusable")).toBe("false"));
     expect(icons.at(0).prop("aria-label")).toBe("Complete");   // answered: true

--- a/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
+++ b/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { DynamicTextContext } from "@concord-consortium/dynamic-text";
 import { ActivityLevelFeedbackBanner } from "./activity-level-feedback-banner";
 import { ActivityFeedback } from "../../types";
+import TeacherFeedbackIcon from "../../assets/svg-icons/teacher-feedback-icon.svg";
 
 jest.mock("./rubric", () => ({
   RubricComponent: () => <div data-testid="mock-rubric" />
@@ -58,10 +59,10 @@ describe("Activity Level Feedback component", () => {
         <ActivityLevelFeedbackBanner teacherFeedback={mockFeedback} />
       </DynamicTextContext.Provider>
     );
-    const icon = container.querySelector("test-file-stub");
-    expect(icon).not.toBeNull();
-    expect(icon?.getAttribute("aria-hidden")).toBe("true");
-    expect(icon?.getAttribute("focusable")).toBe("false");
+    const icons = container.querySelectorAll(TeacherFeedbackIcon);
+    expect(icons).toHaveLength(1);
+    expect(icons[0]).toHaveAttribute("aria-hidden", "true");
+    expect(icons[0]).toHaveAttribute("focusable", "false");
   });
   it("renders component without a rubric when `hideRubricFromStudentsInStudentReport` is true", () => {
     const mockFeedbackWithHiddenRubric = {

--- a/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
+++ b/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
@@ -50,6 +50,19 @@ describe("Activity Level Feedback component", () => {
     renderComponent(mockFeedbackWithRubric);
     expect(screen.queryByTestId("mock-rubric")).not.toBeNull();
   });
+  it("hides the decorative feedback icon from assistive technology", () => {
+    // The banner's "Overall Teacher Feedback for This Activity:" heading conveys the meaning,
+    // so the icon is decorative and must not be announced.
+    const { container } = render(
+      <DynamicTextContext.Provider value={mockDynamicTextContextValue}>
+        <ActivityLevelFeedbackBanner teacherFeedback={mockFeedback} />
+      </DynamicTextContext.Provider>
+    );
+    const icon = container.querySelector("test-file-stub");
+    expect(icon).not.toBeNull();
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
+    expect(icon?.getAttribute("focusable")).toBe("false");
+  });
   it("renders component without a rubric when `hideRubricFromStudentsInStudentReport` is true", () => {
     const mockFeedbackWithHiddenRubric = {
       ...mockFeedback,

--- a/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
+++ b/src/components/teacher-feedback/activity-level-feedback-banner.test.tsx
@@ -59,7 +59,9 @@ describe("Activity Level Feedback component", () => {
         <ActivityLevelFeedbackBanner teacherFeedback={mockFeedback} />
       </DynamicTextContext.Provider>
     );
-    const icons = container.querySelectorAll(TeacherFeedbackIcon);
+    const banner = container.querySelector('[data-testid="activity-level-feedback-banner"]');
+    expect(banner).not.toBeNull();
+    const icons = banner!.querySelectorAll(TeacherFeedbackIcon);
     expect(icons).toHaveLength(1);
     expect(icons[0]).toHaveAttribute("aria-hidden", "true");
     expect(icons[0]).toHaveAttribute("focusable", "false");

--- a/src/components/teacher-feedback/sequence-intro-feedback-banner.test.tsx
+++ b/src/components/teacher-feedback/sequence-intro-feedback-banner.test.tsx
@@ -7,7 +7,7 @@ describe("Intro Feedback Banner component", () => {
   it("renders component for a sequence", () => {
     const wrapper = shallow(<SequenceIntroFeedbackBanner />);
     expect(wrapper.find('[data-cy="intro-feedback-banner"]').length).toBe(1);
-    expect(wrapper.find('[data-cy="intro-feedback-banner"]').contains("Your teacher has provided feedback."));
+    expect(wrapper.find('[data-cy="intro-feedback-banner"]').contains("Your teacher has provided feedback.")).toBe(true);
   });
 
   it("hides the decorative feedback icon from assistive technology", () => {

--- a/src/components/teacher-feedback/sequence-intro-feedback-banner.test.tsx
+++ b/src/components/teacher-feedback/sequence-intro-feedback-banner.test.tsx
@@ -8,4 +8,14 @@ describe("Intro Feedback Banner component", () => {
     expect(wrapper.find('[data-cy="intro-feedback-banner"]').length).toBe(1);
     expect(wrapper.find('[data-cy="intro-feedback-banner"]').contains("Your teacher has provided feedback."));
   });
+
+  it("hides the decorative feedback icon from assistive technology", () => {
+    // The adjacent "Your teacher has provided feedback." text already conveys the meaning,
+    // so the icon is decorative and must not be announced.
+    const wrapper = shallow(<SequenceIntroFeedbackBanner />);
+    const icon = wrapper.find("test-file-stub");
+    expect(icon.length).toBe(1);
+    expect(icon.prop("aria-hidden")).toBe("true");
+    expect(icon.prop("focusable")).toBe("false");
+  });
 });

--- a/src/components/teacher-feedback/sequence-intro-feedback-banner.test.tsx
+++ b/src/components/teacher-feedback/sequence-intro-feedback-banner.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { SequenceIntroFeedbackBanner } from "./sequence-intro-feedback-banner";
+import TeacherFeedbackIcon from "../../assets/svg-icons/teacher-feedback-icon.svg";
 
 describe("Intro Feedback Banner component", () => {
   it("renders component for a sequence", () => {
@@ -13,7 +14,7 @@ describe("Intro Feedback Banner component", () => {
     // The adjacent "Your teacher has provided feedback." text already conveys the meaning,
     // so the icon is decorative and must not be announced.
     const wrapper = shallow(<SequenceIntroFeedbackBanner />);
-    const icon = wrapper.find("test-file-stub");
+    const icon = wrapper.find(TeacherFeedbackIcon);
     expect(icon.length).toBe(1);
     expect(icon.prop("aria-hidden")).toBe("true");
     expect(icon.prop("focusable")).toBe("false");

--- a/src/components/teacher-feedback/summary-page-question-feedback.test.tsx
+++ b/src/components/teacher-feedback/summary-page-question-feedback.test.tsx
@@ -13,4 +13,18 @@ describe("SummaryPageQuestionFeedback", () => {
     expect(wrapper.find('[data-testid="summary-page-question-feedback"]').length).toBe(1);
     expect(wrapper.find('[data-testid="summary-page-question-feedback-content"]').text()).toContain("Amazing!");
   });
+
+  it("hides the decorative feedback icon from assistive technology", () => {
+    // The adjacent "Teacher Feedback:" label conveys the meaning, so the icon is decorative.
+    const teacherFeedback = {
+      content: "Amazing!",
+      questionId: "123",
+      timestamp: "2021-08-31T14:00:00Z"
+    };
+    const wrapper = shallow(<SummaryPageQuestionFeedback teacherFeedback={teacherFeedback} />);
+    const icon = wrapper.find("test-file-stub");
+    expect(icon.length).toBe(1);
+    expect(icon.prop("aria-hidden")).toBe("true");
+    expect(icon.prop("focusable")).toBe("false");
+  });
 });

--- a/src/components/teacher-feedback/summary-page-question-feedback.test.tsx
+++ b/src/components/teacher-feedback/summary-page-question-feedback.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { SummaryPageQuestionFeedback } from "./summary-page-question-feedback";
+import TeacherFeedbackIcon from "../../assets/svg-icons/teacher-feedback-icon.svg";
 
 describe("SummaryPageQuestionFeedback", () => {
   it("renders component", () => {
@@ -22,7 +23,7 @@ describe("SummaryPageQuestionFeedback", () => {
       timestamp: "2021-08-31T14:00:00Z"
     };
     const wrapper = shallow(<SummaryPageQuestionFeedback teacherFeedback={teacherFeedback} />);
-    const icon = wrapper.find("test-file-stub");
+    const icon = wrapper.find(TeacherFeedbackIcon);
     expect(icon.length).toBe(1);
     expect(icon.prop("aria-hidden")).toBe("true");
     expect(icon.prop("focusable")).toBe("false");


### PR DESCRIPTION
## Summary

[AP-103](https://concord-consortium.atlassian.net/browse/AP-103) asks that the SVG icons on the **completion page** carry meaningful text alternatives — informative icons get a descriptive `aria-label`, purely decorative icons get `aria-hidden="true"` (audit Issue #67, WCAG **1.1.1**, Level A).

**The remediation itself already shipped.** It was delivered as part of **AP-88** ("hide decorative SVG icons from assistive technology", #564). Every SVG icon on the completion page already has the correct treatment:

| Icon | Location | Treatment | Why |
|---|---|---|---|
| `IconComplete` / `IconIncomplete` | `summary-table.tsx:50-51` | `role="img" aria-label="Complete"/"Incomplete" focusable="false"` | Informative — conveys per-question answered state with no adjacent text |
| `IconCheck` / `IconUnfinishedCheck` | `completion-page-content.tsx:157-158` | `aria-hidden="true" focusable="false"` | Decorative — completion status is conveyed by the adjacent progress text |
| `TeacherFeedbackIcon` | sequence-intro / activity-level / summary-page feedback banners | `aria-hidden="true" focusable="false"` | Decorative — adjacent text ("Your teacher has provided feedback.", "Teacher Feedback:", etc.) conveys the meaning |

So this PR adds **no production code** — it closes the one remaining gap: **regression test coverage**. Before this, only the summary-table's labelled icons were guarded by a test; nothing prevented a future change from silently un-hiding the decorative icons or dropping the labels.

## What's in this PR (tests only)

- **`completion-page-content.test.tsx`** — assert the top status icon is decorative (`aria-hidden="true"`, `focusable="false"`). Drives the full rendered state (past the "Fetching your data" placeholder) by capturing the `watchAllAnswers` callback in the `firebase-db` mock and delivering answers.
- **`activity-level-feedback-banner.test.tsx`**, **`sequence-intro-feedback-banner.test.tsx`**, **`summary-page-question-feedback.test.tsx`** — assert each `TeacherFeedbackIcon` is decorative.
- **`summary-table.test.tsx`** — extend the existing role/`aria-label` test to also assert `focusable="false"` on the meaningful icons.

## Verification

- `npx jest src/components/activity-completion/ src/components/teacher-feedback/` → **30 passed** (10 suites)
- The 5 touched suites: **13 passed**
- `eslint -c .eslintrc.build.js` on the changed files → clean

## Notes

- Decorative-vs-informative was judged per usage: the same `icon-check-circle.svg` is decorative on the status banner (text states the status) but informative in the summary table (no adjacent text), so the two contexts get different treatment — and the tests encode that distinction.
- Screen-reader spot-check is still worth doing as the AC's manual step, but the automated coverage now locks in the markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-103]: https://concord-consortium.atlassian.net/browse/AP-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ