### PR TITLE
AP-123: restrict activity-supplied URLs to safe schemes and plugin scripts to allowed hosts

### DIFF
--- a/src/components/activity-page/managed-interactive/iframe-runtime.tsx
+++ b/src/components/activity-page/managed-interactive/iframe-runtime.tsx
@@ -28,6 +28,7 @@ import { useMediaLibrary } from "../../media-library-context";
 import { IframeRuntimeFeedback } from "../../teacher-feedback/iframe-runtime-feedback";
 import { isOfferingLocked } from "../../../utilities/portal-data-utils";
 import { queryValue, queryValueBoolean } from "../../../utilities/url-query";
+import { isHttpUrl } from "../../../utilities/url-utils";
 import { anonymousPortalData } from "../../../portal-api";
 import { useCompositeRef } from "../../../utilities/use-composite-ref";
 import { applyOverrides } from "../../../utilities/url-overrides/state";
@@ -441,7 +442,7 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
       // Reload the iframe.
       // Apply URL overrides here too, to match the JSX src={applyOverrides(url)};
       // otherwise this imperative assignment clobbers the overridden src with the raw url.
-      iframeRef.current.src = applyOverrides(url);
+      iframeRef.current.src = isHttpUrl(url) ? applyOverrides(url) : "about:blank";
       // Re-init interactive, this time using a new mode (report or runtime).
       const phone: IframePhone = new iframePhone.ParentEndpoint(iframeRef.current, initInteractive);
       phoneRef.current = phone;
@@ -553,7 +554,7 @@ export const IframeRuntime: React.ForwardRefExoticComponent<IProps> = forwardRef
         tabIndex={locked ? -1 : 0}
         key={`${id}-${reloadCount}`}
         ref={composedIframeRef}
-        src={applyOverrides(url)}
+        src={isHttpUrl(url) ? applyOverrides(url) : "about:blank"}
         id={id}
         width={width}
         height={height}

--- a/src/components/activity-page/managed-interactive/lightbox.tsx
+++ b/src/components/activity-page/managed-interactive/lightbox.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from "react";
 import { IShowLightbox } from "@concord-consortium/lara-interactive-api";
 import ReactModal from "react-modal";
 import { applyOverrides } from "../../../utilities/url-overrides/state";
+import { isHttpUrl } from "../../../utilities/url-utils";
 import "./lightbox.scss";
 
 export interface IProps extends IShowLightbox {
@@ -88,7 +89,7 @@ export const Lightbox: React.FC<IProps> = (props) => {
       {
         isImage ?
         <img ref={imgRef} src={url} onLoad={imgLoaded} style={{ width: imgWidth, height: imgHeight, visibility: imgWidth === undefined ? "hidden" : "visible" }} data-testid="lightbox-image" /> :
-        <iframe src={applyOverrides(url)} width={iframeSizeOpts.width} height={iframeSizeOpts.height} title="Image lightbox" data-testid="lightbox-iframe" />
+        <iframe src={isHttpUrl(url) ? applyOverrides(url) : "about:blank"} width={iframeSizeOpts.width} height={iframeSizeOpts.height} title="Image lightbox" data-testid="lightbox-iframe" />
       }
       </div>
     </ReactModal>

--- a/src/utilities/plugin-utils.test.ts
+++ b/src/utilities/plugin-utils.test.ts
@@ -98,6 +98,18 @@ describe("Plugin utility functions", () => {
       expect(MockLARA.Plugins.setNextPluginLabel).toHaveBeenCalledTimes(2);
       expect(handleLoadPlugins).toHaveBeenCalledTimes(1);
     });
+
+    it("does not load a script served from a host that is not allowed", () => {
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+      // the plugin url is https://example.com/plugin.js, which is not an allowed host
+      const activityWithDisallowedPlugin = { ...activity, plugins: [plugin], pages: [] } as Activity;
+      loadPluginScripts(MockLARA, [activityWithDisallowedPlugin], handleLoadPlugins);
+      expect(MockLARA.Plugins.setNextPluginLabel).not.toHaveBeenCalled();
+      expect(document.body.appendChild).not.toHaveBeenCalled();
+      // the skipped script must still settle so the remaining plugins are not blocked
+      expect(handleLoadPlugins).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
   });
 
   describe("#validateEmbeddablePluginContextForPlugin", () => {

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -4,7 +4,7 @@ import { LaraGlobalType } from "../lara-plugin";
 import { IEmbeddableContextOptions, IPluginRuntimeContextOptions } from "../lara-plugin/plugins/plugin-context";
 import { Activity, EmbeddableType, IEmbeddablePlugin, Plugin, ApprovedScript } from "../types";
 import { getResourceUrl } from "../lara-api";
-import { isHttpUrl } from "./url-utils";
+import { isAllowedPluginScriptUrl } from "./url-utils";
 
 export interface UsedApprovedScriptInfo {
   id: number;
@@ -72,8 +72,13 @@ export const findUsedApprovedScripts = (activities: Activity[]) => {
 export const loadPluginScripts = (LARA: LaraGlobalType, activities: Activity[], handleLoadScripts: () => void) => {
   const scripts = findUsedApprovedScripts(activities);
   scripts.forEach((usedScriptInfo) => {
-    if (!isHttpUrl(usedScriptInfo.approvedScript.url)) {
-      // Skip plugin scripts whose url does not use a supported (http/https) scheme.
+    if (!isAllowedPluginScriptUrl(usedScriptInfo.approvedScript.url)) {
+      // Skip plugin scripts that do not use a supported (http/https) scheme or that
+      // are not served from an allowed host. These run in the Activity Player origin,
+      // so an activity must not be able to point them at arbitrary JavaScript.
+      // eslint-disable-next-line no-console
+      console.warn(`plugin${usedScriptInfo.id} script not loaded, url is not allowed:`,
+                   usedScriptInfo.approvedScript.url);
       usedScriptInfo.loaded = true;
       if (scripts.filter((p) => !p.loaded).length === 0) {
         handleLoadScripts();
@@ -89,10 +94,6 @@ export const loadPluginScripts = (LARA: LaraGlobalType, activities: Activity[], 
     script.src = usedScriptInfo.approvedScript.url;
     script.setAttribute("data-id", pluginLabel);
     script.onload = function() {
-      if (typeof window.jest === undefined) {
-        // eslint-disable-next-line no-console
-        console.log(`plugin${usedScriptInfo.id} script loaded`);
-      }
       usedScriptInfo.loaded = true;
       if (scripts.filter((p) => !p.loaded).length === 0) {
         handleLoadScripts();

--- a/src/utilities/plugin-utils.ts
+++ b/src/utilities/plugin-utils.ts
@@ -4,6 +4,7 @@ import { LaraGlobalType } from "../lara-plugin";
 import { IEmbeddableContextOptions, IPluginRuntimeContextOptions } from "../lara-plugin/plugins/plugin-context";
 import { Activity, EmbeddableType, IEmbeddablePlugin, Plugin, ApprovedScript } from "../types";
 import { getResourceUrl } from "../lara-api";
+import { isHttpUrl } from "./url-utils";
 
 export interface UsedApprovedScriptInfo {
   id: number;
@@ -71,6 +72,14 @@ export const findUsedApprovedScripts = (activities: Activity[]) => {
 export const loadPluginScripts = (LARA: LaraGlobalType, activities: Activity[], handleLoadScripts: () => void) => {
   const scripts = findUsedApprovedScripts(activities);
   scripts.forEach((usedScriptInfo) => {
+    if (!isHttpUrl(usedScriptInfo.approvedScript.url)) {
+      // Skip plugin scripts whose url does not use a supported (http/https) scheme.
+      usedScriptInfo.loaded = true;
+      if (scripts.filter((p) => !p.loaded).length === 0) {
+        handleLoadScripts();
+      }
+      return;
+    }
     // set plugin label
     const pluginLabel = "plugin" + usedScriptInfo.id;
     LARA.Plugins.setNextPluginLabel(pluginLabel);

--- a/src/utilities/url-utils.test.ts
+++ b/src/utilities/url-utils.test.ts
@@ -1,4 +1,4 @@
-import { isHttpUrl } from "./url-utils";
+import { isAllowedPluginScriptUrl, isHttpUrl } from "./url-utils";
 
 describe("isHttpUrl", () => {
   it("accepts absolute http and https urls", () => {
@@ -17,5 +17,57 @@ describe("isHttpUrl", () => {
     expect(isHttpUrl("")).toBe(false);
     expect(isHttpUrl("/relative/path")).toBe(false);
     expect(isHttpUrl("example.com/no-scheme")).toBe(false);
+  });
+});
+
+describe("isAllowedPluginScriptUrl", () => {
+  it("accepts the plugin script urls approved in production and staging", () => {
+    const approvedScriptUrls = [
+      "https://model-feedback.concord.org/version/1.1.2/trap.js",
+      "https://model-feedback.concord.org/version/1.1.2/aquifer.js",
+      "https://model-feedback.concord.org/version/1.1.2/supply.js",
+      "https://model-feedback.concord.org/version/1.1.2/feedbackView.js",
+      "https://model-feedback.concord.org/version/1.1.2/debugging.js",
+      "https://models-resources.concord.org/glossary-plugin/version/v4.6.0/plugin.js",
+      "https://models-resources.concord.org/glossary-plugin/version/v4.1.0/plugin.js",
+      "https://models-resources.concord.org/glossary-plugin/plugin.js",
+      "https://teacher-edition-tips-plugin.concord.org/version/v3.10.0/plugin.js",
+      "https://lara-sharing-plugin.concord.org/version/v5.0.3/plugin.js",
+      "https://lara-sharing-plugin.concord.org/version/v5.0.2/plugin.js",
+      "https://lara-sharing-plugin.concord.org/branch/master/plugin.js",
+      "https://glossary-plugin.concord.org/version/v3.13.0-pre.4/plugin.js",
+      "https://glossary-plugin.concord.org/branch/master/plugin.js",
+    ];
+    approvedScriptUrls.forEach((url) => expect(isAllowedPluginScriptUrl(url)).toBe(true));
+  });
+
+  it("accepts concord.org itself and any subdomain", () => {
+    expect(isAllowedPluginScriptUrl("https://concord.org/plugin.js")).toBe(true);
+    expect(isAllowedPluginScriptUrl("https://a.b.concord.org/plugin.js")).toBe(true);
+  });
+
+  it("accepts locally served scripts on any port", () => {
+    expect(isAllowedPluginScriptUrl("http://localhost:8080/plugin.js")).toBe(true);
+    expect(isAllowedPluginScriptUrl("http://127.0.0.1:11000/plugin.js")).toBe(true);
+  });
+
+  it("rejects hosts that merely look like an allowed host", () => {
+    expect(isAllowedPluginScriptUrl("https://evilconcord.org/plugin.js")).toBe(false);
+    expect(isAllowedPluginScriptUrl("https://concord.org.example.com/plugin.js")).toBe(false);
+    expect(isAllowedPluginScriptUrl("https://example.com/concord.org/plugin.js")).toBe(false);
+    expect(isAllowedPluginScriptUrl("https://notlocalhost/plugin.js")).toBe(false);
+    expect(isAllowedPluginScriptUrl("https://evil.127.0.0.1.example.com/plugin.js")).toBe(false);
+  });
+
+  it("rejects allowed hosts reached with an unsupported scheme", () => {
+    expect(isAllowedPluginScriptUrl("javascript:alert(1)")).toBe(false);
+    expect(isAllowedPluginScriptUrl("data:text/javascript,alert(1)")).toBe(false);
+    expect(isAllowedPluginScriptUrl("ftp://models-resources.concord.org/plugin.js")).toBe(false);
+  });
+
+  it("rejects empty, missing, or relative values", () => {
+    expect(isAllowedPluginScriptUrl(undefined)).toBe(false);
+    expect(isAllowedPluginScriptUrl("")).toBe(false);
+    expect(isAllowedPluginScriptUrl("/relative/plugin.js")).toBe(false);
   });
 });

--- a/src/utilities/url-utils.test.ts
+++ b/src/utilities/url-utils.test.ts
@@ -1,0 +1,21 @@
+import { isHttpUrl } from "./url-utils";
+
+describe("isHttpUrl", () => {
+  it("accepts absolute http and https urls", () => {
+    expect(isHttpUrl("http://example.com/foo")).toBe(true);
+    expect(isHttpUrl("https://example.com/foo?bar=1")).toBe(true);
+  });
+
+  it("rejects urls that use an unsupported scheme", () => {
+    expect(isHttpUrl("javascript:alert(1)")).toBe(false);
+    expect(isHttpUrl("data:text/html,<h1>hi</h1>")).toBe(false);
+    expect(isHttpUrl("ftp://example.com/file")).toBe(false);
+  });
+
+  it("rejects empty, missing, or relative values", () => {
+    expect(isHttpUrl(undefined)).toBe(false);
+    expect(isHttpUrl("")).toBe(false);
+    expect(isHttpUrl("/relative/path")).toBe(false);
+    expect(isHttpUrl("example.com/no-scheme")).toBe(false);
+  });
+});

--- a/src/utilities/url-utils.ts
+++ b/src/utilities/url-utils.ts
@@ -1,0 +1,12 @@
+// Returns true only for absolute http(s) URLs. Values that use another scheme,
+// or that do not parse as an absolute URL (e.g. a relative path), return false
+// so callers can fall back to a safe default.
+export const isHttpUrl = (url?: string): boolean => {
+  if (!url) return false;
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+};

--- a/src/utilities/url-utils.ts
+++ b/src/utilities/url-utils.ts
@@ -10,3 +10,22 @@ export const isHttpUrl = (url?: string): boolean => {
     return false;
   }
 };
+
+// Domains that may serve plugin scripts, matched exactly or as a dot-suffix.
+const allowedPluginScriptDomains = ["concord.org"];
+
+// Hosts that may serve plugin scripts, matched exactly (any port). These let a
+// developer test a locally served plugin script.
+const allowedPluginScriptHosts = ["localhost", "127.0.0.1"];
+
+// Returns true only for http(s) plugin script urls served from an allowed host.
+// Plugin scripts are loaded via <script src> and so run in the Activity Player's
+// own origin, where a scheme check alone is not enough: any https url would still
+// execute. Matching is done on the parsed hostname rather than on the url text, so
+// lookalikes such as evilconcord.org or concord.org.example.com are rejected.
+export const isAllowedPluginScriptUrl = (url?: string): boolean => {
+  if (!url || !isHttpUrl(url)) return false;
+  const { hostname } = new URL(url);
+  if (allowedPluginScriptHosts.includes(hostname)) return true;
+  return allowedPluginScriptDomains.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`));
+};


### PR DESCRIPTION
Restricts URLs taken from activity/sequence JSON before they are used as an iframe `src` or a plugin `<script>` source.

- Interactive and lightbox iframe `src` fall back to `about:blank` unless the URL uses an http(s) scheme.
- Plugin scripts are loaded only when the URL is http(s) **and** served from an allowed host: `*.concord.org`, plus `localhost` / `127.0.0.1` on any port for local development. Host matching is done on the parsed hostname (exact or dot-suffix) so lookalikes such as `evilconcord.org` are rejected.
- Adds an `isHttpUrl` / `isAllowedPluginScriptUrl` helper module with unit tests, plus a test covering the plugin-loader skip path.
- Removes an unreachable debug `console.log` in the plugin loader whose `typeof window.jest === undefined` guard could never fire.

Addresses AP-123. Full test suite and Cypress run in CI.
