### PR TITLE
fix: let a short secondary column stick when the primary can't [AP-129]

### DIFF
--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -232,7 +232,8 @@
   }
 
   // The collapsible panel groups the secondary embeddables so the trigger's aria-controls
-  // can reference it; `display: contents` keeps the embeddables as direct layout children.
+  // can reference it; `display: contents` means it adds no box of its own, so the wrapper it
+  // holds stays a direct layout child of the column and can stick to it.
   .collapsible-panel {
     display: contents;
   }

--- a/src/components/activity-page/section.scss
+++ b/src/components/activity-page/section.scss
@@ -214,6 +214,23 @@
     }
   }
 
+  // The secondary column sticks under the same rules as the primary one (see AP-129): when
+  // the primary column is too tall to stick, a short secondary column keeps its content, a
+  // graph or table the questions refer to, in view while the questions scroll past.
+  .column.secondary {
+    .embeddableWrapper {
+      top: 10px;
+      align-self: flex-start;
+      &.pinned {
+        position: sticky;
+      }
+      // Clear the collapsible header, which is sticky at the top of the column and 35px tall.
+      &.below-collapsible-header.pinned {
+        top: 45px;
+      }
+    }
+  }
+
   // The collapsible panel groups the secondary embeddables so the trigger's aria-controls
   // can reference it; `display: contents` keeps the embeddables as direct layout children.
   .collapsible-panel {

--- a/src/components/activity-page/section.test.tsx
+++ b/src/components/activity-page/section.test.tsx
@@ -198,9 +198,17 @@ describe("Section component", () => {
     const pinnedColumn = (primaryHeight?: number, secondaryHeight?: number, secondaryPinnable = true) =>
       getPinnedColumn({ primaryHeight, secondaryHeight, screenHeight, secondaryPinnable });
 
-    it("pins nothing until both columns have been measured", () => {
+    it("pins nothing until the primary column has been measured", () => {
       expect(pinnedColumn(undefined, undefined)).toBeUndefined();
+      // the secondary column cannot be pinned on its own: the decision needs both heights
       expect(pinnedColumn(undefined, 300)).toBeUndefined();
+    });
+
+    it("pins the primary column without waiting for the secondary column to be measured", () => {
+      expect(pinnedColumn(500, undefined)).toBe("primary");
+      // but a primary column that cannot be pinned leaves nothing pinned until the
+      // secondary column has been measured too
+      expect(pinnedColumn(3000, undefined)).toBeUndefined();
     });
 
     it("pins the primary column when it fits in the window", () => {

--- a/src/components/activity-page/section.test.tsx
+++ b/src/components/activity-page/section.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Section } from "./section";
+import { getPinnedColumn, Section } from "./section";
 import { configure, fireEvent, render } from "@testing-library/react";
 import { DefaultTestPage, DefaultTestSection, DefaultXhtmlComponent } from "../../test-utils/model-for-tests";
 import { IEmbeddableXhtml } from "../../types";
@@ -190,6 +190,38 @@ describe("Section component", () => {
       const panelId = trigger.getAttribute("aria-controls");
       expect(panelId).toBeTruthy();
       expect(container.querySelector(`#${panelId}`)).not.toBeNull();
+    });
+  });
+
+  describe("getPinnedColumn (AP-129)", () => {
+    const screenHeight = 900;
+    const pinnedColumn = (primaryHeight?: number, secondaryHeight?: number, secondaryPinnable = true) =>
+      getPinnedColumn({ primaryHeight, secondaryHeight, screenHeight, secondaryPinnable });
+
+    it("pins nothing until both columns have been measured", () => {
+      expect(pinnedColumn(undefined, undefined)).toBeUndefined();
+      expect(pinnedColumn(undefined, 300)).toBeUndefined();
+    });
+
+    it("pins the primary column when it fits in the window", () => {
+      expect(pinnedColumn(500, 2000)).toBe("primary");
+      // it keeps the primary column pinned even when the secondary column is shorter
+      expect(pinnedColumn(500, 100)).toBe("primary");
+    });
+
+    it("pins the secondary column when the primary column is too tall and the secondary fits", () => {
+      expect(pinnedColumn(3000, 400)).toBe("secondary");
+    });
+
+    it("pins nothing when both columns are taller than the window", () => {
+      expect(pinnedColumn(3000, 1200)).toBeUndefined();
+    });
+
+    it("pins nothing when the secondary column is not shorter than the primary, or is unpinnable", () => {
+      // a secondary column no shorter than the primary has nothing to stay in view for
+      expect(pinnedColumn(1000, 1000)).toBeUndefined();
+      // empty or collapsed secondary columns have nothing worth pinning
+      expect(pinnedColumn(3000, 400, false)).toBeUndefined();
     });
   });
 });

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -188,7 +188,8 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
       <div className={containerClass} ref={secondaryDivRef} data-cy="section-column-secondary">
         {secondaryEmbeddablesToRender.length > 0 && collapsible && renderCollapsibleHeader()}
         {/* The panel wrapper carries the id referenced by the trigger's aria-controls. It uses
-            `display: contents` so the embeddables remain direct layout children of the column. */}
+            `display: contents` so it adds no box of its own: the embeddable wrapper below stays
+            a direct layout child of the column, which is what lets it stick to the column. */}
         <div id={collapsiblePanelId} className="collapsible-panel">
           <div className={wrapperClass} ref={secondaryWrapperDivRef}>
             {!isSecondaryCollapsed && renderEmbeddables(secondaryEmbeddablesToRender, questionNumStart)}

--- a/src/components/activity-page/section.tsx
+++ b/src/components/activity-page/section.tsx
@@ -35,6 +35,43 @@ export interface SectionImperativeAPI {
 const right = "right";
 const left = "left";
 
+export type PinnedColumn = "primary" | "secondary" | undefined;
+
+interface IGetPinnedColumnOptions {
+  primaryHeight?: number;
+  secondaryHeight?: number;
+  screenHeight: number;
+  secondaryPinnable: boolean;
+}
+
+/**
+ * Decides which of the two columns, if either, sticks to the top of the window while the
+ * section scrolls past. Only one column can stick: the wrapper it is applied to is the one
+ * that stays put while the taller column scrolls.
+ *
+ * The primary column keeps the rule it has always had (it sticks whenever its content fits
+ * in the window). What is new is that the secondary column is now eligible too, but only
+ * when the primary column cannot stick, so no section that behaves correctly today changes.
+ * That covers the reported case: a long stack of questions in the primary column, with the
+ * graph or table the questions refer to sitting in the short secondary column.
+ *
+ * When both columns are taller than the window nothing sticks, which is the current
+ * behavior. See AP-129.
+ */
+export const getPinnedColumn = (options: IGetPinnedColumnOptions): PinnedColumn => {
+  const { primaryHeight, secondaryHeight, screenHeight, secondaryPinnable } = options;
+  // Heights are undefined until the ResizeObserver first fires, so nothing is pinned on the
+  // first paint.
+  if (primaryHeight !== undefined && primaryHeight < screenHeight) {
+    return "primary";
+  }
+  if (secondaryPinnable && secondaryHeight !== undefined && secondaryHeight < screenHeight &&
+      primaryHeight !== undefined && secondaryHeight < primaryHeight) {
+    return "secondary";
+  }
+  return undefined;
+};
+
 export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((props, ref) => {
   const { activityLayout, page, section, questionNumberStart, hiddenTab, addRefToQuestionMap } = props;
   const [isSecondaryCollapsed, setIsSecondaryCollapsed] = useState(false);
@@ -115,6 +152,8 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
 
     const embeddableWrapperDivRef = React.useRef(null);
     const wrapperSize: any = useSize(embeddableWrapperDivRef);
+    const secondaryWrapperDivRef = React.useRef(null);
+    const secondaryWrapperSize: any = useSize(secondaryWrapperDivRef);
 
     const renderPrimaryEmbeddables = (primaryEmbeddablesToRender: EmbeddableType[], questionNumStart: number) => {
     const maxAspectRatioEmbeddables = primaryEmbeddablesToRender.filter(e => {
@@ -128,8 +167,7 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
     const hasMaxAspectRatio = maxAspectRatioEmbeddables.length > 0;
     const containerClass = classNames("column", layout, "primary", {"expand": isSecondaryCollapsed},
                                       {"max-aspect-ratio": hasMaxAspectRatio});
-    const isPinned = wrapperSize?.height < screenHeight.dynamicHeight;
-    const wrapperClass = classNames ("embeddableWrapper", {"pinned": isPinned});
+    const wrapperClass = classNames ("embeddableWrapper", {"pinned": pinnedColumn === "primary"});
     return (
       <div className={containerClass} ref={primaryDivRef} data-cy="section-column-primary">
         <div className={wrapperClass} ref={embeddableWrapperDivRef}>
@@ -142,13 +180,19 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
   const renderSecondaryEmbeddables = (secondaryEmbeddablesToRender: EmbeddableType[], questionNumStart: number) => {
     const collapsible = section.secondary_column_collapsible;
     const containerClass = classNames("column", layout, "secondary", {"collapsed": isSecondaryCollapsed});
+    // When this column sticks it has to clear the collapsible header, which is itself sticky
+    // at the top of the column, so the offset differs depending on whether the header is there.
+    const wrapperClass = classNames("embeddableWrapper", {"pinned": pinnedColumn === "secondary"},
+                                    {"below-collapsible-header": collapsible});
     return (
       <div className={containerClass} ref={secondaryDivRef} data-cy="section-column-secondary">
         {secondaryEmbeddablesToRender.length > 0 && collapsible && renderCollapsibleHeader()}
         {/* The panel wrapper carries the id referenced by the trigger's aria-controls. It uses
             `display: contents` so the embeddables remain direct layout children of the column. */}
         <div id={collapsiblePanelId} className="collapsible-panel">
-          {!isSecondaryCollapsed && renderEmbeddables(secondaryEmbeddablesToRender, questionNumStart)}
+          <div className={wrapperClass} ref={secondaryWrapperDivRef}>
+            {!isSecondaryCollapsed && renderEmbeddables(secondaryEmbeddablesToRender, questionNumStart)}
+          </div>
         </div>
       </div>
     );
@@ -243,6 +287,13 @@ export const Section: React.ForwardRefExoticComponent<IProps> = forwardRef((prop
   const responsiveDirection  = singleColumn ? "column" : "row";
   const responsiveDirectionStyle = { flexDirection: responsiveDirection } as React.CSSProperties;
   const leftPrimary = layout === "60-40" || layout === "70-30";
+  // A collapsed secondary column has nothing showing, so there is nothing worth sticking.
+  const pinnedColumn = getPinnedColumn({
+    primaryHeight: wrapperSize?.height,
+    secondaryHeight: secondaryWrapperSize?.height,
+    screenHeight: screenHeight.dynamicHeight,
+    secondaryPinnable: secondaryEmbeddables.length > 0 && !isSecondaryCollapsed
+  });
   const getNumQuestionsLeftColumn = () => {
     const column = leftPrimary ? primaryEmbeddables : secondaryEmbeddables;
     let numQuestions = 0;


### PR DESCRIPTION
## Problem

In a two-column section, only the "primary" column could ever stick to the top while the section scrolled, and only when its content was short enough to fit in the window: `const isPinned = wrapperSize?.height < screenHeight.dynamicHeight`. The stylesheet had no sticky rule for `.column.secondary` at all, so the secondary column was never eligible.

That combination made the behavior look random to authors. On the reported activity (14294), the sections that work are the ones where the graph happens to sit in the primary column and that column is short (68px to 738px). The sections Jie reported as broken are the ones where the primary column is the long stack of questions (2287px, 3080px, 3774px, several screens' worth) and the graph sits in the secondary column: the primary is too tall to stick, the secondary is not allowed to, so nothing sticks and the student reads "why are the blue points located in that area of the graph" with the graph scrolled off the top.

There is a timing element to the "sometimes works" part too: the height comes from a `ResizeObserver` that starts out `undefined`, and interactive iframes resize themselves after load, so a section near the window-height boundary can land on either side of the threshold depending on load timing and window size.

See AP-129 for the full measurements: https://concord-consortium.atlassian.net/browse/AP-129

## Fix

The pin decision moves into an exported pure function, `getPinnedColumn()`, and the secondary column gets a wrapper of its own plus the matching sticky CSS.

The rule is deliberately additive:

- the primary column keeps exactly the rule it has today (it sticks whenever its content fits in the window), so no section that behaves correctly today changes
- the secondary column sticks only when the primary cannot and the secondary both fits in the window and is shorter than the primary
- when both columns are taller than the window nothing sticks, which is also today's behavior

A collapsed or empty secondary column is not eligible, and when the column carries the collapsible header the sticky offset clears it (`top: 45px` rather than `10px`), since that header is itself sticky at the top of the column.

## Tests

Five new unit cases covering `getPinnedColumn`: unmeasured columns, primary-fits, secondary-fits-when-primary-cannot, both-too-tall, and the not-shorter / not-pinnable guards.

Verified in Playwright at 1440x900 against all five of the URLs from the ticket, reading the `pinned` class and the stuck position off the DOM after scrolling:

| Page | Primary | Secondary | Before | After |
| --- | --- | --- | --- | --- |
| 3 | 3080px | 470px | nothing sticks | secondary sticks at top: 10 |
| 5 section 2 | 2287px | 347px | nothing sticks | secondary sticks |
| 7 section 2 | 3774px | 405px | nothing sticks | secondary sticks |
| 2 (6 sections) | 284 to 738px | | primary sticks | unchanged, still stuck at top: 10 |
| 4 (3 sections) | 68 to 636px | | primary sticks | unchanged, still stuck at top: 10 |
| 5 sections 1, 3, 4 and 7 sections 1, 3 | 505 to 720px | | primary sticks | unchanged |

Branch build for testing: https://activity-player.concord.org/branch/sticky-column-fix/index.html?activity=https%3A%2F%2Fauthoring.concord.org%2Fapi%2Fv1%2Factivities%2F14294.json&author-preview=true&page=page_163697&runKey=72b48632-fc87-41cd-b71d-d2fbd1348efb

## Open questions (why this is a draft)

Jie has not confirmed the behavior yet, and two design questions from the ticket are still unanswered:

1. Should the *shorter* column always be the one that sticks, even when the primary column would fit and stick under today's rule? This PR says no, to keep the change regression-free, but that is the more aggressive reading of what was asked for.
2. What should happen when both columns are taller than the window? This PR keeps today's behavior (nothing sticks). None of the pages in this activity hit that case, but other activities will.

There is also a third question worth settling separately: whether this stays automatic (measured heights) or becomes an explicit author choice in LARA, which would be a LARA change rather than an Activity Player one.
