### PR TITLE
Switch S3 deployment workflows to OIDC authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
       - build_test
       - cypress
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -80,12 +84,14 @@ jobs:
           # skip installing cypress since it isn't needed for just building
           # This decreases the deploy time quite a bit
           CYPRESS_INSTALL_BINARY: 0
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/activity-player
+          aws-region: us-east-1
       - uses: concord-consortium/s3-deploy-action@v1
         with:
           bucket: models-resources
           prefix: activity-player
-          awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           deployRunUrl: https://activity-player.concord.org/__deployPath__/index.html
           # Parameters to GHActions have to be strings, so a regular yaml array cannot

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -5,6 +5,7 @@ on:
       version:
         description: The git tag for the version to use for index-staging.html
         required: true
+run-name: Release Staging ${{ github.event.inputs.version }}
 env:
   BUCKET: models-resources
   PREFIX: activity-player
@@ -13,12 +14,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/activity-player
+          aws-region: us-east-1
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
     steps:
       - uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -5,6 +5,7 @@ on:
       version:
         description: The git tag for the version to use for index.html
         required: true
+run-name: Release Production ${{ github.event.inputs.version }}
 env:
   BUCKET: models-resources
   PREFIX: activity-player
@@ -13,12 +14,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::612297603577:role/activity-player
+          aws-region: us-east-1
       - run: >
           aws s3 cp
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/version/${{ github.event.inputs.version }}/${{ env.SRC_FILE }}
           s3://${{ env.BUCKET }}/${{ env.PREFIX }}/${{ env.DEST_FILE }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: read
     steps:
       - uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
[DEV-163](https://concord-consortium.atlassian.net/browse/DEV-163)

Replace static AWS access-key secrets with OIDC role assumption via `aws-actions/configure-aws-credentials` in `ci.yml` and both release workflows, using the new per-repo IAM role.

Also add `run-name` to the release workflows so the Actions UI shows which version each run released.

Follows the pattern established in `ocean-explorer` and `starter-projects`.

[DEV-163]: https://concord-consortium.atlassian.net/browse/DEV-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ