### PR TITLE
fix: retract the stale tutor-unavailable banner on recovery [AP-118]

### DIFF
--- a/src/components/chat/use-chat.test.ts
+++ b/src/components/chat/use-chat.test.ts
@@ -77,4 +77,44 @@ describe("useChat with DebugTransport", () => {
     act(() => { emitStatus("error"); });
     expect(result.current.error).toContain("unavailable");
   });
+
+  it("retracts the unavailable error once the conversation recovers", () => {
+    let emitStatus: (s: ChatStatus) => void = () => undefined;
+    const transport: ChatTransport = {
+      subscribe: (onTurns, onStatus) => { emitStatus = onStatus; onTurns([]); onStatus("idle"); return () => undefined; },
+      sendUserMessage: async () => undefined,
+    };
+    const { result } = renderHook(() => useChat({ transport, header: "h" }));
+
+    // A conversation whose parent doc still carries status:"error" from an earlier failure shows the
+    // banner on its first snapshot...
+    act(() => { emitStatus("error"); });
+    expect(result.current.error).toContain("unavailable");
+
+    // ...and must clear it once a later drain succeeds, rather than leaving a stale error sitting
+    // underneath the tutor's own replies for the life of the page.
+    act(() => { emitStatus("generating"); });
+    expect(result.current.error).toBeNull();
+
+    act(() => { emitStatus("error"); });
+    expect(result.current.error).toContain("unavailable");
+    act(() => { emitStatus("idle"); });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not retract a sendMessage failure when the status changes", async () => {
+    let emitStatus: (s: ChatStatus) => void = () => undefined;
+    const transport: ChatTransport = {
+      subscribe: (onTurns, onStatus) => { emitStatus = onStatus; onTurns([]); onStatus("idle"); return () => undefined; },
+      sendUserMessage: async () => { throw new Error("write rejected"); },
+    };
+    const { result } = renderHook(() => useChat({ transport, header: "h" }));
+
+    await act(async () => { await result.current.sendMessage("hi").catch(() => undefined); });
+    expect(result.current.error).toBe("write rejected");
+
+    // the status effect owns only its own message — an unrelated transition must leave this one alone
+    act(() => { emitStatus("generating"); });
+    expect(result.current.error).toBe("write rejected");
+  });
 });

--- a/src/components/chat/use-chat.ts
+++ b/src/components/chat/use-chat.ts
@@ -17,6 +17,10 @@ export interface UseChatResult {
   header: string;
 }
 
+// The authoritative-status error text. Named so the status effect can tell its own message apart from
+// a `sendMessage` failure and retract only the former.
+export const kTutorUnavailable = "The tutor is currently unavailable. Please try again.";
+
 export interface UseChatOptions {
   transport: ChatTransport;
   // "Chat about: Page N — <title>" — makes the per-page scoping legible.
@@ -40,10 +44,19 @@ export function useChat({ transport, header }: UseChatOptions): UseChatResult {
     return unsubscribe;
   }, [transport]);
 
-  // Surface an authoritative `status:"error"` as a visible error (rather than an infinite spinner).
+  // Surface an authoritative `status:"error"` as a visible error (rather than an infinite spinner),
+  // and RETRACT it once the conversation recovers. Without the retraction the banner latched for the
+  // life of the page: a conversation that had errored (the parent doc keeps `status:"error"` until a
+  // later drain succeeds) showed the error on the first snapshot after load, then kept showing it
+  // underneath the tutor's own successful replies once the backend recovered.
+  //
+  // Only the message THIS effect owns is retracted — a `sendMessage` failure writes its own text and
+  // must survive an unrelated status transition, so it is left alone.
   useEffect(() => {
     if (status === "error") {
-      setError("The tutor is currently unavailable. Please try again.");
+      setError(kTutorUnavailable);
+    } else {
+      setError(prev => (prev === kTutorUnavailable ? null : prev));
     }
   }, [status]);
 


### PR DESCRIPTION
## Problem

The `status === "error"` effect in `use-chat.ts` set the error banner but never cleared it, so once shown it latched for the life of the page.

The visible symptom, hit while testing chat against staging: a conversation whose parent doc still carried `status:"error"` from an earlier failure showed the banner on its first snapshot after load. The backend then recovered and the tutor replied normally, but the stale "The tutor is currently unavailable. Please try again." row kept sitting directly underneath the tutor's own successful replies.

Practically, a student who hit one transient failure kept seeing "tutor is currently unavailable" for the rest of that page even while it was working. It only cleared on the next send or on page navigation, which are the two existing `setError(null)` sites.

## Fix

The effect now retracts the message when status leaves `"error"`.

It retracts **only the message it owns** (extracted as `kTutorUnavailable`). A `sendMessage` failure writes its own text and must survive an unrelated status transition, so it is deliberately left alone.

## Tests

Two new cases in `use-chat.test.ts`, covering both directions:

- the banner clears once a later drain succeeds (`error` → `generating`/`idle`)
- a `sendMessage` failure is **not** wiped by a subsequent status change

Full suite: 101 suites, 553 passed, 9 skipped. Lint clean.

## Notes

Cosmetic only, no behavior change to the chat transport, rules, or the backend. Found while verifying the chat tutor against staging as part of the 2.17.0 release.