### PR TITLE
fix(AP-95): improve Hide/Show focus ring visibility on dark header

### DIFF
--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -247,6 +247,14 @@
     &:focus-visible {
       outline: none;
       box-shadow: inset 0 0 0 2px white, inset 0 0 0 4px $cc-button-focus-ring;
+
+      // box-shadow is dropped in forced-colors mode; restore an outline (which is rendered
+      // there) so keyboard focus stays visible. Inset so the sticky header's clipped edges
+      // don't hide it.
+      @media (forced-colors: active) {
+        outline: 2px solid Highlight;
+        outline-offset: -2px;
+      }
     }
 
     &.right {

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -240,11 +240,13 @@
     top: 0;
     z-index: 3;
 
-    // Explicit, high-contrast focus ring (the sticky dark header can clip or wash out the
-    // browser default). Inset so the sticky/clipped edges don't hide it.
+    // Focus ring using the app-wide double-ring idiom (see app.scss), but with the white
+    // band outermost so it stays high-contrast against the dark header and its near-white
+    // text — the blue brand ring alone is too low-contrast on charcoal. Inset box-shadow so
+    // the sticky header's clipped edges can't hide it.
     &:focus-visible {
-      outline: 2px solid white;
-      outline-offset: -2px;
+      outline: none;
+      box-shadow: inset 0 0 0 2px white, inset 0 0 0 4px $cc-button-focus-ring;
     }
 
     &.right {


### PR DESCRIPTION
## Summary

Addresses project-team review feedback on AP-95: the keyboard focus ring on the "Hide/Show" disclosure button was hard to distinguish. The button's white ring blended into the header's own near-white text/arrows (`#dfdfdf` on charcoal `#3f3f3f`), so keyboard focus didn't clearly stand out.

This switches the ring to the app-wide double-ring idiom (see `app.scss`), but with the **white band outermost** for high contrast against the dark header and the blue brand ring (`$cc-button-focus-ring`) inside. It uses an inset `box-shadow` so the sticky header's clipped edges can't hide it.

## Changes

- `src/components/activity-page/section.scss` — replace the `2px solid white` inset outline on `.collapsible-header:focus-visible` with `box-shadow: inset 0 0 0 2px white, inset 0 0 0 4px $cc-button-focus-ring`.

## Testing

- No test changes needed — no unit/Cypress test asserts the focus styling.
- `npx tsc --noEmit` clean for project source.

Jira: AP-95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
