### PR TITLE
fix: chat tutor cost, reliability, layout and coverage defects [AP-126]

### DIFF
--- a/cypress/e2e/chat.test.ts
+++ b/cypress/e2e/chat.test.ts
@@ -1,0 +1,111 @@
+import ActivityPage from "../support/elements/activity-page";
+import Chat from "../support/elements/chat";
+
+const activityPage = new ActivityPage;
+const chat = new Chat;
+
+// Coverage for the assembled showChat gate in app.tsx. Its helpers (resolveChatEnabled,
+// getChatIdentity, shouldShowChat) have unit tests, but the composed behaviour that actually enforces
+// EXT-2 (no chat on single-page activities) and EXT-7 (no chat on the completion page) had none.
+//
+// Two flags matter here and both are deliberate:
+//   - `chatDebug` forces the no-backend DebugTransport. WITHOUT it a bundled sample takes the LIVE
+//     transport, because the debug fallback keys off `!identity.activityUrl` and getResourceUrl()
+//     returns the sample NAME (truthy, not empty). A live run would write real chat docs to
+//     report-service-dev and bill an OpenAI turn per forwarded log, from CI.
+//   - `preview` is NOT used. Anonymous preview runs resolve to no chat identity at all (the run key is
+//     literally "preview", which getChatIdentity rejects), so the gate would be off for the wrong
+//     reason and every assertion below would pass vacuously.
+const chatUrl = (activity: string, extra = "") =>
+  `?activity=${activity}&chat=true&chatDebug=true${extra}`;
+
+context("Chat tutor sidebar gate", () => {
+  describe("the ?chat flag", () => {
+    it("does not render the launcher without the flag", () => {
+      cy.visit("?activity=sample-activity-1");
+      activityPage.getPage(2).click();
+      activityPage.getPageContent().should("be.visible"); // page rendered, so absence below is real
+      chat.getLauncher().should("not.exist");
+    });
+
+    it("does not render the launcher for ?chat=false", () => {
+      cy.visit("?activity=sample-activity-1&chat=false&chatDebug=true");
+      activityPage.getPage(2).click();
+      activityPage.getPageContent().should("be.visible");
+      chat.getLauncher().should("not.exist");
+    });
+
+    it("renders the launcher on a content page with the flag", () => {
+      cy.visit(chatUrl("sample-activity-1"));
+      activityPage.getPage(2).click();
+      chat.getLauncher().should("be.visible");
+    });
+  });
+
+  describe("page-level exclusions", () => {
+    it("does not render the launcher on the activity intro page", () => {
+      // The intro page is currentPage === 0: a real page of the activity, but not a content page to
+      // tutor on. Landing here is the default, so no navigation is needed.
+      cy.visit(chatUrl("sample-activity-1"));
+      activityPage.getPagesHeader().should("be.visible"); // we really are on the intro page
+      chat.getLauncher().should("not.exist");
+    });
+
+    it("does not render the launcher on the completion page (EXT-7)", () => {
+      cy.visit(chatUrl("sample-activity-1"));
+      activityPage.getPage(2).click();
+      chat.getLauncher().should("be.visible"); // present first, so its absence below is the gate
+      // .first(): the completion-page button is rendered in both the top and bottom nav.
+      activityPage.getCompletionPage().first().click();
+      chat.getLauncher().should("not.exist");
+    });
+
+    it("does not render the launcher on a single-page activity (EXT-2)", () => {
+      // A single-page layout has no per-page scoping for a conversation to be about.
+      cy.visit(chatUrl("sample-activity-single-page-layout"));
+      chat.getLauncher().should("not.exist");
+    });
+  });
+
+  describe("opening and closing the drawer", () => {
+    beforeEach(() => {
+      cy.visit(chatUrl("sample-activity-1"));
+      activityPage.getPage(2).click();
+    });
+
+    it("opens the drawer from the launcher and closes it again", () => {
+      chat.getSidebar().should("not.exist");
+      chat.getLauncher().click();
+      chat.getSidebar().should("be.visible");
+      chat.getHeader().should("contain", "Ask the Tutor");
+      chat.getComposer().should("be.visible");
+      // NOT chat-empty: DebugTransport seeds the would-be system prompt as an opening turn, so the
+      // empty state never renders in a dry run. The seeded turn is collapsed, so assert the toggle
+      // and expand it to reach the dry-run text.
+      chat.getDebugBody().should("not.exist");
+      chat.getDebugToggle().click();
+      chat.getDebugBody().should("contain", "local dry run");
+
+      chat.getCloseButton().click();
+      chat.getSidebar().should("not.exist");
+      chat.getLauncher().should("be.visible"); // launcher comes back, so the chat is re-openable
+    });
+
+    it("swaps the conversation when the student navigates to another page", () => {
+      // The transport is re-keyed per activityId + pageId, so navigating away is a hard conversation
+      // swap rather than a carried-over thread.
+      chat.getLauncher().click();
+      chat.getInput().type("scoped to page two{enter}");
+      chat.getUserRows().should("contain", "scoped to page two");
+
+      // getNavPageButton, not getPage: [data-cy=activity-page-links] only exists on the intro page,
+      // so getPage() cannot move between content pages. sample-activity-1 has exactly two content
+      // pages plus a completion page, so index 0 (page one) is the only other page to move to.
+      // The panel also re-closes on navigation, hence the second launcher click.
+      activityPage.getNavPageButton(0).click();
+      chat.getLauncher().click();
+      chat.getUserRows().should("not.exist");        // the page-two message did not follow us
+      chat.getDebugToggle().should("be.visible");    // a fresh conversation, freshly seeded
+    });
+  });
+});

--- a/cypress/support/elements/chat.js
+++ b/cypress/support/elements/chat.js
@@ -1,0 +1,39 @@
+class Chat {
+  getLauncher() {
+    return cy.get("[data-cy=chat-launcher]");
+  }
+  getSidebar() {
+    return cy.get("[data-cy=chat-sidebar]");
+  }
+  getHeader() {
+    return cy.get("[data-cy=chat-header]");
+  }
+  getCloseButton() {
+    return cy.get("[data-cy=chat-close]");
+  }
+  getMessages() {
+    return cy.get("[data-cy=chat-messages]");
+  }
+  getEmptyState() {
+    return cy.get("[data-cy=chat-empty]");
+  }
+  getComposer() {
+    return cy.get("[data-cy=chat-composer]");
+  }
+  getInput() {
+    return cy.get("[data-cy=chat-input]");
+  }
+  // DebugTransport's seeded "what would be sent" turn. Its body is collapsed until the toggle is
+  // clicked, so the segment text is absent from the DOM until then.
+  getDebugToggle() {
+    return cy.get("[data-cy=chat-debug-toggle]");
+  }
+  getDebugBody() {
+    return cy.get("[data-cy=chat-debug-body]");
+  }
+  getUserRows() {
+    return cy.get("[data-cy=chat-row-user]");
+  }
+}
+
+export default Chat;

--- a/specs/AP-118-chat-sidebar-spike.md
+++ b/specs/AP-118-chat-sidebar-spike.md
@@ -84,7 +84,7 @@ onSnapshot renders new docs ◀──────────────── 
   attribution in the DOM, a single `aria-live="polite"` region announced on assistant-message
   completion, AT-exposed "…" indicator, and keyboard focus management for the overlay drawer.
 
-### Phase 2 — live sim-awareness: log forwarding + sim prompts *(specced; see Not Yet Implemented)*
+### Phase 2 — live sim-awareness: log forwarding + sim prompts *(implemented)*
 
 - **Log forwarding.** Interactive log messages forwarded into the conversation as `kind:"log"` docs
   (dropping mouse-move/-button spam), fed to the model as **`developer`-role telemetry** wrapped in a
@@ -165,15 +165,27 @@ onSnapshot renders new docs ◀──────────────── 
   project + test/pilot data, never real PII); production needs per-requester scoping or authenticated-only
   chat.
 
+## What Shipped
+
+**Both phases are implemented.** Phase 1 (per-page chat loop, page-context system prompt, dual-mode
+sidebar) and Phase 2 (live sim-awareness) are all on the live path as of the AP-118 merge:
+
+- **Log forwarding** — `handleLog` in `managed-interactive` → `chat-log-forwarder` (spam drop,
+  trailing-edge coalesce, MC choice-map enrichment) → a `kind:"log"` doc, consumed by the
+  report-service log branch with drain-step coalescing (`functions/src/chat/drain.ts`).
+- **URL-keyed sim prompts** — `functions/src/chat/sim-prompts.ts`, matched host/subdomain-first.
+
+**Where page context is assembled.** The live path assembles it **server-side**, and only there.
+`FirestoreTransport.sendUserMessage` writes ids, the activity URL and display-only orientation hints —
+**no page body and no `authored_state` ever leave the browser** (this is the point of ENG-8: the
+answer-bearing `authored_state` stays server-side). The client-side `assemblePageContext` is used by
+`DebugTransport` alone, to render "what would be sent" in the no-backend dry run; the function
+re-derives the same context from the activity it fetches.
+
 ## Not Yet Implemented
 
-The spec covers two phases plus a set of intentionally-deferred later tiers. As of closing, the spec and
-the de-risking spikes are complete; the following were **specced but explicitly deferred** rather than
-sliced into Phase-1-fine build steps:
+The following remain **specced but explicitly deferred**:
 
-- **Phase 2 (live sim-awareness)** — log forwarding from `handleLog`, the report-service log branch +
-  coalescing, the client-side MC choice-map enrichment, and the URL-keyed sim-prompt map. Specced at
-  file level but "not sliced into Phase-1-fine commits"; it is the deferred follow-on.
 - **Later Tiers (design preserved, not lost):** global/cross-page conversation & memory; streaming via a
   2nd-gen HTTP/callable function; LARA authoring of per-question tutoring guidance; an `authored_state`
   answer-key-stripping transform (fallback if the raw approach leaks answers); a one-time "current

--- a/specs/AP-118-chat-sidebar-spike.md
+++ b/specs/AP-118-chat-sidebar-spike.md
@@ -191,9 +191,10 @@ The following remain **specced but explicitly deferred**:
   answer-key-stripping transform (fallback if the raw approach leaks answers); a one-time "current
   answers" snapshot on chat-open (fallback if logs prove too blind — e.g. chat opened after working, or
   sim outcomes that never hit the log stream); image vision; broader (non-log) proactive triggers.
-- **Spike-code cleanup before deploy** — the emulator-spike triggers (`chatSpikeOnWrite`,
-  `chatTutorSpikeOnWrite`) are registered in report-service `index.ts` and must be removed (or evolved
-  into the real RS-2/RS-3/RS-4 trigger) before `firebase deploy --only functions`.
+
+Spike-code cleanup is **done**, not deferred: the emulator-spike triggers (`chatSpikeOnWrite`,
+`chatTutorSpikeOnWrite`) were evolved into the single real `chatTutorOnWrite` trigger, which is the
+only chat trigger report-service `index.ts` registers and is deployed on both projects.
 
 ## Decisions
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -48,7 +48,7 @@ import { initializeAttachmentsManager } from "@concord-consortium/interactive-ap
 import { LaraDataContext } from "./lara-data-context";
 import { ChatSidebar } from "./chat/chat-sidebar";
 import { resolveChatEnabled } from "../utilities/chat-flag";
-import { getChatIdentity } from "./chat/chat-eligibility";
+import { getChatIdentity, shouldShowChat } from "./chat/chat-eligibility";
 import { OrientationHints } from "../utilities/chat-context";
 import { __closeAllPopUps } from "../lara-plugin/plugin-api/popup";
 import { IPageChangeNotification, PageChangeNotificationErrorTimeout, PageChangeNotificationStartTimeout } from "./activity-page/page-change-notification";
@@ -575,17 +575,25 @@ export class App extends React.PureComponent<IProps, IState> {
     // completion), and a learner/anonymous identity with a usable key.
     const currentPageObj = currentPage > 0 ? pagesVisible[currentPage - 1] : undefined;
     const chatIdentity = getChatIdentity(getPortalData());
-    const showChat = this.chatEnabled
-      && !idle && !errorType
-      && activity.layout !== ActivityLayouts.SinglePage
-      && !!currentPageObj
-      && !currentPageObj.is_completion
-      && !!chatIdentity;
+    const showChat = shouldShowChat({
+      chatEnabled: this.chatEnabled,
+      idle: !!idle,
+      hasError: !!errorType,
+      isSinglePageActivity: activity.layout === ActivityLayouts.SinglePage,
+      isContentPage: !!currentPageObj,
+      isCompletionPage: !!currentPageObj?.is_completion,
+      identity: chatIdentity,
+    });
     const chatHints: OrientationHints = {
       sequenceTitle: sequence ? (sequence.display_title || sequence.title) : undefined,
       activityTitle: activity.name,
       activityIndex: sequence ? activityIndex : undefined,
       activityCount: sequence ? sequence.activities.length : undefined,
+      // Page N of M derived HERE, once, from the same `pagesVisible` the student is paging through
+      // (which honours ?author-preview), and passed down. chat-context falls back to deriving it
+      // from the activity only when these are absent, which is the report-service lift's case.
+      pageNumber: currentPage,
+      pageCount: pagesVisible.length,
     };
 
     return (
@@ -645,7 +653,6 @@ export class App extends React.PureComponent<IProps, IState> {
             fullWidth={fullWidth}
             activity={activity}
             page={currentPageObj}
-            pageNumber={currentPage}
             hints={chatHints}
             identity={chatIdentity}
           />

--- a/src/components/chat/chat-eligibility.test.ts
+++ b/src/components/chat/chat-eligibility.test.ts
@@ -1,4 +1,4 @@
-import { getChatIdentity } from "./chat-eligibility";
+import { ChatIdentity, getChatIdentity, shouldShowChat } from "./chat-eligibility";
 import { IAnonymousPortalData, IPortalData } from "../../portal-types";
 
 const anon = (runKey: string): IAnonymousPortalData => ({
@@ -58,5 +58,50 @@ describe("getChatIdentity", () => {
   it("rejects authenticated teachers and learners with no learner key", () => {
     expect(getChatIdentity(authed("teacher", "some-key"))).toBeNull();
     expect(getChatIdentity(authed("learner", undefined))).toBeNull();
+  });
+});
+
+describe("shouldShowChat", () => {
+  const identity: ChatIdentity = { source: "s", key: "learner-key-1", ownerFields: { run_key: "r" } };
+  // The all-clear baseline: a flagged-on learner on an ordinary content page.
+  const eligible = {
+    chatEnabled: true,
+    idle: false,
+    hasError: false,
+    isSinglePageActivity: false,
+    isContentPage: true,
+    isCompletionPage: false,
+    identity,
+  };
+
+  it("shows chat for a flagged-on learner on a content page", () => {
+    expect(shouldShowChat(eligible)).toBe(true);
+  });
+
+  it("stays off unless the flag is on", () => {
+    expect(shouldShowChat({ ...eligible, chatEnabled: false })).toBe(false);
+  });
+
+  it("stays off without a usable identity (teacher / preview / short run key)", () => {
+    expect(shouldShowChat({ ...eligible, identity: null })).toBe(false);
+  });
+
+  // EXT-2: a single-page activity has no per-page scoping for the conversation to be about.
+  it("stays off for a single-page activity", () => {
+    expect(shouldShowChat({ ...eligible, isSinglePageActivity: true })).toBe(false);
+  });
+
+  // EXT-7: the completion page is not a content page to tutor on.
+  it("stays off on the completion page", () => {
+    expect(shouldShowChat({ ...eligible, isCompletionPage: true })).toBe(false);
+  });
+
+  it("stays off on the activity intro page", () => {
+    expect(shouldShowChat({ ...eligible, isContentPage: false })).toBe(false);
+  });
+
+  it("stays off behind the idle and error screens", () => {
+    expect(shouldShowChat({ ...eligible, idle: true })).toBe(false);
+    expect(shouldShowChat({ ...eligible, hasError: true })).toBe(false);
   });
 });

--- a/src/components/chat/chat-eligibility.test.ts
+++ b/src/components/chat/chat-eligibility.test.ts
@@ -11,6 +11,12 @@ const anon = (runKey: string): IAnonymousPortalData => ({
   database: { appName: "report-service-dev", sourceKey: "auth.concord.org" },
 } as unknown as IAnonymousPortalData);
 
+// The offering's activityUrl here is the LAUNCH url the Portal actually stores, copied from a real
+// report-service-pro chat doc. The previous fixture used an authoring URL, which no production
+// offering ever supplies, and that is what hid the bug the resourceUrl regression test below covers.
+const kLaunchUrl =
+  "https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.concord.org%2Fapi%2Fv1%2Factivities%2F9.json";
+
 const authed = (userType: "teacher" | "learner", learnerKey?: string): IPortalData => ({
   type: "authenticated",
   userType,
@@ -19,8 +25,9 @@ const authed = (userType: "teacher" | "learner", learnerKey?: string): IPortalDa
   platformUserId: "555",
   contextId: "class-hash",
   resourceLinkId: "offering-1",
+  resourceUrl: "https://authoring.concord.org/activities/9",
   database: { appName: "report-service-dev", sourceKey: "portal.concord.org" },
-  offering: { id: 1, activityUrl: "https://authoring.concord.org/activities/9.json", rubricUrl: "", locked: false },
+  offering: { id: 1, activityUrl: kLaunchUrl, rubricUrl: "", locked: false },
 } as unknown as IPortalData);
 
 describe("getChatIdentity", () => {
@@ -52,7 +59,17 @@ describe("getChatIdentity", () => {
       platform_id: "https://portal.concord.org",
       context_id: "class-hash",
     });
-    expect(identity!.activityUrl).toBe("https://authoring.concord.org/activities/9.json");
+    expect(identity!.activityUrl).toBe("https://authoring.concord.org/activities/9");
+  });
+
+  it("sends the learner's resourceUrl, never the offering launch url the function would reject", () => {
+    // Regression: the function's AUTHORING_HOSTS allowlist rejects activity-player.concord.org, so
+    // sending the launch url killed the first turn of every authenticated conversation that opened with
+    // a typed message ("disallowed activity host"). A log-first turn resolves the activity from the
+    // trusted default host instead, which is why this survived staging and only bit real learners.
+    const identity = getChatIdentity(authed("learner", "learner-key-1"));
+    expect(identity!.activityUrl).not.toBe(kLaunchUrl);
+    expect(new URL(identity!.activityUrl!).hostname).toBe("authoring.concord.org");
   });
 
   it("rejects authenticated teachers and learners with no learner key", () => {

--- a/src/components/chat/chat-eligibility.ts
+++ b/src/components/chat/chat-eligibility.ts
@@ -54,7 +54,14 @@ export function getChatIdentity(
       platform_id: portalData.platformId,
       context_id: portalData.contextId,
     },
-    activityUrl: portalData.offering?.activityUrl,
+    // resourceUrl, NOT offering.activityUrl. The offering's `activity_url` is the Portal's LAUNCH url
+    // (`https://activity-player.concord.org/?activity=<encoded authoring url>`), whose host is not on the
+    // function's AUTHORING_HOSTS allowlist, so resolveActivityUrl rejects it with "disallowed activity
+    // host" and the turn dies with status:"error". That only shows up when the FIRST turn of a
+    // conversation is a typed message: a log-first turn installs the prompt via the trusted default host
+    // and never validates this field, which is what masked it in production. resourceUrl is the same
+    // getResourceUrl() value the anonymous branch sends, and it resolves to the authoring URL.
+    activityUrl: portalData.resourceUrl,
   };
 }
 

--- a/src/components/chat/chat-eligibility.ts
+++ b/src/components/chat/chat-eligibility.ts
@@ -57,3 +57,30 @@ export function getChatIdentity(
     activityUrl: portalData.offering?.activityUrl,
   };
 }
+
+// Inputs to the chat mount gate, as plain booleans plus the resolved identity, so the composed
+// decision is testable on its own. It lived inline in App.renderActivity, where the individual
+// helpers had unit tests but the assembled gate — the thing that actually enforces EXT-2 (no chat on
+// single-page activities) and EXT-7 (no chat on the completion page) — had none.
+export interface ChatGateInputs {
+  chatEnabled: boolean;           // the ?chat / localStorage flag
+  idle: boolean;                  // the idle-timeout screen is showing
+  hasError: boolean;              // an app-level error screen is showing
+  isSinglePageActivity: boolean;  // EXT-2 — a single-page layout has no per-page scoping to chat about
+  isContentPage: boolean;         // false on the activity intro page (currentPage === 0)
+  isCompletionPage: boolean;      // EXT-7 — the completion page is not a content page to tutor on
+  identity: ChatIdentity | null;  // learner/anonymous identity with a usable conversation key
+}
+
+export function shouldShowChat(inputs: ChatGateInputs): boolean {
+  const {
+    chatEnabled, idle, hasError, isSinglePageActivity, isContentPage, isCompletionPage, identity,
+  } = inputs;
+  return chatEnabled
+    && !idle
+    && !hasError
+    && !isSinglePageActivity
+    && isContentPage
+    && !isCompletionPage
+    && !!identity;
+}

--- a/src/components/chat/chat-log-forwarder.test.ts
+++ b/src/components/chat/chat-log-forwarder.test.ts
@@ -4,6 +4,7 @@ import {
   registerChatLogSink,
   unregisterChatLogSink,
   getChatLogSink,
+  kLogCoalesceMs,
   ChatLogPayload,
 } from "./chat-log-forwarder";
 
@@ -64,22 +65,76 @@ describe("buildForwardedLog", () => {
 });
 
 describe("chat log sink registry", () => {
+  beforeEach(() => jest.useFakeTimers());
   afterEach(() => {
     const s = getChatLogSink();
     if (s) unregisterChatLogSink(s);
+    jest.useRealTimers();
   });
 
-  it("forwards a built payload to the registered sink", () => {
-    const forwarded: ChatLogPayload[] = [];
-    const sink = { forwardLog: (p: ChatLogPayload) => forwarded.push(p) };
-    registerChatLogSink(sink);
+  const logOnce = (action: string, value?: unknown, interactiveId = "int-2") =>
     forwardInteractiveLog({
-      logData: { action: "did thing", value: 1 },
-      interactiveId: "int-2",
+      logData: { action, value },
+      interactiveId,
       interactiveUrl: "https://flood.concord.org/",
     });
+
+  it("forwards a built payload to the registered sink once the coalesce window closes", () => {
+    const forwarded: ChatLogPayload[] = [];
+    registerChatLogSink({ forwardLog: (p: ChatLogPayload) => forwarded.push(p) });
+    logOnce("did thing", 1);
+    // nothing written yet — the window is still open
+    expect(forwarded).toHaveLength(0);
+    jest.advanceTimersByTime(kLogCoalesceMs);
     expect(forwarded).toHaveLength(1);
     expect(forwarded[0].action).toBe("did thing");
+  });
+
+  // Every forwarded log is a Firestore write plus a report-service function invocation that bills its
+  // own tutor turn, so a burst (a slider dragged across its range) must collapse to one doc.
+  it("coalesces a burst of the same action into a single forward carrying the latest value", () => {
+    const forwarded: ChatLogPayload[] = [];
+    registerChatLogSink({ forwardLog: (p: ChatLogPayload) => forwarded.push(p) });
+    logOnce("changed model", 1);
+    jest.advanceTimersByTime(kLogCoalesceMs / 3);
+    logOnce("changed model", 2);
+    jest.advanceTimersByTime(kLogCoalesceMs / 3);
+    logOnce("changed model", 3);
+    // the window runs from the FIRST log and is not pushed out by later ones, so a continuous stream
+    // still flushes on schedule rather than starving
+    jest.advanceTimersByTime(kLogCoalesceMs);
+    expect(forwarded).toHaveLength(1);
+    expect(forwarded[0].value).toBe(3);
+  });
+
+  it("keeps two genuinely different actions from the same interactive", () => {
+    const forwarded: ChatLogPayload[] = [];
+    registerChatLogSink({ forwardLog: (p: ChatLogPayload) => forwarded.push(p) });
+    logOnce("changed model", 1);
+    logOnce("submit answer", "b");
+    jest.advanceTimersByTime(kLogCoalesceMs);
+    expect(forwarded.map(p => p.action).sort()).toEqual(["changed model", "submit answer"]);
+  });
+
+  it("starts a fresh window after the previous one flushes", () => {
+    const forwarded: ChatLogPayload[] = [];
+    registerChatLogSink({ forwardLog: (p: ChatLogPayload) => forwarded.push(p) });
+    logOnce("changed model", 1);
+    jest.advanceTimersByTime(kLogCoalesceMs);
+    logOnce("changed model", 2);
+    jest.advanceTimersByTime(kLogCoalesceMs);
+    expect(forwarded.map(p => p.value)).toEqual([1, 2]);
+  });
+
+  // A queued payload belongs to the conversation that was active when it was built. Closing the panel
+  // (or navigating pages) must drop it rather than land it in the next conversation.
+  it("discards a pending log when the sink is unregistered", () => {
+    const sink = { forwardLog: jest.fn() };
+    registerChatLogSink(sink);
+    logOnce("did thing", 1);
+    unregisterChatLogSink(sink);
+    jest.advanceTimersByTime(kLogCoalesceMs);
+    expect(sink.forwardLog).not.toHaveBeenCalled();
   });
 
   it("is a no-op when no sink is registered", () => {

--- a/src/components/chat/chat-log-forwarder.ts
+++ b/src/components/chat/chat-log-forwarder.ts
@@ -68,6 +68,41 @@ export const buildForwardedLog = (params: {
   return { interactive_id: interactiveId, interactive_url: interactiveUrl, action, value: logData?.value, data };
 };
 
+// Trailing-edge coalesce window. The spec lists a client-side spam drop AND debounce as required cost
+// controls; only the drop above had shipped. Server-side coalescing bounds the token cost but not the
+// per-log Firestore write and function invocation, and a steady trickle at idle bills a turn each time.
+export const kLogCoalesceMs = 3000;
+
+// Keyed by interactive AND action: a burst of the same action (a slider dragged across its range)
+// collapses to one forwarded doc carrying the latest state, while two genuinely different actions
+// from the same interactive both survive. Keying on the interactive alone would silently discard the
+// earlier of two distinct actions.
+const coalesceKey = (payload: ChatLogPayload): string => `${payload.interactive_id}::${payload.action}`;
+
+interface PendingLog {
+  payload: ChatLogPayload;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pendingLogs = new Map<string, PendingLog>();
+
+// Trailing edge of a FIXED window opened by the first log of a burst — later logs in the window
+// replace the payload but do not push the deadline out. (A restart-on-every-log debounce would let a
+// continuous stream starve forever and never forward anything.)
+const flushPendingLog = (key: string): void => {
+  const entry = pendingLogs.get(key);
+  if (!entry) return;
+  pendingLogs.delete(key);
+  activeSink?.forwardLog(entry.payload);
+};
+
+// Drop anything still in flight. Called on any sink change: a queued payload belongs to the
+// conversation that was active when it was built, and must never land in a different one.
+const discardPendingLogs = (): void => {
+  pendingLogs.forEach(entry => clearTimeout(entry.timer));
+  pendingLogs.clear();
+};
+
 // Convenience for callers (managed-interactive): build + forward to the active sink, if any.
 export const forwardInteractiveLog = (params: {
   logData: any;
@@ -78,19 +113,30 @@ export const forwardInteractiveLog = (params: {
   const sink = getChatLogSink();
   if (!sink) return;
   const payload = buildForwardedLog(params);
-  if (payload) sink.forwardLog(payload);
+  if (!payload) return;
+  const key = coalesceKey(payload);
+  const entry = pendingLogs.get(key);
+  if (entry) {
+    entry.payload = payload; // newest state wins; the window's deadline is untouched
+    return;
+  }
+  pendingLogs.set(key, { payload, timer: setTimeout(() => flushPendingLog(key), kLogCoalesceMs) });
 };
 
 let activeSink: ChatLogSink | null = null;
 
 export const registerChatLogSink = (sink: ChatLogSink): void => {
+  if (activeSink !== sink) discardPendingLogs();
   activeSink = sink;
 };
 
 // Only clear if the caller is still the registered sink (avoids a late unmount clobbering a newer
 // sink that registered during a page swap).
 export const unregisterChatLogSink = (sink: ChatLogSink): void => {
-  if (activeSink === sink) activeSink = null;
+  if (activeSink === sink) {
+    discardPendingLogs();
+    activeSink = null;
+  }
 };
 
 export const getChatLogSink = (): ChatLogSink | null => activeSink;

--- a/src/components/chat/chat-sidebar.scss
+++ b/src/components/chat/chat-sidebar.scss
@@ -1,15 +1,26 @@
 @import "../vars.scss";
 
-$chat-width: 25vw;
-$chat-min-width: 320px;
-$chat-max-width: 420px;
+// ONE source of truth for the drawer's rendered width. It has to be a single clamped value rather
+// than width + min-width + max-width, because the body-class rules below offset AP's fixed right-edge
+// UI by exactly this much: with a separate 25vw plus a 320px min-width, a narrow viewport rendered a
+// 320px drawer but only shifted the UI 25vw, leaving it partly covered.
+$chat-width: clamp(320px, 25vw, 420px);
+
+// AP's page-sidebar occupies a 1999 (transparent full-viewport overlay) / 2000 (expanded dialog)
+// band. The chat drawer sits just above it: at its old 1950 the transparent overlay covered the
+// drawer whenever the "Did you know?" dialog was open, so the chat rendered but was inert and clicks
+// on it dismissed the dialog instead. The launcher shares the band for the same reason.
+$chat-z: 2001;
+// The page-sidebar's parked offscreen offset (see page-sidebar/sidebar.scss `.sidebar-container`).
+// Duplicated deliberately: the offset below has to be relative to it.
+$page-sidebar-parked-right: -500px;
 
 // ---- Launcher (shown when the chat is closed) --------------------------------------------------
 .chat-launcher {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 1900;
+  z-index: $chat-z;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -36,8 +47,14 @@ $chat-max-width: 420px;
 
 // ---- Panel (shown when open) -------------------------------------------------------------------
 .chat-sidebar {
-  z-index: 1950;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: $chat-width;
+  z-index: $chat-z;
   background: white;
+  border-left: 1px solid $cc-charcoal-light2;
   box-sizing: border-box;
 
   &:focus-visible { outline: none; }
@@ -45,44 +62,58 @@ $chat-max-width: 420px;
   // OVERLAY (fixed-width activities): a right-edge drawer that does not touch the activity, so its
   // interactives don't break. Reuses the page-sidebar fixed-overlay pattern.
   &.overlay {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: $chat-width;
-    min-width: $chat-min-width;
-    max-width: $chat-max-width;
-    border-left: 1px solid $cc-charcoal-light2;
     box-shadow: -3px 0 15px rgba(0, 0, 0, 0.2);
   }
 
-  // PUSH (responsive activities): a fixed 25% right column; the activity reflows to 75% via the
-  // body-class rules below.
+  // PUSH (responsive activities): geometrically identical to the overlay, but the activity reflows
+  // around it (see the body-class rules below) rather than sliding underneath, so no drop shadow is
+  // needed — nothing is being covered.
   &.push {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    width: $chat-width;
-    min-width: $chat-min-width;
-    max-width: $chat-max-width;
-    border-left: 1px solid $cc-charcoal-light2;
+    box-shadow: none;
   }
 
   .chat { height: 100%; }
 }
 
+// ---- Right-edge reflow (while a chat is open) --------------------------------------------------
+// BOTH modes: AP's viewport-fixed right-edge UI has to move out from under the drawer. These rules
+// previously lived under the push-only body class, and push was disabled, so they never applied —
+// the drawer painted over the expandable container's tabs (making them unclickable) and over the
+// page-sidebar.
+body.ap-chat-open {
+  .expandable-container { right: $chat-width; }
+
+  // Collapsed: the 500px panel stays parked offscreen and only its tab (absolutely positioned at the
+  // container's left edge) is visible, so shift `right` by the drawer width to move that tab clear
+  // rather than setting it outright, which would drag the whole parked panel into view.
+  .sidebar-container { right: calc(#{$page-sidebar-parked-right} + #{$chat-width}); }
+
+  // Expanded: the dialog itself must clear the drawer. Its own `right: 0 !important` (which exists to
+  // beat the inline animation style) can only be overridden on the same terms.
+  .sidebar-container.expanded { right: $chat-width !important; }
+
+  // NOTE: the page-sidebar's transparent dismiss overlay is deliberately left spanning the full
+  // viewport, so it still covers the drawer. While that dialog is open the chat is inert anyway —
+  // `setBackgroundInert()` in page-sidebar/sidebar-panel.tsx marks every sibling of
+  // #expandable-container inert + aria-hidden, and the drawer is one of those siblings (that is the
+  // modal's intended behaviour, not a stacking bug). Insetting the overlay to the drawer's edge would
+  // therefore only turn the drawer into a dead zone; leaving it covered keeps the ordinary
+  // click-outside-to-dismiss, after which the chat is interactive again.
+}
+
 // ---- Push reflow (only while a push chat is open) ----------------------------------------------
 // The responsive activity's primary column is width:100% and flex-shrinks, so reserving
 // space on the right reflows it to ~75% without breaking interactives (they resize natively via the
-// LARA resize protocol). We shift the activity content and offset AP's viewport-fixed sidebars.
+// LARA resize protocol). Overlay mode deliberately does NOT do this: a fixed-width activity has no
+// reflow to give, and narrowing it would break its interactives.
 body.ap-chat-push-open {
   .activity.responsive {
+    // `.app .activity.responsive` is `width: 100%` and content-box, so padding alone GREW the box
+    // past the viewport instead of reflowing it — the activity kept its full width and simply ran on
+    // underneath the drawer, which is why push mode never actually pushed. Switching to border-box
+    // for the duration of the open chat makes the reserved strip come out of the 100% instead of
+    // being added to it. Scoped to this body class, so the closed-chat box model is untouched.
+    box-sizing: border-box;
     padding-right: $chat-width;
   }
-
-  // Offset the "Did you know?" page-sidebar + expandable container so they don't render OVER the
-  // reserved chat strip (they are position:fixed to the viewport right edge).
-  .sidebar-container { right: $chat-width; }
-  .expandable-container { right: $chat-width; }
 }

--- a/src/components/chat/chat-sidebar.test.tsx
+++ b/src/components/chat/chat-sidebar.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { act, configure, fireEvent, render, screen } from "@testing-library/react";
 import { ChatSidebar } from "./chat-sidebar";
 import { ChatIdentity } from "./chat-eligibility";
+import { getChatLogSink } from "./chat-log-forwarder";
 import { Activity } from "../../types";
 import { getVisiblePages } from "../../utilities/page-walk";
 import _activity from "../../data/version-2/sample-new-sections-activity-1.json";
@@ -19,15 +20,16 @@ const renderSidebar = (fullWidth: boolean) =>
       fullWidth={fullWidth}
       activity={activity}
       page={page}
-      pageNumber={2}
-      hints={{ activityTitle: activity.name }}
+      hints={{ activityTitle: activity.name, pageNumber: 2, pageCount: 5 }}
       identity={identity}
     />
   );
 
+const openChat = () => act(() => { fireEvent.click(screen.getByTestId("chat-launcher")); });
+
 describe("ChatSidebar", () => {
   afterEach(() => {
-    document.body.classList.remove("ap-chat-push-open");
+    document.body.classList.remove("ap-chat-open", "ap-chat-push-open");
   });
 
   it("starts closed with an accessible launcher", () => {
@@ -39,26 +41,64 @@ describe("ChatSidebar", () => {
 
   it("opens the panel and shows the tutor header", () => {
     renderSidebar(true);
-    act(() => { fireEvent.click(screen.getByTestId("chat-launcher")); });
+    openChat();
     expect(screen.getByTestId("chat-sidebar")).toBeInTheDocument();
     expect(screen.getByTestId("chat-header")).toHaveTextContent("Ask the Tutor");
   });
 
-  // Push/reflow mode is temporarily forced off (kForceOverlay) — every activity uses the overlay
-  // drawer and never reflows the activity, even a responsive (fullWidth) one.
-  it("uses the overlay drawer and never reflows the activity while push is forced off", () => {
-    renderSidebar(true); // responsive activity
+  // A responsive (fullWidth) activity gets PUSH: the activity reflows to make room, driven by the
+  // ap-chat-push-open body class. This path was unreachable while kForceOverlay was set, so it had no
+  // coverage at all.
+  it("uses push mode for a responsive activity and reflows the activity", () => {
+    renderSidebar(true);
+    expect(screen.getByTestId("chat-launcher")).toHaveClass("push");
+    openChat();
+    expect(screen.getByTestId("chat-sidebar")).toHaveClass("push");
+    expect(document.body.classList.contains("ap-chat-open")).toBe(true);
+    expect(document.body.classList.contains("ap-chat-push-open")).toBe(true);
+  });
+
+  // A fixed-width activity gets OVERLAY: the drawer floats over the page and the activity is never
+  // narrowed (that would break its fixed-width interactives).
+  it("uses overlay mode for a fixed-width activity and never reflows the activity", () => {
+    renderSidebar(false);
     expect(screen.getByTestId("chat-launcher")).toHaveClass("overlay");
-    act(() => { fireEvent.click(screen.getByTestId("chat-launcher")); });
+    openChat();
     expect(screen.getByTestId("chat-sidebar")).toHaveClass("overlay");
+    // still offsets AP's fixed right-edge UI...
+    expect(document.body.classList.contains("ap-chat-open")).toBe(true);
+    // ...but does not reflow the activity itself
     expect(document.body.classList.contains("ap-chat-push-open")).toBe(false);
   });
 
-  it("uses the overlay drawer for a fixed-width activity too", () => {
-    renderSidebar(false);
-    expect(screen.getByTestId("chat-launcher")).toHaveClass("overlay");
-    act(() => { fireEvent.click(screen.getByTestId("chat-launcher")); });
-    expect(screen.getByTestId("chat-sidebar")).toHaveClass("overlay");
+  it("drops the reflow body classes when the chat closes", () => {
+    renderSidebar(true);
+    openChat();
+    expect(document.body.classList.contains("ap-chat-open")).toBe(true);
+    act(() => { fireEvent.click(screen.getByTestId("chat-close")); });
+    expect(document.body.classList.contains("ap-chat-open")).toBe(false);
     expect(document.body.classList.contains("ap-chat-push-open")).toBe(false);
+  });
+
+  it("closes the drawer on Escape", () => {
+    renderSidebar(false);
+    openChat();
+    expect(screen.getByTestId("chat-sidebar")).toBeInTheDocument();
+    act(() => { fireEvent.keyDown(screen.getByTestId("chat-input"), { key: "Escape" }); });
+    expect(screen.queryByTestId("chat-sidebar")).toBeNull();
+    expect(screen.getByTestId("chat-launcher")).toBeInTheDocument();
+  });
+
+  // Forwarding interactive logs while the panel is CLOSED wrote a Firestore doc and billed an OpenAI
+  // turn per log for a conversation nobody was reading — and the panel re-closes on every page nav.
+  it("registers the log sink only while the panel is open", () => {
+    renderSidebar(false);
+    expect(getChatLogSink()).toBeNull();
+
+    openChat();
+    expect(getChatLogSink()).not.toBeNull();
+
+    act(() => { fireEvent.click(screen.getByTestId("chat-close")); });
+    expect(getChatLogSink()).toBeNull();
   });
 });

--- a/src/components/chat/chat-sidebar.tsx
+++ b/src/components/chat/chat-sidebar.tsx
@@ -6,6 +6,10 @@
 //   - fixed-width → OVERLAY: a position:fixed right-edge drawer (activity untouched), states
 //     closed / open. (A thin rail is a possible future enhancement, not built here.)
 //
+// BOTH modes set the `ap-chat-open` body class, which offsets AP's viewport-fixed right-edge UI (the
+// "Did you know?" page-sidebar and the expandable container) out from under the panel. Only push adds
+// `ap-chat-push-open`, which additionally reflows the activity itself.
+//
 // The mount gate (concrete content page + learner/anon identity) lives in app.tsx; this component
 // assumes it is mounted only when appropriate, so `page.id` and identity are defined.
 import React, { useEffect, useMemo, useRef, useState } from "react";
@@ -24,23 +28,32 @@ interface IProps {
   fullWidth: boolean;       // true → responsive activity → push; false → fixed-width → overlay
   activity: Activity;
   page: Page;
-  pageNumber: number;       // 1-based content page number (currentPage)
-  hints: OrientationHints;
+  hints: OrientationHints;  // carries the authoritative 1-based pageNumber / pageCount (see app.tsx)
   identity: ChatIdentity;   // {source, key, ownerFields, activityUrl}
 }
 
-// TEMPORARY: the responsive push/reflow layout isn't finished, so force the overlay drawer for all
-// activities while we test functionality. Flip back to `fullWidth` to re-enable push mode.
-const kForceOverlay = true;
+// djb2 — a stable, dependency-free string hash. Only used to namespace conversations for an activity
+// with no `id` (see `activityId` below); nothing security-relevant depends on it.
+const hashString = (s: string): string => {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(36);
+};
 
 export const ChatSidebar: React.FC<IProps> = (props) => {
-  const { fullWidth, activity, page, pageNumber, hints, identity } = props;
-  const push = fullWidth && !kForceOverlay;
+  const { fullWidth, activity, page, hints, identity } = props;
+  const push = fullWidth;
   const [open, setOpen] = useState(false);
   const launcherRef = useRef<HTMLButtonElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
 
-  const activityId = activity.id ?? "standalone";
+  // An id-less activity falls back to a hash of its URL rather than a shared "standalone" literal,
+  // which would namespace every id-less activity into the SAME conversation bucket. Unreachable on
+  // the live path today (id-less sample activities have no activityUrl, so they take the debug
+  // transport, and the server needs a real id) — this is just a safe default if that ever changes.
+  const activityId = activity.id
+    ?? (identity.activityUrl ? `url-${hashString(identity.activityUrl)}` : "standalone");
   // Chat requires a real URL-based activity fetchable server-side; the bundled sample activities
   // aren't, so fall back to the debug transport when there's no activityUrl (or ?chatDebug).
   const useDebug = resolveChatDebug() || !identity.activityUrl;
@@ -55,12 +68,20 @@ export const ChatSidebar: React.FC<IProps> = (props) => {
       activityId,
       pageId: page.id,
       ownerFields: identity.ownerFields,
+      // NOTE: consumed HOST-ONLY server-side — `resolveActivityUrl` rebuilds
+      // `https://{host}/api/v1/activities/{id}.json` from the authoritative path param rather than
+      // fetching what this anonymously-writable doc says (confused-deputy hardening). That is why the
+      // two identity branches can hand over differently-shaped URLs harmlessly. Do not "normalize"
+      // these into something the server's AUTHORING_HOSTS allowlist would reject.
       activityUrl: identity.activityUrl,
       hints,
     });
     // Depend on the PRIMITIVE hint/owner-field values (not the object identities) so the transport
     // rebuilds and picks up fresh orientation metadata when it loads asynchronously (e.g. sequence
     // title/index arriving after mount) — while still hard-swapping the conversation on page nav.
+    // `identity.source` is deliberately in the deps but NOT passed to the transport: the Firestore
+    // paths come from module-level `portalData`, so a change of effective source must rebuild the
+    // transport (re-resolving those paths) even though nothing reads it here.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     useDebug, identity.source, identity.key, activityId, page.id,
@@ -76,12 +97,27 @@ export const ChatSidebar: React.FC<IProps> = (props) => {
   const header = "Ask the Tutor";
   const chat = useChat({ transport, header });
 
+  // Forward interactive logs ONLY while the panel is open. The subscription itself stays alive when
+  // closed (the launcher's pending dot reads it), but forwarding while closed wrote a Firestore doc
+  // and billed an OpenAI turn for every interactive log a student generated without ever opening the
+  // tutor — and the panel re-closes on every page nav, so most of that spend was on conversations
+  // nobody read. It also contradicts the spec's reason for keeping student answers out of the system
+  // prompt, which is that chat-closed work is unobserved.
+  useEffect(() => {
+    if (!open) return;
+    transport.setLogForwarding(true);
+    return () => transport.setLogForwarding(false);
+  }, [transport, open]);
+
   // Scope line prepended to the copied transcript so a pasted conversation is self-describing.
-  // (Only used for copy output; the visible header stays "Ask the Tutor".)
+  // (Only used for copy output; the visible header stays "Ask the Tutor".) The page number comes from
+  // the same `hints` the page context is built from, so the transcript and the tutor's own
+  // "Page N of M" can never disagree.
   const pageTitle = page.name?.trim();
+  const pageLabel = hints.pageNumber != null ? `, Page ${hints.pageNumber}` : "";
   const transcriptTitle = pageTitle
-    ? `${activity.name}, Page ${pageNumber}: ${pageTitle}`
-    : `${activity.name}, Page ${pageNumber}`;
+    ? `${activity.name}${pageLabel}: ${pageTitle}`
+    : `${activity.name}${pageLabel}`;
 
   // Default to closed whenever the conversation swaps (page nav) or the wrapper changes. Mark the
   // close as nav-driven so focus is NOT yanked to the launcher (see the focus effect).
@@ -104,14 +140,14 @@ export const ChatSidebar: React.FC<IProps> = (props) => {
     prevOpen.current = open;
   }, [open]);
 
-  // Push reflow: toggle a body class so the responsive activity narrows to make room and
-  // the viewport-fixed page-sidebar is offset (see chat-sidebar.scss). Overlay mode never reflows.
+  // Body classes: `ap-chat-open` in BOTH modes offsets AP's viewport-fixed right-edge UI out from
+  // under the panel; `ap-chat-push-open` additionally reflows the responsive activity to make room
+  // (see chat-sidebar.scss). Overlay mode never reflows the activity.
   useEffect(() => {
-    if (push && open) {
-      document.body.classList.add("ap-chat-push-open");
-      return () => document.body.classList.remove("ap-chat-push-open");
-    }
-    return undefined;
+    if (!open) return undefined;
+    const classes = push ? ["ap-chat-open", "ap-chat-push-open"] : ["ap-chat-open"];
+    document.body.classList.add(...classes);
+    return () => document.body.classList.remove(...classes);
   }, [push, open]);
 
   if (!open) {
@@ -135,11 +171,14 @@ export const ChatSidebar: React.FC<IProps> = (props) => {
 
   return (
     <div
-      ref={panelRef}
-      tabIndex={-1}
       className={`chat-sidebar ${push ? "push" : "overlay"}`}
       role="complementary"
       aria-label="Activity tutor chat"
+      // Escape closes the drawer, matching what users expect of one. Scoped to the panel (the event
+      // bubbles up from the focused composer) rather than the document, so Escape elsewhere on the
+      // page is untouched. Not a conformance requirement — this is a non-modal complementary region
+      // with a labeled close button — but it is what a drawer should do.
+      onKeyDown={e => { if (e.key === "Escape") setOpen(false); }}
       data-cy="chat-sidebar"
     >
       <Chat chat={chat} onClose={() => setOpen(false)} closeLabel="Close chat" transcriptTitle={transcriptTitle} />

--- a/src/components/chat/chat.scss
+++ b/src/components/chat/chat.scss
@@ -1,18 +1,5 @@
 @import "../vars.scss";
 
-// Accessibility utility: content available to assistive tech but visually hidden.
-.visually-hidden {
-  position: absolute !important;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .chat {
   display: flex;
   flex-direction: column;
@@ -22,6 +9,22 @@
   font-size: 14px;
   color: $font-color;
   box-sizing: border-box;
+
+  // Accessibility utility: content available to assistive tech but visually hidden. Scoped to `.chat`
+  // rather than declared globally — this stylesheet ships in the main bundle whether or not the chat
+  // flag is on, so a bare `.visually-hidden` here was a global utility owned by a feature. Nesting it
+  // also lifts the specificity enough that the `!important` on `position` is no longer needed.
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 
   .chat-header {
     display: flex;

--- a/src/components/chat/transport-firestore.test.ts
+++ b/src/components/chat/transport-firestore.test.ts
@@ -356,6 +356,26 @@ describe("FirestoreTransport", () => {
     transport.dispose();
   });
 
+  // The denial schedules a retry AND ensureParent() revives the listener on the first send, so on a
+  // fresh page both race to re-attach. Whichever loses must not tear down the live listener: that is an
+  // unsubscribe plus a fresh Firestore listen, and a re-delivered snapshot that can bounce the status.
+  it("does not re-attach the parent listener when ensureParent already revived it", async () => {
+    jest.useFakeTimers();
+    const transport = makeTransport();
+    transport.subscribe(() => undefined, () => undefined);
+    expect(parentAttachCount).toBe(1);
+
+    emitParentError({ code: "permission-denied", message: "denied" }); // schedules a retry
+    await transport.sendUserMessage("what is this?");                  // revives it first
+    expect(parentAttachCount).toBe(2);
+
+    jest.advanceTimersByTime(kResubscribeBaseMs * 4); // the pending retry fires...
+    expect(parentAttachCount).toBe(2);                // ...and finds the listener already live
+    expect(parentSnapshotCb).toBeDefined();           // the live listener was left intact
+    transport.dispose();
+    jest.useRealTimers();
+  });
+
   it("does not re-create the parent when it already exists", async () => {
     parentExists = true;
     const transport = makeTransport();

--- a/src/components/chat/transport-firestore.test.ts
+++ b/src/components/chat/transport-firestore.test.ts
@@ -1,4 +1,6 @@
-import { FirestoreTransport } from "./transport-firestore";
+import {
+  FirestoreTransport, kMaxResubscribeAttempts, kResubscribeBaseMs, kReplyTimeoutMs,
+} from "./transport-firestore";
 import { ChatStatus, ChatTurn } from "./transport";
 
 // Fakes for the firebase-db chat helpers so we can assert reads/writes without a real Firestore.
@@ -7,8 +9,12 @@ let parentExists = false;
 const parentSet = jest.fn(async (data: any) => { parentSetData = data; parentExists = true; });
 let parentSetData: any;
 let messagesSnapshotCb: ((snap: any) => void) | undefined;
+let messagesErrorCb: ((err: any) => void) | undefined;
 let parentSnapshotCb: ((doc: any) => void) | undefined;
 let parentErrorCb: ((err: any) => void) | undefined;
+// How many times each listener has been attached, so a test can assert a re-subscribe actually happened.
+let messagesAttachCount = 0;
+let parentAttachCount = 0;
 // Records the where() constraints applied to the messages query, so a test can assert the read is
 // owner-scoped (unconstrained anonymous list reads are denied by the Firestore rules).
 let messagesWhere: Array<[string, string, any]> = [];
@@ -18,15 +24,17 @@ jest.mock("../../firebase-db", () => {
   const query: any = {
     orderBy: () => query,
     where: (field: string, op: string, value: any) => { messagesWhere.push([field, op, value]); return query; },
-    onSnapshot: (cb: (snap: any) => void, _err: (e: any) => void) => {
-      messagesSnapshotCb = cb;
-      return () => { messagesSnapshotCb = undefined; };
+    onSnapshot: (cb: (snap: any) => void, err: (e: any) => void) => {
+      messagesAttachCount++;
+      messagesSnapshotCb = cb; messagesErrorCb = err;
+      return () => { messagesSnapshotCb = undefined; messagesErrorCb = undefined; };
     },
   };
   return {
     getChatMessagesRef: () => ({ ...query, add: async (doc: any) => { messageAdds.push(doc); } }),
     getChatParentRef: () => ({
       onSnapshot: (cb: (doc: any) => void, err: (e: any) => void) => {
+        parentAttachCount++;
         parentSnapshotCb = cb; parentErrorCb = err;
         return () => { parentSnapshotCb = undefined; parentErrorCb = undefined; };
       },
@@ -57,6 +65,24 @@ const emitMessages = (docs: Array<{ id: string; data: any; pending?: boolean }>)
   });
 };
 
+// Firestore TERMINATES an onSnapshot listener after invoking its error callback: it can never fire
+// again, and NOTHING arrives on that listener until something re-attaches. Model that contract by
+// dropping the captured callbacks as the error is delivered — otherwise a test can "receive" events
+// on a listener that is dead in production, which is exactly how the missing re-attach went unnoticed.
+const emitParentError = (err: any) => {
+  const cb = parentErrorCb;
+  parentSnapshotCb = undefined;
+  parentErrorCb = undefined;
+  cb?.(err);
+};
+
+const emitMessagesError = (err: any) => {
+  const cb = messagesErrorCb;
+  messagesSnapshotCb = undefined;
+  messagesErrorCb = undefined;
+  cb?.(err);
+};
+
 describe("FirestoreTransport", () => {
   beforeEach(() => {
     messageAdds.length = 0;
@@ -64,6 +90,12 @@ describe("FirestoreTransport", () => {
     parentSetData = undefined;
     parentSet.mockClear();
     messagesWhere = [];
+    messagesAttachCount = 0;
+    parentAttachCount = 0;
+    messagesSnapshotCb = undefined;
+    messagesErrorCb = undefined;
+    parentSnapshotCb = undefined;
+    parentErrorCb = undefined;
   });
 
   it("constrains the messages read by the owner field (anonymous list reads are otherwise denied)", () => {
@@ -74,17 +106,94 @@ describe("FirestoreTransport", () => {
     transport.dispose();
   });
 
-  it("treats a permission-denied read as idle (conversation not created yet), not error", () => {
+  it("treats a permission-denied PARENT read as idle (conversation not created yet), not error", () => {
+    jest.useFakeTimers();
     const transport = makeTransport();
     const statuses: ChatStatus[] = [];
     transport.subscribe(() => undefined, s => statuses.push(s));
     // A fresh page's parent doc doesn't exist yet; the anonymous read is denied — benign, not a tutor
-    // outage. Other error codes still surface as error.
-    parentErrorCb?.({ code: "permission-denied", message: "denied" });
+    // outage.
+    emitParentError({ code: "permission-denied", message: "denied" });
     expect(statuses[statuses.length - 1]).toBe("idle");
-    parentErrorCb?.({ code: "unavailable", message: "network" });
+    // The listener is now dead, so the re-attach must happen before another error can be delivered.
+    jest.advanceTimersByTime(kResubscribeBaseMs);
+    expect(parentErrorCb).toBeDefined();
+    // Any other code is a real read failure worth showing.
+    emitParentError({ code: "unavailable", message: "network" });
     expect(statuses[statuses.length - 1]).toBe("error");
     transport.dispose();
+    jest.useRealTimers();
+  });
+
+  // The parent listener carries the ONLY authoritative tutor-error signal. Attached once in
+  // subscribe(), it dies on the fresh-page denial and, without a re-attach, status:"error" is
+  // unreachable for the life of the mount — the student watches a typing indicator forever.
+  it("re-attaches the parent listener after it is terminated, and then sees status:error", () => {
+    jest.useFakeTimers();
+    const transport = makeTransport();
+    const statuses: ChatStatus[] = [];
+    transport.subscribe(() => undefined, s => statuses.push(s));
+    expect(parentAttachCount).toBe(1);
+
+    emitParentError({ code: "permission-denied", message: "denied" });
+    expect(parentSnapshotCb).toBeUndefined(); // terminated
+
+    jest.advanceTimersByTime(kResubscribeBaseMs);
+    expect(parentAttachCount).toBe(2);
+    expect(parentSnapshotCb).toBeDefined();
+
+    // the authoritative error now reaches the UI, which it never did before the re-attach
+    parentSnapshotCb?.({ exists: true, data: () => ({ status: "error" }) });
+    expect(statuses[statuses.length - 1]).toBe("error");
+    transport.dispose();
+    jest.useRealTimers();
+  });
+
+  // A `list` read has no "doc doesn't exist yet" case, so permission-denied always means the rules
+  // rejected the query. Swallowing it as idle showed a healthy-looking chat that would never render.
+  it("surfaces a permission-denied MESSAGES read as an error rather than idle", () => {
+    jest.useFakeTimers();
+    const transport = makeTransport();
+    const statuses: ChatStatus[] = [];
+    transport.subscribe(() => undefined, s => statuses.push(s));
+    emitMessagesError({ code: "permission-denied", message: "denied" });
+    expect(statuses[statuses.length - 1]).toBe("error");
+    // and it re-subscribes rather than leaving the conversation dead
+    jest.advanceTimersByTime(kResubscribeBaseMs);
+    expect(messagesAttachCount).toBe(2);
+    transport.dispose();
+    jest.useRealTimers();
+  });
+
+  it("recovers to idle once a re-subscribed messages listener delivers a snapshot", () => {
+    jest.useFakeTimers();
+    const transport = makeTransport();
+    const statuses: ChatStatus[] = [];
+    transport.subscribe(() => undefined, s => statuses.push(s));
+    emitMessagesError({ code: "unavailable", message: "network" });
+    expect(statuses[statuses.length - 1]).toBe("error");
+    jest.advanceTimersByTime(kResubscribeBaseMs);
+    emitMessages([]);
+    expect(statuses[statuses.length - 1]).toBe("idle");
+    transport.dispose();
+    jest.useRealTimers();
+  });
+
+  it("gives up re-subscribing after the bounded number of consecutive failures", () => {
+    jest.useFakeTimers();
+    const transport = makeTransport();
+    transport.subscribe(() => undefined, () => undefined);
+    for (let i = 0; i < kMaxResubscribeAttempts; i++) {
+      emitParentError({ code: "unavailable", message: "network" });
+      jest.advanceTimersByTime(kResubscribeBaseMs * Math.pow(2, i));
+    }
+    expect(parentAttachCount).toBe(1 + kMaxResubscribeAttempts);
+    // one more failure exhausts the budget — nothing re-attaches
+    emitParentError({ code: "unavailable", message: "network" });
+    jest.advanceTimersByTime(60000);
+    expect(parentAttachCount).toBe(1 + kMaxResubscribeAttempts);
+    transport.dispose();
+    jest.useRealTimers();
   });
 
   it("maps user and non-null assistant docs to turns; ignores logs and null assistant docs", () => {
@@ -120,6 +229,57 @@ describe("FirestoreTransport", () => {
     ]);
     expect(statuses[statuses.length - 1]).toBe("idle");
     transport.dispose();
+  });
+
+  // A turn lost server-side with no status:"error" written (function never fired, cold-start timeout,
+  // crash before the status commit) leaves an unanswered user doc and nothing to re-trigger the
+  // function, so the indicator spun forever with no error and no way to retry.
+  it("times out an unanswered user message and surfaces an error", () => {
+    jest.useFakeTimers();
+    const transport = makeTransport();
+    const statuses: ChatStatus[] = [];
+    transport.subscribe(() => undefined, s => statuses.push(s));
+    emitMessages([{ id: "u1", data: { kind: "user", text: "hi" } }]);
+    expect(statuses[statuses.length - 1]).toBe("generating");
+
+    jest.advanceTimersByTime(kReplyTimeoutMs - 1);
+    expect(statuses[statuses.length - 1]).toBe("generating");
+
+    jest.advanceTimersByTime(1);
+    expect(statuses[statuses.length - 1]).toBe("error");
+    transport.dispose();
+    jest.useRealTimers();
+  });
+
+  it("restarts the reply timeout for a new message and clears it on a reply", () => {
+    jest.useFakeTimers();
+    const transport = makeTransport();
+    const statuses: ChatStatus[] = [];
+    transport.subscribe(() => undefined, s => statuses.push(s));
+
+    emitMessages([{ id: "u1", data: { kind: "user", text: "hi" } }]);
+    jest.advanceTimersByTime(kReplyTimeoutMs);
+    expect(statuses[statuses.length - 1]).toBe("error");
+
+    // retrying writes a NEW user doc → fresh clock, error retracted
+    emitMessages([
+      { id: "u1", data: { kind: "user", text: "hi" } },
+      { id: "u2", data: { kind: "user", text: "hi again" } },
+    ]);
+    expect(statuses[statuses.length - 1]).toBe("generating");
+
+    // the reply lands well inside the new window → idle, and no late timeout fires afterwards
+    jest.advanceTimersByTime(kReplyTimeoutMs / 2);
+    emitMessages([
+      { id: "u1", data: { kind: "user", text: "hi" } },
+      { id: "u2", data: { kind: "user", text: "hi again" } },
+      { id: "a1", data: { kind: "assistant", userText: "here you go" } },
+    ]);
+    expect(statuses[statuses.length - 1]).toBe("idle");
+    jest.advanceTimersByTime(kReplyTimeoutMs * 2);
+    expect(statuses[statuses.length - 1]).toBe("idle");
+    transport.dispose();
+    jest.useRealTimers();
   });
 
   it("surfaces parent status:error, but does NOT show typing for a bare status:generating", () => {
@@ -181,6 +341,21 @@ describe("FirestoreTransport", () => {
     expect(messageAdds[0].status).toBeUndefined();
   });
 
+  // The common real-world sequence: subscribe on a fresh page (parent absent → denied → listener
+  // dead), then the student sends. Creating the parent makes it readable again, so revive the
+  // listener immediately rather than waiting out the backoff.
+  it("revives the dead parent listener as soon as ensureParent creates the doc", async () => {
+    const transport = makeTransport();
+    transport.subscribe(() => undefined, () => undefined);
+    emitParentError({ code: "permission-denied", message: "denied" });
+    expect(parentSnapshotCb).toBeUndefined();
+
+    await transport.sendUserMessage("what is this?");
+    expect(parentAttachCount).toBe(2);
+    expect(parentSnapshotCb).toBeDefined();
+    transport.dispose();
+  });
+
   it("does not re-create the parent when it already exists", async () => {
     parentExists = true;
     const transport = makeTransport();
@@ -196,5 +371,22 @@ describe("FirestoreTransport", () => {
     // forwardLog is fire-and-forget; flush the async chain (ensureParent + add).
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(messageAdds.some(d => d.kind === "log" && d.interactive_id === "int-1" && d.run_key === "run-key-123456")).toBe(true);
+  });
+
+  // The subscription stays alive while the panel is closed (the launcher's pending dot needs it), so
+  // the log sink must be driven separately — a closed panel that forwarded logs billed a tutor turn
+  // per interactive log for a conversation nobody was reading.
+  it("registers as the log sink only when forwarding is explicitly enabled", async () => {
+    const { getChatLogSink } = jest.requireActual("./chat-log-forwarder");
+    const transport = makeTransport();
+    transport.subscribe(() => undefined, () => undefined);
+    expect(getChatLogSink()).toBeNull();
+
+    transport.setLogForwarding(true);
+    expect(getChatLogSink()).toBe(transport);
+
+    transport.setLogForwarding(false);
+    expect(getChatLogSink()).toBeNull();
+    transport.dispose();
   });
 });

--- a/src/components/chat/transport-firestore.ts
+++ b/src/components/chat/transport-firestore.ts
@@ -7,6 +7,11 @@
 // Receive: onSnapshot on the messages subcollection (ordered by createdAt); render `user` +
 //          non-null `assistant` docs. Reload restores history via the same subscription.
 // Status:  onSnapshot on the parent doc's `status` — authoritative generating|idle|error.
+//
+// Both listeners are re-attachable. Firestore TERMINATES an onSnapshot listener after invoking its
+// error callback, so a listener attached once in subscribe() is gone for the life of the mount after
+// the first error — including the denied read of a not-yet-created parent doc, which happens on
+// EVERY fresh page. See attachParent()/scheduleReattach().
 import { getChatMessagesRef, getChatParentRef, chatServerTimestamp } from "../../firebase-db";
 import { OrientationHints } from "../../utilities/chat-context";
 import { ChatStatus, ChatTransport, ChatTurn } from "./transport";
@@ -22,6 +27,14 @@ export interface FirestoreTransportOptions {
   hints: OrientationHints;
 }
 
+// Bounded re-subscribe. Without it a single transient `unavailable` permanently kills the
+// conversation until the student navigates away.
+export const kMaxResubscribeAttempts = 5;
+export const kResubscribeBaseMs = 1000;
+// How long an unanswered `user` doc may sit before the wait is called a failure. Long enough to clear
+// a cold start plus a slow generation, short enough that the student isn't left watching dots.
+export const kReplyTimeoutMs = 75000;
+
 export class FirestoreTransport implements ChatTransport, ChatLogSink {
   private unsubMessages?: () => void;
   private unsubParent?: () => void;
@@ -33,6 +46,22 @@ export class FirestoreTransport implements ChatTransport, ChatLogSink {
   private parentStatus: ChatStatus = "idle";
   private awaitingReply = false;
   private onStatus?: (status: ChatStatus) => void;
+  private onTurns?: (turns: ChatTurn[]) => void;
+  // Per-listener read-failure flags (kept separate so a recovered listener clears only its own).
+  private messagesReadError = false;
+  private parentReadError = false;
+  // False from the moment the parent listener errors (Firestore has torn it down) until it is
+  // re-attached, so ensureParent() knows whether it needs to revive it.
+  private parentListenerLive = false;
+  private messagesAttempts = 0;
+  private parentAttempts = 0;
+  private retryTimers = new Set<ReturnType<typeof setTimeout>>();
+  private replyTimer?: ReturnType<typeof setTimeout>;
+  private replyTimedOut = false;
+  // Id of the unanswered `user` doc the reply timeout is currently running against, so a NEW
+  // unanswered message restarts the clock while an unchanged wait leaves it alone.
+  private pendingUserId?: string;
+  private disposed = false;
 
   constructor(private readonly opts: FirestoreTransportOptions) {}
 
@@ -43,9 +72,13 @@ export class FirestoreTransport implements ChatTransport, ChatLogSink {
     // function also flips status→"generating" while SILENTLY processing forwarded interactive logs
     // (e.g. "scrolled out of view" telemetry) that yield a `userText:null` non-reply; keying the
     // indicator off that made "..." flash on open with no question asked. `error` stays authoritative.
-    const effective: ChatStatus =
-      this.parentStatus === "error" ? "error"
-        : this.awaitingReply ? "generating" : "idle";
+    //
+    // A failed read and a timed-out wait are both surfaced as `error` rather than left as a healthy
+    // -looking idle/generating: a chat that will never render anything, and a wait that will never
+    // end, are both tutor failures from the student's point of view.
+    const failed = this.parentStatus === "error" || this.messagesReadError
+      || this.parentReadError || this.replyTimedOut;
+    const effective: ChatStatus = failed ? "error" : this.awaitingReply ? "generating" : "idle";
     this.onStatus(effective);
   }
 
@@ -74,42 +107,75 @@ export class FirestoreTransport implements ChatTransport, ChatLogSink {
     return getChatParentRef(this.opts.key, this.opts.activityId, this.opts.pageId);
   }
 
-  // Snapshot read errors are NOT tutor failures — the authoritative tutor `error` arrives via the
-  // parent doc's `status` field (the success path). A `permission-denied` here is the EXPECTED benign
-  // case for a conversation that doesn't exist yet: on a fresh page the parent doc is absent until the
-  // function creates it (first send), and the rules deny an anonymous read of a missing doc — the same
-  // denial `ensureParent()` swallows. Treat it as `idle` (no conversation yet) rather than surfacing
-  // "tutor unavailable". Any other code (network `unavailable`, etc.) is a real read failure worth
-  // showing. Logged either way so a genuine rules regression is diagnosable without a network trace.
-  private onReadError(where: string, err: { code?: string; message?: string }) {
-    console.warn(`[chat] ${where} read error (${err.code}):`, err.message);
-    this.parentStatus = err.code === "permission-denied" ? "idle" : "error";
+  // The messages subscription is a `list`, so there is no "the doc doesn't exist yet" case here: a
+  // `permission-denied` always means the rules rejected the QUERY. Mapping it to `idle` (as the
+  // shared handler used to) presented a chat that looked healthy and would never render anything,
+  // evidenced only by a console warning. Treat every messages read failure as an error and retry.
+  private onMessagesError(err: { code?: string; message?: string }) {
+    console.warn(`[chat] messages read error (${err.code}):`, err.message);
+    this.messagesReadError = true;
     this.emitStatus();
+    this.scheduleReattach("messages");
   }
 
-  subscribe(onTurns: (turns: ChatTurn[]) => void, onStatus: (status: ChatStatus) => void): () => void {
-    this.onStatus = onStatus;
-    // Emit the reset current state synchronously (per the ChatTransport contract) so a subscriber
-    // that swapped from another conversation doesn't briefly show the previous one's status.
-    this.parentStatus = "idle";
-    this.awaitingReply = false;
-    onTurns([]);
+  // The parent read is a single-doc `get`, where `permission-denied` IS the expected benign case: on a
+  // fresh page the parent doc is absent until the function creates it (first send), and the rules deny
+  // an anonymous read of a missing doc — the same denial `ensureParent()` swallows. Treat that as
+  // `idle` (no conversation yet) rather than "tutor unavailable"; any other code (network `unavailable`,
+  // etc.) is a real read failure worth showing. Either way the listener is now dead, so re-attach:
+  // otherwise the authoritative `status:"error"` is unreachable for the rest of this mount.
+  private onParentError(err: { code?: string; message?: string }) {
+    console.warn(`[chat] parent read error (${err.code}):`, err.message);
+    this.parentListenerLive = false;
+    if (err.code === "permission-denied") {
+      this.parentStatus = "idle";
+    } else {
+      this.parentReadError = true;
+    }
     this.emitStatus();
-    // Register as the active log sink so handleLog forwarding reaches THIS page conversation while
-    // it is mounted; dispose() (the returned cleanup) unregisters it.
-    registerChatLogSink(this);
+    this.scheduleReattach("parent");
+  }
+
+  // Exponential backoff, bounded so a genuinely broken conversation doesn't retry forever. A delivered
+  // snapshot resets the counter, so only *consecutive* failures count toward the cap.
+  private scheduleReattach(which: "messages" | "parent") {
+    if (this.disposed) return;
+    const attempts = which === "messages" ? ++this.messagesAttempts : ++this.parentAttempts;
+    if (attempts > kMaxResubscribeAttempts) {
+      console.warn(`[chat] ${which} listener gave up after ${kMaxResubscribeAttempts} attempts`);
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(timer);
+      if (this.disposed) return;
+      if (which === "messages") {
+        this.attachMessages();
+      } else {
+        this.attachParent();
+      }
+    }, kResubscribeBaseMs * Math.pow(2, attempts - 1));
+    this.retryTimers.add(timer);
+  }
+
+  private attachMessages() {
+    if (this.disposed) return;
+    this.unsubMessages?.();
     // Estimate pending serverTimestamps so a just-sent doc orders correctly before the server
     // resolves it (otherwise it can momentarily sort to the top as null).
     this.unsubMessages = this.messagesQuery().onSnapshot(
       snapshot => {
+        this.messagesAttempts = 0;
+        this.messagesReadError = false;
         const turns: ChatTurn[] = [];
         let idx = 0;
         let lastUserIdx = -1;
         let lastAssistantIdx = -1;
+        let lastUserId: string | undefined;
         snapshot.forEach(doc => {
           const d = doc.data({ serverTimestamps: "estimate" }) as any;
           if (d.kind === "user") {
             lastUserIdx = idx;
+            lastUserId = doc.id;
             turns.push({ id: doc.id, sender: "user", text: d.text ?? "", pending: doc.metadata.hasPendingWrites });
           } else if (d.kind === "assistant") {
             lastAssistantIdx = idx;
@@ -124,22 +190,84 @@ export class FirestoreTransport implements ChatTransport, ChatLogSink {
         // trailing `log` doc (forwarded telemetry) neither clears it during a real wait nor pins it on
         // after a completed reply.
         this.awaitingReply = lastUserIdx > lastAssistantIdx;
-        onTurns(turns);
+        this.updateReplyTimeout(this.awaitingReply ? lastUserId : undefined);
+        this.onTurns?.(turns);
         this.emitStatus();
       },
-      err => this.onReadError("messages", err)
+      err => this.onMessagesError(err)
     );
+  }
 
+  private attachParent() {
+    if (this.disposed) return;
+    this.unsubParent?.();
+    this.parentListenerLive = true;
     this.unsubParent = this.parentRef().onSnapshot(
       doc => {
+        this.parentAttempts = 0;
+        this.parentReadError = false;
         const status = doc.exists ? (doc.data() as any)?.status : undefined;
         this.parentStatus = status === "generating" ? "generating" : status === "error" ? "error" : "idle";
         this.emitStatus();
       },
-      err => this.onReadError("parent", err)
+      err => this.onParentError(err)
     );
+  }
 
+  // A turn can be lost server-side with no `status:"error"` ever written — the function never fired, a
+  // cold start timed out, or it crashed before the status commit. The newest doc is then an unanswered
+  // `user` doc, so `awaitingReply` stays true and the typing indicator spins with no error and no
+  // recovery; the 5-minute stale-lock reclaim doesn't help, because nothing re-triggers the function.
+  // Time the wait out and surface an error so the student can retry.
+  private updateReplyTimeout(pendingUserId?: string) {
+    // An unchanged wait keeps its running clock; only a new (or cleared) unanswered message resets it.
+    if (pendingUserId === this.pendingUserId) return;
+    this.pendingUserId = pendingUserId;
+    if (this.replyTimer) {
+      clearTimeout(this.replyTimer);
+      this.replyTimer = undefined;
+    }
+    this.replyTimedOut = false;
+    if (!pendingUserId) return;
+    this.replyTimer = setTimeout(() => {
+      this.replyTimer = undefined;
+      if (this.disposed || !this.awaitingReply) return;
+      this.replyTimedOut = true;
+      this.emitStatus();
+    }, kReplyTimeoutMs);
+  }
+
+  subscribe(onTurns: (turns: ChatTurn[]) => void, onStatus: (status: ChatStatus) => void): () => void {
+    this.onStatus = onStatus;
+    this.onTurns = onTurns;
+    this.disposed = false;
+    // Emit the reset current state synchronously (per the ChatTransport contract) so a subscriber
+    // that swapped from another conversation doesn't briefly show the previous one's status.
+    this.parentStatus = "idle";
+    this.awaitingReply = false;
+    this.messagesReadError = false;
+    this.parentReadError = false;
+    this.replyTimedOut = false;
+    this.pendingUserId = undefined;
+    this.messagesAttempts = 0;
+    this.parentAttempts = 0;
+    onTurns([]);
+    this.emitStatus();
+    this.attachMessages();
+    this.attachParent();
     return () => this.dispose();
+  }
+
+  // Registered only while the panel is OPEN (driven by the sidebar), never merely because we are
+  // subscribed. The subscription stays alive while closed so the launcher's pending dot works, but a
+  // closed panel that also forwarded logs wrote a Firestore doc and billed an OpenAI turn per
+  // interactive log, for a conversation nobody was reading.
+  setLogForwarding(enabled: boolean): void {
+    if (enabled) {
+      registerChatLogSink(this);
+    } else {
+      unregisterChatLogSink(this);
+    }
   }
 
   // Create the parent doc once, with owner fields ONLY. The security rules disallow a client
@@ -164,6 +292,11 @@ export class FirestoreTransport implements ChatTransport, ChatLogSink {
           // clears the memo so a later send retries the read (which will then see it exists).
           await this.parentRef().set({ ...this.opts.ownerFields }, { merge: true });
         }
+        // The parent doc now exists, so a read of it is permitted. If the listener died on the
+        // fresh-page denial (the common case — the doc was absent when subscribe() ran), revive it
+        // here; otherwise the authoritative `status:"error"` would stay unreachable for this mount
+        // and a failed turn would show as an endless typing indicator instead of an error.
+        if (!this.parentListenerLive) this.attachParent();
       })();
       // Don't memoize a rejected attempt — clear it so a later send can retry. The rejection is
       // deliberately NOT rethrown: the expected failure here is the benign race above (the parent
@@ -202,7 +335,7 @@ export class FirestoreTransport implements ChatTransport, ChatLogSink {
   }
 
   // Forward an interactive log as a `kind:"log"` doc on the same per-page path. The
-  // payload is already MC-enriched + spam-filtered by handleLog (managed-interactive).
+  // payload is already MC-enriched, spam-filtered and debounced by the forwarder.
   forwardLog(payload: ChatLogPayload): void {
     void (async () => {
       try {
@@ -225,11 +358,21 @@ export class FirestoreTransport implements ChatTransport, ChatLogSink {
   }
 
   dispose(): void {
+    this.disposed = true;
     this.unsubMessages?.();
     this.unsubParent?.();
     this.unsubMessages = undefined;
     this.unsubParent = undefined;
+    this.parentListenerLive = false;
+    this.retryTimers.forEach(t => clearTimeout(t));
+    this.retryTimers.clear();
+    if (this.replyTimer) {
+      clearTimeout(this.replyTimer);
+      this.replyTimer = undefined;
+    }
+    this.pendingUserId = undefined;
     this.onStatus = undefined;
+    this.onTurns = undefined;
     unregisterChatLogSink(this);
   }
 }

--- a/src/components/chat/transport-firestore.ts
+++ b/src/components/chat/transport-firestore.ts
@@ -150,9 +150,14 @@ export class FirestoreTransport implements ChatTransport, ChatLogSink {
       if (this.disposed) return;
       if (which === "messages") {
         this.attachMessages();
-      } else {
+      } else if (!this.parentListenerLive) {
         this.attachParent();
       }
+      // else: ensureParent() already revived the parent listener before this timer fired. That is the
+      // COMMON fresh-page ordering — the denial schedules this retry, then the student's first send
+      // creates the doc and re-attaches immediately. Re-attaching a live listener is pure churn: an
+      // unsubscribe plus a fresh Firestore listen, and a re-delivered snapshot that can bounce the
+      // status in the UI. The messages listener has no equivalent revival path, so it has no guard.
     }, kResubscribeBaseMs * Math.pow(2, attempts - 1));
     this.retryTimers.add(timer);
   }

--- a/src/components/chat/transport.ts
+++ b/src/components/chat/transport.ts
@@ -42,6 +42,11 @@ export interface ChatTransport {
   subscribe(onTurns: (turns: ChatTurn[]) => void, onStatus: (status: ChatStatus) => void): () => void;
   // Write a user message (live path) / render what would be sent (debug path).
   sendUserMessage(text: string): Promise<void>;
+  // Start/stop forwarding interactive logs into THIS conversation. Deliberately separate from
+  // subscribe(): the sidebar keeps the subscription alive while closed (the launcher's pending dot
+  // needs it) but must NOT forward logs then — a closed panel that still wrote a log doc per
+  // interactive log billed an OpenAI turn for a conversation nobody was reading.
+  setLogForwarding(enabled: boolean): void;
 }
 
 export interface DebugTransportOptions {
@@ -114,9 +119,6 @@ export class DebugTransport implements ChatTransport, ChatLogSink {
   }
 
   subscribe(onTurns: (turns: ChatTurn[]) => void, onStatus: (status: ChatStatus) => void): () => void {
-    // Register so log forwarding surfaces the would-be log payload in the dry-run view; the
-    // returned cleanup unregisters it, tying the sink to the subscription lifecycle.
-    registerChatLogSink(this);
     this.turnListeners.add(onTurns);
     this.statusListeners.add(onStatus);
     onTurns([...this.turns]);
@@ -124,8 +126,20 @@ export class DebugTransport implements ChatTransport, ChatLogSink {
     return () => {
       this.turnListeners.delete(onTurns);
       this.statusListeners.delete(onStatus);
+      // Belt-and-braces: the sidebar disables forwarding on close, but an unmount must never leave
+      // a stale sink registered.
       unregisterChatLogSink(this);
     };
+  }
+
+  // Registered only while the panel is open, so the dry-run view surfaces the would-be log payload
+  // exactly when the live path would actually write one.
+  setLogForwarding(enabled: boolean): void {
+    if (enabled) {
+      registerChatLogSink(this);
+    } else {
+      unregisterChatLogSink(this);
+    }
   }
 
   private emitTurns() {

--- a/src/components/chat/use-chat.test.ts
+++ b/src/components/chat/use-chat.test.ts
@@ -51,6 +51,7 @@ describe("useChat with DebugTransport", () => {
         return () => undefined;
       },
       sendUserMessage: async () => undefined,
+      setLogForwarding: () => undefined,
     };
     const { result } = renderHook(() => useChat({ transport, header: "h" }));
     expect(result.current.pending).toBe(false);
@@ -71,6 +72,7 @@ describe("useChat with DebugTransport", () => {
     const transport: ChatTransport = {
       subscribe: (onTurns, onStatus) => { emitStatus = onStatus; onTurns([]); onStatus("idle"); return () => undefined; },
       sendUserMessage: async () => undefined,
+      setLogForwarding: () => undefined,
     };
     const { result } = renderHook(() => useChat({ transport, header: "h" }));
     expect(result.current.error).toBeNull();
@@ -83,6 +85,7 @@ describe("useChat with DebugTransport", () => {
     const transport: ChatTransport = {
       subscribe: (onTurns, onStatus) => { emitStatus = onStatus; onTurns([]); onStatus("idle"); return () => undefined; },
       sendUserMessage: async () => undefined,
+      setLogForwarding: () => undefined,
     };
     const { result } = renderHook(() => useChat({ transport, header: "h" }));
 
@@ -107,6 +110,7 @@ describe("useChat with DebugTransport", () => {
     const transport: ChatTransport = {
       subscribe: (onTurns, onStatus) => { emitStatus = onStatus; onTurns([]); onStatus("idle"); return () => undefined; },
       sendUserMessage: async () => { throw new Error("write rejected"); },
+      setLogForwarding: () => undefined,
     };
     const { result } = renderHook(() => useChat({ transport, header: "h" }));
 

--- a/src/utilities/chat-context.test.ts
+++ b/src/utilities/chat-context.test.ts
@@ -52,6 +52,21 @@ describe("chat-context assembler", () => {
     expect(ctx.orientation.activityTitle).toBe("My Activity");
   });
 
+  // App derives Page N of M from its OWN visible-page list, which keeps hidden pages under
+  // ?author-preview. Deriving again here disagreed with it: `getVisiblePages` always filters hidden
+  // pages, so a hidden page the student was really on gave findIndex -1 → "Page 1 of M".
+  it("prefers the caller's page numbering over its own derivation", () => {
+    const hiddenPage = syntheticActivity.pages[2] as unknown as Page; // is_hidden: true
+    // without hints: not in the visible list at all → the misleading 1-of-2 fallback
+    const derived = assemblePageContext(syntheticActivity, hiddenPage);
+    expect(derived.orientation.pageNumber).toBe(1);
+    // with hints from App (author-preview numbering): the page the student is actually on
+    const passed = assemblePageContext(syntheticActivity, hiddenPage, { pageNumber: 3, pageCount: 3 });
+    expect(passed.orientation.pageNumber).toBe(3);
+    expect(passed.orientation.pageCount).toBe(3);
+    expect(renderPageContext(passed)).toContain("Page 3 of 3");
+  });
+
   it("falls back to activity.name for the title and omits sequence/activity lines when standalone", () => {
     const page = getVisiblePages(activity)[1];
     const ctx = assemblePageContext(activity, page);

--- a/src/utilities/chat-context.ts
+++ b/src/utilities/chat-context.ts
@@ -43,6 +43,10 @@ export interface OrientationHints {
   activityTitle?: string;          // falls back to activity.name
   activityIndex?: number;          // 0-based index into the sequence; only in a sequence
   activityCount?: number;          // M, only in a sequence
+  // 1-based page number / total over the page list the STUDENT is actually paging through. Supplied
+  // by the caller so the whole app derives it ONCE (see the fallback note in assemblePageContext).
+  pageNumber?: number;
+  pageCount?: number;
 }
 
 const imagePathRegex = /\.(png|jpe?g|gif|svg|webp|bmp)$/i;
@@ -73,7 +77,14 @@ export function assemblePageContext(
 ): PageContext {
   const visiblePages = getVisiblePages(activity);
   const pageIdx = visiblePages.findIndex(p => p.id === page.id);
-  const pageNumber = pageIdx >= 0 ? pageIdx + 1 : 1;
+  // Prefer the caller's numbering. `getVisiblePages` here ALWAYS filters hidden pages, whereas App's
+  // own visible-page list keeps them under `?author-preview` — so deriving locally reported "Page 1 of
+  // M" (findIndex → -1) for a hidden page the student was really on, and could disagree with the
+  // number the same app state showed elsewhere. The local derivation stays as the fallback: it keeps
+  // this module self-sufficient for the report-service lift, where there is no author-preview and
+  // filtering hidden pages is exactly right.
+  const pageNumber = hints.pageNumber ?? (pageIdx >= 0 ? pageIdx + 1 : 1);
+  const pageCount = hints.pageCount ?? visiblePages.length;
 
   const body: PageContextBodyItem[] = [];
   // Authored order: visible sections, then visible embeddables within each section.
@@ -102,7 +113,7 @@ export function assemblePageContext(
       activityIndex: hints.activityIndex,
       activityCount: hints.activityCount,
       pageNumber,
-      pageCount: visiblePages.length,
+      pageCount,
       pageTitle: page.name ?? null,
     },
     body,


### PR DESCRIPTION
Fixes the blocking, high and medium findings from the AP-118 post-merge review, plus a production defect found while verifying them.

Jira: AP-126. Review: #577.

## The production defect (not in the ticket's nine findings)

**Authenticated learners got no reply to the first message of a conversation.**

`getChatIdentity()` sent `portalData.offering?.activityUrl`, which is the Portal offering's `activity_url`, which is the AP **launch** url (`https://activity-player.concord.org/?activity=<encoded authoring url>`). Its host is not on the report-service function's `AUTHORING_HOSTS` allowlist, so `resolveActivityUrl` throws `disallowed activity host: activity-player.concord.org` and the turn dies with `status:"error"`. Anonymous runs were unaffected because that branch already sent `portalData.resourceUrl`.

Fix: send `resourceUrl` on the authenticated branch too. `IPortalData` already carries it, from the same `getResourceUrl()` (`portal-api.ts:407`).

**Why this branch makes it urgent.** The defect only bites when the first turn of a conversation is a typed message: `resolveActivityUrl` is reached only from `composePageSystemPrompt`, which runs only while `!promptInstalled`. A log-first turn installs the prompt via the trusted default host and never validates the client url. In 2.17.0 the log sink is registered in `subscribe()` (whenever mounted), so a log turn usually landed first and silently shielded the bug. **Finding 1 below moves registration to open-only, which removes that shield**, so open-then-type makes the typed message the first turn. Shipping finding 1 without this fix would make the defect fire far more often.

The unit fixture had set `offering.activityUrl` to an authoring url, a shape no production offering supplies, so the suite could not fail. It now uses the real launch url copied out of `report-service-pro`, with a regression test pinning the resolved hostname.

Verified end to end against `report-service-pro` with a real authenticated production student: before, the first typed turn died with `disallowed activity host` and no reply; after, it is answered and the parent settles `idle` with `promptInstalled` set.

## The ticket's nine findings

| # | Finding | Where it landed |
|---|---|---|
| 1 | Logs forwarded, and billed, while the panel is closed | `setLogForwarding()`, called from the open effect (`chat-sidebar.tsx:108`) |
| 2 | Parent status listener dies on first load, never reattached | `attachParent()` + `scheduleReattach()` with bounded backoff; the test now models Firestore's terminal-error contract, which is what hid this. Also fixed at source by [report-service#410](https://github.com/concord-consortium/report-service/pull/410) |
| 3 | No client-side debounce on log forwarding | `kLogCoalesceMs = 3000`, trailing-edge coalesce keyed `interactive_id::action` |
| 4 | Shared error handler; neither listener re-subscribes | `onMessagesError` / `onParentError` split, messages denial treated as an error, bounded re-subscribe |
| 5 | Typing indicator can spin forever after a dropped turn | `kReplyTimeoutMs = 75000` |
| 6 | Overlay drawer covers AP's fixed right-edge UI | `.expandable-container` / `.sidebar-container` offsets applied in overlay mode; z-index reconciled above the page-sidebar's 1999/2000 band |
| 7 | `kForceOverlay` makes the push path dead code | constant removed, push mode finished and reachable |
| 8 | Page number derived twice, wrong under author-preview | derived once via `hints.pageNumber ?? …` |
| 9 | The showChat gate has no test | `shouldShowChat` unit suite **plus** `cypress/e2e/chat.test.ts` |

## Cypress coverage (finding 9)

`cypress/e2e/chat.test.ts` covers the flag (absent / `false` / on), the intro-page exclusion, the completion page (EXT-7), single-page activities (EXT-2), open/close, and the per-page conversation swap.

Two details are load-bearing rather than stylistic, and both are commented in the spec:

- **Every visit passes `?chatDebug=true`.** Without it a bundled sample takes the LIVE transport, because the debug fallback keys off `!identity.activityUrl` and `getResourceUrl()` returns the sample NAME, which is truthy. CI would otherwise write real chat docs to `report-service-dev` and bill an OpenAI turn per forwarded log.
- **It deliberately does not use `&preview`,** which most other specs do. A preview run's key is literally `"preview"`, which `getChatIdentity` rejects, so the gate would be off for the wrong reason and every assertion would pass vacuously.

Also corrects the spec's "Not Yet Implemented" section, which still listed spike-code cleanup (`chatSpikeOnWrite` / `chatTutorSpikeOnWrite`) as pending; those became the single real `chatTutorOnWrite`.

## Testing

101 suites, 577 jest tests, 8 Cypress tests, lint clean (it covers `cypress/` too).

Verified live on both environments, anonymous and authenticated-learner paths: a real tutor reply now renders end to end. The earlier `invalid activityUrl` failures were an artifact of the bundled sample activity not being fetchable server-side, not the pipeline.

## Companion report-service PRs

Neither is required for this to work, but both are already deployed to dev and pro:

- **[report-service#410](https://github.com/concord-consortium/report-service/pull/410)** permits reading a chat parent doc that does not exist yet, removing the `permission-denied` that killed the status listener on every fresh conversation (finding 2's root cause).
- **[report-service#411](https://github.com/concord-consortium/report-service/pull/411)** steps over a permanently-failing message instead of wedging the conversation, so a good message is never blocked behind a bad one. Without it, conversations poisoned by the defect above stay bricked forever even after this fix ships.

## Note for the reviewer

One full-suite run failed once and I could not reproduce it in 22 subsequent runs (4 full, 6 chat-only, 8 of `transport-firestore.test.ts`, plus the runs above). I could not identify which test it was, because the captured output was console noise from the error-path tests rather than the assertion. Flagging it rather than calling the suite clean.

