### PR TITLE
fix(AP-104): use semantic links for completion page Question items

### DIFF
--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -6,7 +6,7 @@ import IconUnfinishedCheck from "../../assets/svg-icons/icon-unfinished-check-ci
 import { Sequence, Activity, ActivityFeedback, QuestionFeedback } from "../../types";
 import { renderHTML } from "../../utilities/render-html";
 import { watchAllAnswers, watchQuestionLevelFeedback, WrappedDBAnswer } from "../../firebase-db";
-import { getEmbeddable, getPageNumberFromEmbeddable, isQuestion, isSequenceFinished } from "../../utilities/activity-utils";
+import { getEmbeddable, getPageIDFromPosition, getPageNumberFromEmbeddable, isQuestion, isSequenceFinished } from "../../utilities/activity-utils";
 import { answerHasResponse, answersQuestionIdToRefId, refIdToAnswersQuestionId } from "../../utilities/embeddable-utils";
 import { SummaryTable, IQuestionStatus } from "./summary-table";
 import { SequenceIntroFeedbackBanner } from "../teacher-feedback/sequence-intro-feedback-banner";
@@ -88,11 +88,13 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
         const authoredState = embeddable?.authored_state ? JSON.parse(embeddable.authored_state) : {};
         const answered = answer ? answerHasResponse(answer, authoredState) : false;
         const page = getPageNumberFromEmbeddable(activity, embeddableId) || 0;
+        const pageId = getPageIDFromPosition(activity, page);
 
         summaries.push({
           embeddableId,
           number: idx + 1,
           page,
+          pageId,
           prompt: authoredState.prompt,
           answered,
           feedback

--- a/src/components/activity-completion/completion-page-content.tsx
+++ b/src/components/activity-completion/completion-page-content.tsx
@@ -6,7 +6,7 @@ import IconUnfinishedCheck from "../../assets/svg-icons/icon-unfinished-check-ci
 import { Sequence, Activity, ActivityFeedback, QuestionFeedback } from "../../types";
 import { renderHTML } from "../../utilities/render-html";
 import { watchAllAnswers, watchQuestionLevelFeedback, WrappedDBAnswer } from "../../firebase-db";
-import { getEmbeddable, getPageIDFromPosition, getPageNumberFromEmbeddable, isQuestion, isSequenceFinished } from "../../utilities/activity-utils";
+import { getEmbeddable, getPageIdFromEmbeddable, getPageNumberFromEmbeddable, isQuestion, isSequenceFinished } from "../../utilities/activity-utils";
 import { answerHasResponse, answersQuestionIdToRefId, refIdToAnswersQuestionId } from "../../utilities/embeddable-utils";
 import { SummaryTable, IQuestionStatus } from "./summary-table";
 import { SequenceIntroFeedbackBanner } from "../teacher-feedback/sequence-intro-feedback-banner";
@@ -88,7 +88,7 @@ export const CompletionPageContent: React.FC<IProps> = (props) => {
         const authoredState = embeddable?.authored_state ? JSON.parse(embeddable.authored_state) : {};
         const answered = answer ? answerHasResponse(answer, authoredState) : false;
         const page = getPageNumberFromEmbeddable(activity, embeddableId) || 0;
-        const pageId = getPageIDFromPosition(activity, page);
+        const pageId = getPageIdFromEmbeddable(activity, embeddableId);
 
         summaries.push({
           embeddableId,

--- a/src/components/activity-completion/summary-table.scss
+++ b/src/components/activity-completion/summary-table.scss
@@ -58,11 +58,17 @@
           font-style: normal;
           letter-spacing: normal;
           margin: 0;
-          outline: none;
           padding: 0;
           text-decoration: underline;
           text-transform: none;
           width: auto;
+
+          // Keyboard focus indicator with >=3:1 non-text contrast against both the
+          // white and teal-light7 alternating row backgrounds.
+          &:focus-visible {
+            outline: 2px solid $cc-teal-dark1;
+            outline-offset: 2px;
+          }
         }
       }
       .question-prompt {

--- a/src/components/activity-completion/summary-table.scss
+++ b/src/components/activity-completion/summary-table.scss
@@ -45,7 +45,7 @@
       .question-page-and-number {
         flex: 0 0 auto;
 
-        button {
+        a {
           appearance: none;
           background: transparent;
           border: none;

--- a/src/components/activity-completion/summary-table.test.tsx
+++ b/src/components/activity-completion/summary-table.test.tsx
@@ -43,7 +43,7 @@ describe("Summary Table component", () => {
       <DynamicTextTester><SummaryTable questionsStatus={questionsStatus} onPageChange={mockOnPageChange} /></DynamicTextTester>
     );
     const preventDefault = jest.fn();
-    wrapper.find('a[data-testid="question-link"]').at(2).simulate("click", { preventDefault });
+    wrapper.find('a[data-testid="question-link"]').at(2).simulate("click", { button: 0, preventDefault });
     expect(preventDefault).toHaveBeenCalled();
     expect(mockOnPageChange).toHaveBeenCalledWith(2, undefined);
   });
@@ -54,7 +54,18 @@ describe("Summary Table component", () => {
       <DynamicTextTester><SummaryTable questionsStatus={questionsStatus} onPageChange={mockOnPageChange} /></DynamicTextTester>
     );
     const preventDefault = jest.fn();
-    wrapper.find('a[data-testid="question-link"]').at(0).simulate("click", { metaKey: true, preventDefault });
+    wrapper.find('a[data-testid="question-link"]').at(0).simulate("click", { button: 0, metaKey: true, preventDefault });
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(mockOnPageChange).not.toHaveBeenCalled();
+  });
+
+  it("lets non-primary (e.g. middle) button clicks fall through to the browser", () => {
+    mockOnPageChange.mockClear();
+    const wrapper = mount(
+      <DynamicTextTester><SummaryTable questionsStatus={questionsStatus} onPageChange={mockOnPageChange} /></DynamicTextTester>
+    );
+    const preventDefault = jest.fn();
+    wrapper.find('a[data-testid="question-link"]').at(0).simulate("click", { button: 1, preventDefault });
     expect(preventDefault).not.toHaveBeenCalled();
     expect(mockOnPageChange).not.toHaveBeenCalled();
   });

--- a/src/components/activity-completion/summary-table.test.tsx
+++ b/src/components/activity-completion/summary-table.test.tsx
@@ -4,9 +4,9 @@ import { mount } from "enzyme";
 import { DynamicTextTester } from "../../test-utils/dynamic-text";
 
 const questionsStatus = [
-                          {number: 1, page: 1, prompt: "What is the answer?", answered: true},
-                          {number: 2, page: 1, prompt: "What is the question?", answered: true},
-                          {number: 3, page: 2, prompt: "Where are we going?", answered: false},
+                          {number: 1, page: 1, pageId: 101, prompt: "What is the answer?", answered: true},
+                          {number: 2, page: 1, pageId: 101, prompt: "What is the question?", answered: true},
+                          {number: 3, page: 2, pageId: 102, prompt: "Where are we going?", answered: false},
                         ];
 const mockOnPageChange = jest.fn();
 
@@ -23,6 +23,40 @@ describe("Summary Table component", () => {
     expect(wrapperComplete.find('[data-testid="question-prompt"]').at(1).text()).toContain("What is the question?");
     expect(wrapperComplete.find('[data-testid="question-page-and-number"]').at(2).text()).toContain("Page 2: Question 3.");
     expect(wrapperComplete.find('[data-testid="question-prompt"]').at(2).text()).toContain("Where are we going?");
+  });
+
+  it("renders the question navigation items as semantic links with page hrefs", () => {
+    const wrapper = mount(
+      <DynamicTextTester><SummaryTable questionsStatus={questionsStatus} onPageChange={mockOnPageChange} /></DynamicTextTester>
+    );
+    // The items navigate to a page, so they must be exposed to assistive technology
+    // as links (native <a href>) rather than buttons.
+    const links = wrapper.find('a[data-testid="question-link"]');
+    expect(links.length).toBe(3);
+    expect(links.at(0).prop("href")).toContain("page=page_101");
+    expect(links.at(2).prop("href")).toContain("page=page_102");
+  });
+
+  it("navigates in-app on a plain click while preventing the default anchor navigation", () => {
+    mockOnPageChange.mockClear();
+    const wrapper = mount(
+      <DynamicTextTester><SummaryTable questionsStatus={questionsStatus} onPageChange={mockOnPageChange} /></DynamicTextTester>
+    );
+    const preventDefault = jest.fn();
+    wrapper.find('a[data-testid="question-link"]').at(2).simulate("click", { preventDefault });
+    expect(preventDefault).toHaveBeenCalled();
+    expect(mockOnPageChange).toHaveBeenCalledWith(2, undefined);
+  });
+
+  it("lets modified clicks fall through to the browser for open-in-new-tab", () => {
+    mockOnPageChange.mockClear();
+    const wrapper = mount(
+      <DynamicTextTester><SummaryTable questionsStatus={questionsStatus} onPageChange={mockOnPageChange} /></DynamicTextTester>
+    );
+    const preventDefault = jest.fn();
+    wrapper.find('a[data-testid="question-link"]').at(0).simulate("click", { metaKey: true, preventDefault });
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(mockOnPageChange).not.toHaveBeenCalled();
   });
 
   it("gives the meaningful complete/incomplete status icons accessible names", () => {

--- a/src/components/activity-completion/summary-table.tsx
+++ b/src/components/activity-completion/summary-table.tsx
@@ -15,7 +15,7 @@ export interface IQuestionStatus {
   embeddableId?: string;
   number: number;
   page: number;
-  pageId?: number | null;
+  pageId: number | null;
   prompt: string;
   answered: boolean;
   feedback?: QuestionFeedback;
@@ -66,7 +66,7 @@ export const SummaryTable: React.FC<IProps> = (props) => {
                 <div className="question-meta">
                   <div className="question-page-and-number" data-testid="question-page-and-number">
                     <a
-                      href={getPageHref(question.pageId ?? null)}
+                      href={getPageHref(question.pageId)}
                       onClick={handleQuestionLinkClick(question.page, refId)}
                       data-testid="question-link"
                     >

--- a/src/components/activity-completion/summary-table.tsx
+++ b/src/components/activity-completion/summary-table.tsx
@@ -6,6 +6,7 @@ import { renderHTML } from "../../utilities/render-html";
 import { QuestionFeedback } from "../../types";
 import { SummaryPageQuestionFeedback } from "../teacher-feedback/summary-page-question-feedback";
 import { answersQuestionIdToRefId } from "../../utilities/embeddable-utils";
+import { getPageHref } from "../../utilities/url-query";
 import { LogEventName, Logger } from "../../lib/logger";
 
 import "./summary-table.scss";
@@ -14,6 +15,7 @@ export interface IQuestionStatus {
   embeddableId?: string;
   number: number;
   page: number;
+  pageId?: number | null;
   prompt: string;
   answered: boolean;
   feedback?: QuestionFeedback;
@@ -27,7 +29,13 @@ interface IProps {
 export const SummaryTable: React.FC<IProps> = (props) => {
   const { questionsStatus, onPageChange } = props;
 
-  const handleQuestionLinkClick = (page: number, refId?: string) => {
+  const handleQuestionLinkClick = (page: number, refId?: string) => (e: React.MouseEvent) => {
+    // Let the browser handle modified clicks (e.g. cmd/ctrl-click to open the
+    // question's page in a new tab) natively via the anchor's href.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+      return;
+    }
+    e.preventDefault();
     onPageChange(page, refId);
     Logger.log({
       event: LogEventName.click_summary_page_question_link,
@@ -57,9 +65,13 @@ export const SummaryTable: React.FC<IProps> = (props) => {
               <td>
                 <div className="question-meta">
                   <div className="question-page-and-number" data-testid="question-page-and-number">
-                    <button onClick={() => handleQuestionLinkClick(question.page, refId)} data-testid="question-link">
+                    <a
+                      href={getPageHref(question.pageId ?? null)}
+                      onClick={handleQuestionLinkClick(question.page, refId)}
+                      data-testid="question-link"
+                    >
                       <DynamicText>Page {question.page}: Question {question.number}.</DynamicText>
-                    </button>
+                    </a>
                   </div>
                   <div className="question-prompt" data-testid="question-prompt">
                     {questionPrompt && <DynamicText><em>{questionPrompt}</em></DynamicText>}

--- a/src/components/activity-completion/summary-table.tsx
+++ b/src/components/activity-completion/summary-table.tsx
@@ -30,9 +30,10 @@ export const SummaryTable: React.FC<IProps> = (props) => {
   const { questionsStatus, onPageChange } = props;
 
   const handleQuestionLinkClick = (page: number, refId?: string) => (e: React.MouseEvent) => {
-    // Let the browser handle modified clicks (e.g. cmd/ctrl-click to open the
-    // question's page in a new tab) natively via the anchor's href.
-    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+    // Let the browser handle native navigation for modified clicks (e.g. cmd/ctrl-click)
+    // and non-primary buttons (e.g. middle-click to open the page in a new tab) via the
+    // anchor's href, rather than intercepting them for in-app navigation.
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
       return;
     }
     e.preventDefault();

--- a/src/utilities/activity-utils.test.ts
+++ b/src/utilities/activity-utils.test.ts
@@ -1,5 +1,5 @@
 import { Activity } from "../types";
-import { isQuestion, numQuestionsOnPreviousPages, enableReportButton, getPagePositionFromQueryValue, isSectionHidden, numQuestionsOnPreviousSections, getPageIDFromPosition, getPageNumberFromEmbeddable } from "./activity-utils";
+import { isQuestion, numQuestionsOnPreviousPages, enableReportButton, getPagePositionFromQueryValue, isSectionHidden, numQuestionsOnPreviousSections, getPageIDFromPosition, getPageIdFromEmbeddable, getPageNumberFromEmbeddable } from "./activity-utils";
 import _activityHidden from "../data/version-2/sample-new-sections-hidden-content.json";
 import _activity from "../data/version-2/sample-new-sections-activity-1.json";
 import { DefaultTestActivity } from "../test-utils/model-for-tests";
@@ -81,5 +81,19 @@ describe("Activity utility functions", () => {
     // make sure the page number of the third page is 2 since the second page is hidden
     expect(pages[2].sections[0].embeddables[0]).toBeDefined();
     expect(getPageNumberFromEmbeddable(activityHidden, pages[2].sections[0].embeddables[0].ref_id)).toBe(2);
+  });
+  it("gets a page id directly from an embeddable, even when hidden pages precede it", () => {
+    const { pages } = activityHidden;
+    const refId = pages[2].sections[0].embeddables[0].ref_id;
+
+    // The embeddable lives on the page with id 3000 (absolute position 3), but its
+    // visible page number is 2 (the hidden page is skipped). Mapping that visible
+    // number through getPageIDFromPosition wrongly resolves to the hidden page (2000),
+    // which is exactly why deriving the id straight from the embeddable is necessary.
+    expect(getPageNumberFromEmbeddable(activityHidden, refId)).toBe(2);
+    expect(getPageIDFromPosition(activityHidden, 2)).toBe(2000);
+
+    expect(getPageIdFromEmbeddable(activityHidden, refId)).toBe(3000);
+    expect(getPageIdFromEmbeddable(activityHidden, "does-not-exist")).toBe(null);
   });
 });

--- a/src/utilities/activity-utils.ts
+++ b/src/utilities/activity-utils.ts
@@ -302,6 +302,21 @@ export const getPageNumberFromEmbeddable = (activity: Activity, embeddableRefId:
   return undefined;
 };
 
+// Returns the id of the page that contains the given embeddable, or null if not found.
+// Prefer this over mapping a page number through getPageIDFromPosition: the visible page
+// number (which skips hidden pages) does not match a page's absolute `position`, so that
+// round-trip resolves to the wrong page when hidden pages precede the target.
+export const getPageIdFromEmbeddable = (activity: Activity, embeddableRefId: string): number | null => {
+  for (const page of activity.pages) {
+    for (const section of page.sections) {
+      if (section.embeddables.some((e: EmbeddableType) => e.ref_id === embeddableRefId)) {
+        return page.id;
+      }
+    }
+  }
+  return null;
+};
+
 export const getVisiblePages = (activity: Activity) => {
   return activity.pages.filter(page => !page.is_hidden);
 };


### PR DESCRIPTION
## AP-104: Fix "Question" links on completion page to use semantic link elements

[AP-104](https://concord-consortium.atlassian.net/browse/AP-104) · WCAG 4.1.2 (Level A)

### Problem
The "Question" navigation items on the activity completion page behaved as links (they navigate to the question's page) but were implemented as `<button>` elements. Screen readers announced them as buttons, and they were not reachable via standard link navigation (Tab, screen-reader link list).

### Changes
- **`summary-table.tsx`** — the `<button>` is now a native `<a href={getPageHref(pageId)}>`. The click handler prevents default and navigates in-app via `onPageChange` for plain clicks, but lets modifier-key clicks (cmd/ctrl/shift/alt) fall through so the anchor's `href` opens the question's page in a new tab. Added `pageId` to `IQuestionStatus`.
- **`completion-page-content.tsx`** — computes each question's `pageId` via `getPageIDFromPosition` and passes it down so the anchor gets a real `?page=page_<id>` href.
- **`summary-table.scss`** — styling selector changed from `button` to `a` (same charcoal/underlined appearance preserved).
- **`summary-table.test.tsx`** — added tests: items render as `<a data-testid="question-link">` with correct page hrefs; plain click navigates in-app and prevents default; modified click falls through to the browser.

### Accessibility audit follow-up
An accesslint audit of the change found the old `outline: none` had been carried over to the now-primary nav links with no replacement, leaving no visible keyboard focus indicator. Added a `:focus-visible` outline in `$cc-teal-dark1` that meets the 3:1 non-text contrast minimum against both the white and teal-light7 alternating row backgrounds (WCAG 2.4.7, Level AA).

### Acceptance criteria
- [x] "Question" navigation elements are native `<a href>` elements
- [x] Screen reader announces the elements as links
- [x] Keyboard users can navigate via standard link navigation
- [x] Visible keyboard focus indicator (audit follow-up)

### Testing
- `summary-table.test.tsx` — 5/5 pass
- `completion-page-content.test.tsx` — 2/2 pass
- ESLint clean on changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AP-104]: https://concord-consortium.atlassian.net/browse/AP-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ